### PR TITLE
feat: active raid route recorder with offline replay

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -65,7 +65,7 @@ export async function buildApp(dependencies: AppDependencies): Promise<FastifyIn
     )
   })
 
-  app.setErrorHandler((error, _request, reply) => {
+  app.setErrorHandler((error, request, reply) => {
     if (error instanceof ZodError) {
       return reply.status(400).send({
         error: { code: 'INVALID_INPUT', message: 'Проверьте введённые данные' },
@@ -81,7 +81,19 @@ export async function buildApp(dependencies: AppDependencies): Promise<FastifyIn
         error: { code: error.code, message: error.message, details: error.details },
       })
     }
-    app.log.error(error)
+    if (request.routeOptions.url === '/api/raids/:raidId/route/batches') {
+      const databaseError = error as { code?: string; constraint?: string }
+      app.log.error(
+        {
+          name: error instanceof Error ? error.name : 'UnknownError',
+          code: databaseError.code,
+          constraint: databaseError.constraint,
+        },
+        'route batch failed',
+      )
+    } else {
+      app.log.error(error)
+    }
     return reply.status(500).send({
       error: { code: 'INTERNAL_ERROR', message: 'Не удалось выполнить запрос' },
     })

--- a/apps/api/src/raid-routes.ts
+++ b/apps/api/src/raid-routes.ts
@@ -20,6 +20,7 @@ const createRaidSchema = z.object({
 })
 const commandSchema = z.object({ expectedVersion: z.coerce.number().int().positive() })
 const assignNavigatorSchema = commandSchema.extend({ navigatorUserId: z.uuid() })
+const navigatorLeaseSchema = commandSchema.extend({ clientInstanceId: z.uuid() })
 const readinessSchema = commandSchema.extend({
   appMode: z.enum(['browser', 'standalone']),
   locationPermission: z.enum(['granted', 'prompt', 'denied', 'unsupported', 'unknown']),
@@ -31,6 +32,26 @@ const readinessSchema = commandSchema.extend({
   measuredAt: z.iso.datetime({ offset: true }),
 })
 const actionableQuerySchema = z.object({ scope: z.literal('actionable') })
+const routeBatchSchema = z.object({
+  schemaVersion: z.literal(1),
+  leaseId: z.uuid(),
+  clientInstanceId: z.uuid(),
+  samples: z
+    .array(
+      z.object({
+        operationId: z.string().trim().min(8).max(100),
+        sequence: z.coerce.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+        capturedAt: z.iso.datetime({ offset: true }),
+        latitude: z.coerce.number().min(56.7).max(57),
+        longitude: z.coerce.number().min(53).max(53.4),
+        accuracyM: z.coerce.number().min(0).max(10_000),
+        speedMps: z.coerce.number().min(0).max(100).optional(),
+        headingDeg: z.coerce.number().min(0).lt(360).optional(),
+      }),
+    )
+    .min(1)
+    .max(50),
+})
 
 function authRequired(reply: FastifyReply) {
   return reply.status(401).send({
@@ -126,6 +147,47 @@ export async function registerRaidRoutes(
     const input = assignNavigatorSchema.parse(request.body)
     return execute(request, reply, dependencies, 'assign-navigator', input)
   })
+  app.post('/api/raids/:raidId/commands/handoff-navigator', async (request, reply) => {
+    const input = assignNavigatorSchema.parse(request.body)
+    return execute(request, reply, dependencies, 'handoff-navigator', input)
+  })
+  app.post('/api/raids/:raidId/route/lease/acquire', async (request, reply) => {
+    const user = await currentUser(request, dependencies)
+    if (!user) return authRequired(reply)
+    const raidId = resourceIdSchema.parse((request.params as { raidId: string }).raidId)
+    return dependencies.raids.acquireNavigatorLease(
+      user.id,
+      raidId,
+      navigatorLeaseSchema.parse(request.body),
+      operationId(request),
+    )
+  })
+  app.post('/api/raids/:raidId/route/lease/recover', async (request, reply) => {
+    const user = await currentUser(request, dependencies)
+    if (!user) return authRequired(reply)
+    const raidId = resourceIdSchema.parse((request.params as { raidId: string }).raidId)
+    return dependencies.raids.recoverNavigatorLease(
+      user.id,
+      raidId,
+      navigatorLeaseSchema.parse(request.body),
+      operationId(request),
+    )
+  })
+  app.post(
+    '/api/raids/:raidId/route/batches',
+    { bodyLimit: 64 * 1024 },
+    async (request, reply) => {
+      const user = await currentUser(request, dependencies)
+      if (!user) return authRequired(reply)
+      const raidId = resourceIdSchema.parse((request.params as { raidId: string }).raidId)
+      return dependencies.raids.submitRouteBatch(
+        user.id,
+        raidId,
+        routeBatchSchema.parse(request.body),
+        operationId(request),
+      )
+    },
+  )
   app.post('/api/raids/:raidId/commands/start', async (request, reply) =>
     execute(request, reply, dependencies, 'start', commandSchema.parse(request.body)),
   )

--- a/apps/api/src/raids.ts
+++ b/apps/api/src/raids.ts
@@ -494,6 +494,13 @@ export class DatabaseRaidService implements RaidService {
         if (!current?.client_instance_id) {
           throw new RaidError('NAVIGATOR_LEASE_MISSING', 409, 'Нет lease для восстановления')
         }
+        if (current.client_instance_id === input.clientInstanceId) {
+          throw new RaidError(
+            'NAVIGATOR_LEASE_ALREADY_CURRENT',
+            409,
+            'Это устройство уже владеет записью маршрута',
+          )
+        }
         const ended = await client.query<{ ended_at: Date }>(
           `UPDATE raid_navigator_leases SET ended_at = now(), ended_reason = 'recover',
              cutover_sequence = max_accepted_sequence

--- a/apps/api/src/raids.ts
+++ b/apps/api/src/raids.ts
@@ -1,10 +1,12 @@
-import { createHash } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import {
   getRaidAllowedActions,
+  getRouteStatusCode,
   isRaidStateTransitionAllowed,
   type RaidAction,
   type RaidParticipantState,
   type RaidState,
+  type RouteStatusCode,
 } from '@kabanda/domain'
 import type { Pool, PoolClient } from 'pg'
 
@@ -42,6 +44,45 @@ export type RaidCommandInput = {
   navigatorUserId?: string
 }
 
+export type NavigatorLeaseInput = {
+  expectedVersion: number
+  clientInstanceId: string
+}
+
+export type RouteSampleInput = {
+  operationId: string
+  sequence: number
+  capturedAt: string
+  latitude: number
+  longitude: number
+  accuracyM: number
+  speedMps?: number | undefined
+  headingDeg?: number | undefined
+}
+
+export type RouteBatchInput = {
+  schemaVersion: 1
+  leaseId: string
+  clientInstanceId: string
+  samples: RouteSampleInput[]
+}
+
+export type RouteStatusProjection = {
+  status: RouteStatusCode
+  navigatorUserId: string | null
+  generation: number | null
+  lastSampleAt: string | null
+  lastReceivedAt: string | null
+  acceptedSampleCount: number
+  missingSequenceCount: number
+}
+
+export type NavigatorLeaseProjection = {
+  id: string
+  generation: number
+  issuedAt: string
+}
+
 export type RaidParticipantProjection = {
   id: string
   displayName: string
@@ -62,6 +103,8 @@ export type RaidProjection = {
   navigatorReady: boolean
   navigatorBlockers: string[]
   navigatorWarnings: string[]
+  routeStatus: RouteStatusProjection
+  navigatorLease: NavigatorLeaseProjection | null
   participants: RaidParticipantProjection[]
   allowedActions: RaidAction[]
 }
@@ -86,6 +129,24 @@ export type RaidReadinessResponse = {
   raid: RaidProjection
 }
 
+export type RaidLeaseResponse = {
+  receipt: {
+    operationId: string
+    command: 'acquire-route' | 'recover-route'
+    serverAt: string
+  }
+  raid: RaidProjection
+}
+
+export type RouteBatchResponse = {
+  batchId: string
+  accepted: Array<{ operationId: string; acceptedAt: string }>
+  duplicates: Array<{ operationId: string }>
+  rejected: Array<{ operationId: string; code: string }>
+  routeStatus: RouteStatusProjection
+  serverAt: string
+}
+
 type RaidRow = {
   id: string
   kabanda_id: string
@@ -107,6 +168,19 @@ type ReadinessRow = {
 
 type StoredReadinessRow = ReadinessRow & {
   expires_at: Date
+}
+
+type LeaseRow = {
+  id: string
+  navigator_user_id: string
+  client_instance_id: string | null
+  generation: number
+  issued_at: Date
+  claimed_at: Date | null
+  heartbeat_expires_at: Date | null
+  ended_at: Date | null
+  max_accepted_sequence: string | number
+  accepted_sample_count: number
 }
 
 const visibleParticipantStates: RaidParticipantState[] = [
@@ -155,6 +229,24 @@ export interface RaidService {
     input: ReadinessInput,
     operationId: string,
   ): Promise<RaidReadinessResponse>
+  acquireNavigatorLease(
+    actorUserId: string,
+    raidId: string,
+    input: NavigatorLeaseInput,
+    operationId: string,
+  ): Promise<RaidLeaseResponse>
+  recoverNavigatorLease(
+    actorUserId: string,
+    raidId: string,
+    input: NavigatorLeaseInput,
+    operationId: string,
+  ): Promise<RaidLeaseResponse>
+  submitRouteBatch(
+    actorUserId: string,
+    raidId: string,
+    input: RouteBatchInput,
+    operationId: string,
+  ): Promise<RouteBatchResponse>
   getRaid(actorUserId: string, raidId: string): Promise<RaidProjection>
   getCurrent(actorUserId: string): Promise<RaidProjection | null>
   listActionable(actorUserId: string, kabandaId: string): Promise<RaidProjection[]>
@@ -263,7 +355,7 @@ export class DatabaseRaidService implements RaidService {
 
       const fromState = raid.state
       const nextVersion = raid.version + 1
-      await this.applyCommand(client, actorUserId, raid, action, input)
+      await this.applyCommand(client, actorUserId, raid, action, input, nextVersion)
       const updated = await client.query<{ updated_at: Date }>(
         `UPDATE raids SET version = $2, updated_at = now() WHERE id = $1 RETURNING updated_at`,
         [raid.id, nextVersion],
@@ -351,6 +443,250 @@ export class DatabaseRaidService implements RaidService {
     })
   }
 
+  async acquireNavigatorLease(
+    actorUserId: string,
+    raidId: string,
+    input: NavigatorLeaseInput,
+    operationId: string,
+  ): Promise<RaidLeaseResponse> {
+    return this.changeNavigatorLease(actorUserId, raidId, input, operationId, false)
+  }
+
+  async recoverNavigatorLease(
+    actorUserId: string,
+    raidId: string,
+    input: NavigatorLeaseInput,
+    operationId: string,
+  ): Promise<RaidLeaseResponse> {
+    return this.changeNavigatorLease(actorUserId, raidId, input, operationId, true)
+  }
+
+  private async changeNavigatorLease(
+    actorUserId: string,
+    raidId: string,
+    input: NavigatorLeaseInput,
+    operationId: string,
+    recover: boolean,
+  ): Promise<RaidLeaseResponse> {
+    const command = recover ? 'recover-route' : 'acquire-route'
+    const requestFingerprint = fingerprint(command, raidId, input)
+    return transaction(this.pool, async (client) => {
+      await this.lockOperation(client, actorUserId, operationId)
+      const replay = await this.replay<RaidLeaseResponse>(
+        client,
+        actorUserId,
+        operationId,
+        requestFingerprint,
+      )
+      if (replay) return replay
+
+      const raid = await this.lockRaid(client, actorUserId, raidId)
+      if (raid.version !== input.expectedVersion) {
+        throw new RaidError('RAID_VERSION_CONFLICT', 409, 'Рейд уже изменился', {
+          currentVersion: raid.version,
+          currentState: raid.state,
+        })
+      }
+      this.requireCurrentNavigator(raid, actorUserId)
+      const current = await this.lockCurrentLease(client, raid.id)
+      let serverAt: Date
+      if (recover) {
+        if (!current?.client_instance_id) {
+          throw new RaidError('NAVIGATOR_LEASE_MISSING', 409, 'Нет lease для восстановления')
+        }
+        const ended = await client.query<{ ended_at: Date }>(
+          `UPDATE raid_navigator_leases SET ended_at = now(), ended_reason = 'recover',
+             cutover_sequence = max_accepted_sequence
+           WHERE id = $1 RETURNING ended_at`,
+          [current.id],
+        )
+        const endedAt = ended.rows[0]?.ended_at
+        if (!endedAt) throw new Error('Recovered lease did not return a cutover time')
+        serverAt = endedAt
+        await client.query(
+          `INSERT INTO raid_navigator_leases
+            (raid_id, navigator_user_id, client_instance_id, generation, claimed_at,
+             heartbeat_expires_at)
+           VALUES ($1, $2, $3, $4, now(), now() + interval '45 seconds')`,
+          [raid.id, actorUserId, input.clientInstanceId, current.generation + 1],
+        )
+      } else {
+        if (!current) {
+          throw new RaidError('NAVIGATOR_LEASE_MISSING', 409, 'Lease ещё не создан')
+        }
+        if (current.navigator_user_id !== actorUserId) throw this.forbiddenCommand()
+        if (current.client_instance_id && current.client_instance_id !== input.clientInstanceId) {
+          throw new RaidError('NAVIGATOR_LEASE_HELD', 409, 'Маршрут пишет другое устройство')
+        }
+        const claimed = await client.query<{ server_at: Date }>(
+          `UPDATE raid_navigator_leases SET client_instance_id = $2,
+             claimed_at = coalesce(claimed_at, now()),
+             heartbeat_expires_at = now() + interval '45 seconds'
+           WHERE id = $1 RETURNING now() AS server_at`,
+          [current.id, input.clientInstanceId],
+        )
+        const claimedAt = claimed.rows[0]?.server_at
+        if (!claimedAt) throw new Error('Acquired lease did not return server time')
+        serverAt = claimedAt
+      }
+
+      const response: RaidLeaseResponse = {
+        receipt: { operationId, command, serverAt: serverAt.toISOString() },
+        raid: await this.project(client, actorUserId, raid.id),
+      }
+      await this.storeReceipt(client, {
+        actorUserId,
+        operationId,
+        raidId: raid.id,
+        command,
+        requestFingerprint,
+        expectedVersion: input.expectedVersion,
+        fromState: raid.state,
+        mutatesState: false,
+        response,
+      })
+      return response
+    })
+  }
+
+  async submitRouteBatch(
+    actorUserId: string,
+    raidId: string,
+    input: RouteBatchInput,
+    operationId: string,
+  ): Promise<RouteBatchResponse> {
+    const requestFingerprint = fingerprint('route-batch', raidId, input)
+    return transaction(this.pool, async (client) => {
+      await this.lockOperation(client, actorUserId, operationId)
+      const replay = await this.replayRouteBatch(
+        client,
+        actorUserId,
+        operationId,
+        requestFingerprint,
+      )
+      if (replay) return replay
+
+      const raid = await this.lockRaid(client, actorUserId, raidId)
+      if (
+        raid.state !== 'active' ||
+        raid.participant_state !== 'active' ||
+        raid.navigator_user_id !== actorUserId
+      ) {
+        throw new RaidError('NAVIGATOR_LEASE_SUPERSEDED', 409, 'Lease больше не действует')
+      }
+      const lease = await this.lockCurrentLease(client, raid.id)
+      if (
+        !lease ||
+        lease.id !== input.leaseId ||
+        lease.navigator_user_id !== actorUserId ||
+        lease.client_instance_id !== input.clientInstanceId
+      ) {
+        throw new RaidError('NAVIGATOR_LEASE_SUPERSEDED', 409, 'Lease больше не действует')
+      }
+      if (!lease.claimed_at) {
+        throw new RaidError('NAVIGATOR_LEASE_UNCLAIMED', 409, 'Lease ещё не активирован')
+      }
+
+      const accepted: RouteBatchResponse['accepted'] = []
+      const duplicates: RouteBatchResponse['duplicates'] = []
+      const rejected: RouteBatchResponse['rejected'] = []
+      let maxAcceptedSequence = Number(lease.max_accepted_sequence)
+      const now = Date.now()
+      for (const sample of input.samples) {
+        const sampleFingerprint = fingerprint('route-sample', raid.id, sample)
+        const capturedAt = new Date(sample.capturedAt)
+        if (
+          capturedAt.getTime() < lease.claimed_at.getTime() - 5_000 ||
+          capturedAt.getTime() > now + 30_000
+        ) {
+          rejected.push({ operationId: sample.operationId, code: 'SAMPLE_OUTSIDE_LEASE' })
+          continue
+        }
+        const existing = await client.query<{
+          operation_id: string
+          sequence: string
+          payload_hash: string
+        }>(
+          `SELECT operation_id, sequence, payload_hash FROM raid_route_samples
+           WHERE (lease_id = $1 AND sequence = $2)
+              OR (raid_id = $3 AND operation_id = $4)
+           LIMIT 1`,
+          [lease.id, sample.sequence, raid.id, sample.operationId],
+        )
+        const stored = existing.rows[0]
+        if (stored) {
+          if (
+            stored.operation_id !== sample.operationId ||
+            Number(stored.sequence) !== sample.sequence ||
+            stored.payload_hash !== sampleFingerprint
+          ) {
+            throw new RaidError(
+              'ROUTE_SAMPLE_CONFLICT',
+              409,
+              'Номер или operationId образца уже использован',
+            )
+          }
+          duplicates.push({ operationId: sample.operationId })
+          continue
+        }
+        const inserted = await client.query<{ received_at: Date }>(
+          `INSERT INTO raid_route_samples
+            (raid_id, lease_id, operation_id, sequence, captured_at, geom, accuracy_m,
+             speed_mps, heading_deg, payload_hash)
+           VALUES ($1, $2, $3, $4, $5,
+             ST_SetSRID(ST_MakePoint($6, $7), 4326)::geography,
+             $8, $9, $10, $11)
+           RETURNING received_at`,
+          [
+            raid.id,
+            lease.id,
+            sample.operationId,
+            sample.sequence,
+            sample.capturedAt,
+            sample.longitude,
+            sample.latitude,
+            sample.accuracyM,
+            sample.speedMps ?? null,
+            sample.headingDeg ?? null,
+            sampleFingerprint,
+          ],
+        )
+        const receivedAt = inserted.rows[0]?.received_at
+        if (!receivedAt) throw new Error('Route sample insert did not return a row')
+        accepted.push({ operationId: sample.operationId, acceptedAt: receivedAt.toISOString() })
+        maxAcceptedSequence = Math.max(maxAcceptedSequence, sample.sequence)
+      }
+
+      const heartbeat = await client.query<{ server_at: Date }>(
+        `UPDATE raid_navigator_leases SET
+           heartbeat_expires_at = now() + interval '45 seconds',
+           max_accepted_sequence = greatest(max_accepted_sequence, $2),
+           accepted_sample_count = accepted_sample_count + $3
+         WHERE id = $1 RETURNING now() AS server_at`,
+        [lease.id, maxAcceptedSequence, accepted.length],
+      )
+      const serverAt = heartbeat.rows[0]?.server_at
+      if (!serverAt) throw new Error('Lease heartbeat did not return a row')
+      const response: RouteBatchResponse = {
+        batchId: operationId,
+        accepted,
+        duplicates,
+        rejected,
+        routeStatus: await this.routeStatus(client, raid),
+        serverAt: serverAt.toISOString(),
+      }
+      await this.storeRouteBatchReceipt(client, {
+        actorUserId,
+        operationId,
+        raidId: raid.id,
+        leaseId: lease.id,
+        requestFingerprint,
+        response,
+      })
+      return response
+    })
+  }
+
   async getRaid(actorUserId: string, raidId: string): Promise<RaidProjection> {
     const client = await this.pool.connect()
     try {
@@ -412,6 +748,7 @@ export class DatabaseRaidService implements RaidService {
     raid: RaidRow,
     action: RaidAction,
     input: RaidCommandInput,
+    nextVersion: number,
   ): Promise<void> {
     switch (action) {
       case 'open-lobby':
@@ -476,6 +813,30 @@ export class DatabaseRaidService implements RaidService {
         ])
         return
       }
+      case 'handoff-navigator': {
+        this.requireOrganizer(raid, actorUserId)
+        if (!input.navigatorUserId) {
+          throw new RaidError('NAVIGATOR_REQUIRED', 400, 'Выберите навигатора')
+        }
+        const candidate = await client.query(
+          `SELECT 1 FROM raid_participants p
+           JOIN kabanda_memberships m
+             ON m.kabanda_id = $3 AND m.user_id = p.user_id AND m.removed_at IS NULL
+           WHERE p.raid_id = $1 AND p.user_id = $2 AND p.state = 'active'
+           FOR UPDATE OF p, m`,
+          [raid.id, input.navigatorUserId, raid.kabanda_id],
+        )
+        if (!candidate.rowCount) throw this.notFound()
+        await this.closeCurrentLease(client, raid.id, 'handoff')
+        await client.query('UPDATE raids SET navigator_user_id = $2 WHERE id = $1', [
+          raid.id,
+          input.navigatorUserId,
+        ])
+        if (raid.state === 'active') {
+          await this.createUnclaimedLease(client, raid.id, input.navigatorUserId)
+        }
+        return
+      }
       case 'start': {
         this.requireOrganizer(raid, actorUserId)
         const readiness = await this.currentReadiness(client, raid.id, raid.navigator_user_id, raid.version)
@@ -507,18 +868,28 @@ export class DatabaseRaidService implements RaidService {
           }
           throw error
         }
+        await this.openActivityWindow(client, raid.id, nextVersion)
+        if (!raid.navigator_user_id) throw this.forbiddenCommand()
+        await this.createUnclaimedLease(client, raid.id, raid.navigator_user_id)
         return
       }
       case 'pause':
         this.requireOrganizer(raid, actorUserId)
+        await this.closeActivityWindow(client, raid.id, nextVersion)
+        await this.closeCurrentLease(client, raid.id, 'pause')
         await client.query(`UPDATE raids SET state = 'paused', paused_at = now() WHERE id = $1`, [raid.id])
         return
       case 'resume':
         this.requireOrganizer(raid, actorUserId)
         await client.query(`UPDATE raids SET state = 'active', paused_at = NULL WHERE id = $1`, [raid.id])
+        await this.openActivityWindow(client, raid.id, nextVersion)
+        if (!raid.navigator_user_id) throw this.forbiddenCommand()
+        await this.createUnclaimedLease(client, raid.id, raid.navigator_user_id)
         return
       case 'cancel':
         this.requireOrganizer(raid, actorUserId)
+        await this.closeActivityWindow(client, raid.id, nextVersion)
+        await this.closeCurrentLease(client, raid.id, 'cancel')
         await client.query(`UPDATE raids SET state = 'cancelled', cancelled_at = now() WHERE id = $1`, [
           raid.id,
         ])
@@ -598,6 +969,145 @@ export class DatabaseRaidService implements RaidService {
     return result.rows[0] ?? null
   }
 
+  private async lockCurrentLease(client: PoolClient, raidId: string): Promise<LeaseRow | null> {
+    const result = await client.query<LeaseRow>(
+      `SELECT id, navigator_user_id, client_instance_id, generation, issued_at, claimed_at,
+         heartbeat_expires_at, ended_at, max_accepted_sequence, accepted_sample_count
+       FROM raid_navigator_leases
+       WHERE raid_id = $1 AND ended_at IS NULL
+       FOR UPDATE`,
+      [raidId],
+    )
+    return result.rows[0] ?? null
+  }
+
+  private async createUnclaimedLease(
+    client: PoolClient,
+    raidId: string,
+    navigatorUserId: string,
+  ): Promise<void> {
+    await client.query(
+      `INSERT INTO raid_navigator_leases (raid_id, navigator_user_id, generation)
+       SELECT $1, $2, coalesce(max(generation), 0) + 1
+       FROM raid_navigator_leases WHERE raid_id = $1`,
+      [raidId, navigatorUserId],
+    )
+  }
+
+  private async closeCurrentLease(
+    client: PoolClient,
+    raidId: string,
+    reason: 'pause' | 'cancel' | 'handoff' | 'recover',
+  ): Promise<void> {
+    await client.query(
+      `UPDATE raid_navigator_leases SET ended_at = now(), ended_reason = $2,
+         cutover_sequence = max_accepted_sequence
+       WHERE raid_id = $1 AND ended_at IS NULL`,
+      [raidId, reason],
+    )
+  }
+
+  private async openActivityWindow(
+    client: PoolClient,
+    raidId: string,
+    openedVersion: number,
+  ): Promise<void> {
+    await client.query(
+      `INSERT INTO raid_activity_windows (raid_id, opened_at, opened_version)
+       VALUES ($1, now(), $2)`,
+      [raidId, openedVersion],
+    )
+  }
+
+  private async closeActivityWindow(
+    client: PoolClient,
+    raidId: string,
+    closedVersion: number,
+  ): Promise<void> {
+    await client.query(
+      `UPDATE raid_activity_windows SET closed_at = now(), closed_version = $2
+       WHERE raid_id = $1 AND closed_at IS NULL`,
+      [raidId, closedVersion],
+    )
+  }
+
+  private requireCurrentNavigator(raid: RaidRow, actorUserId: string): void {
+    if (
+      raid.state !== 'active' ||
+      raid.navigator_user_id !== actorUserId ||
+      raid.participant_state !== 'active'
+    ) {
+      throw this.forbiddenCommand()
+    }
+  }
+
+  private async routeStatus(client: PoolClient, raid: RaidRow): Promise<RouteStatusProjection> {
+    const leaseResult = await client.query<LeaseRow>(
+      `SELECT id, navigator_user_id, client_instance_id, generation, issued_at, claimed_at,
+         heartbeat_expires_at, ended_at, max_accepted_sequence, accepted_sample_count
+       FROM raid_navigator_leases
+       WHERE raid_id = $1 AND ended_at IS NULL`,
+      [raid.id],
+    )
+    const sampleResult = await client.query<{
+      last_sample_at: Date | null
+      last_received_at: Date | null
+      accepted_count: string
+      missing_count: string
+    }>(
+      `SELECT
+         (SELECT max(captured_at) FROM raid_route_samples
+          WHERE lease_id = (SELECT id FROM raid_navigator_leases
+            WHERE raid_id = $1 AND ended_at IS NULL)) AS last_sample_at,
+         (SELECT max(received_at) FROM raid_route_samples
+          WHERE lease_id = (SELECT id FROM raid_navigator_leases
+            WHERE raid_id = $1 AND ended_at IS NULL)) AS last_received_at,
+         (SELECT count(*)::text FROM raid_route_samples WHERE raid_id = $1) AS accepted_count,
+         (SELECT coalesce(sum(max_accepted_sequence - accepted_sample_count), 0)::text
+          FROM raid_navigator_leases WHERE raid_id = $1) AS missing_count`,
+      [raid.id],
+    )
+    const lease = leaseResult.rows[0] ?? null
+    const samples = sampleResult.rows[0]
+    const lastSampleAt = samples?.last_sample_at ?? null
+    const sampleAgeSeconds = lastSampleAt
+      ? Math.max(0, (Date.now() - lastSampleAt.getTime()) / 1000)
+      : null
+    return {
+      status: getRouteStatusCode({
+        raidState: raid.state,
+        leaseClaimed: Boolean(lease?.client_instance_id),
+        leaseHeartbeatFresh: Boolean(
+          lease?.heartbeat_expires_at && lease.heartbeat_expires_at.getTime() > Date.now(),
+        ),
+        sampleAgeSeconds,
+      }),
+      navigatorUserId: raid.navigator_user_id,
+      generation: lease?.generation ?? null,
+      lastSampleAt: lastSampleAt?.toISOString() ?? null,
+      lastReceivedAt: samples?.last_received_at?.toISOString() ?? null,
+      acceptedSampleCount: Number(samples?.accepted_count ?? 0),
+      missingSequenceCount: Number(samples?.missing_count ?? 0),
+    }
+  }
+
+  private async navigatorLeaseProjection(
+    client: PoolClient,
+    raid: RaidRow,
+    actorUserId: string,
+  ): Promise<NavigatorLeaseProjection | null> {
+    if (raid.navigator_user_id !== actorUserId) return null
+    const result = await client.query<{ id: string; generation: number; issued_at: Date }>(
+      `SELECT id, generation, issued_at FROM raid_navigator_leases
+       WHERE raid_id = $1 AND navigator_user_id = $2 AND ended_at IS NULL`,
+      [raid.id, actorUserId],
+    )
+    const lease = result.rows[0]
+    return lease
+      ? { id: lease.id, generation: lease.generation, issuedAt: lease.issued_at.toISOString() }
+      : null
+  }
+
   private async lockRaid(client: PoolClient, actorUserId: string, raidId: string): Promise<RaidRow> {
     const result = await client.query<RaidRow>(
       `SELECT r.id, r.kabanda_id, r.organizer_user_id, r.navigator_user_id,
@@ -608,7 +1118,7 @@ export class DatabaseRaidService implements RaidService {
        JOIN kabanda_memberships m
          ON m.kabanda_id = r.kabanda_id AND m.user_id = $2 AND m.removed_at IS NULL
        LEFT JOIN raid_participants p ON p.raid_id = r.id AND p.user_id = $2
-       WHERE r.id = $1 FOR UPDATE OF r`,
+       WHERE r.id = $1 FOR UPDATE OF r, m`,
       [raidId, actorUserId],
     )
     const raid = result.rows[0]
@@ -684,6 +1194,8 @@ export class DatabaseRaidService implements RaidService {
     const navigatorReady = Boolean(
       navigatorParticipantReady && readiness && readiness.blocker_codes.length === 0,
     )
+    const routeStatus = await this.routeStatus(client, raid)
+    const navigatorLease = await this.navigatorLeaseProjection(client, raid, actorUserId)
     return {
       id: raid.id,
       kabandaId: raid.kabanda_id,
@@ -697,6 +1209,8 @@ export class DatabaseRaidService implements RaidService {
       navigatorReady,
       navigatorBlockers: readiness?.blocker_codes ?? [],
       navigatorWarnings: readiness?.warning_codes ?? [],
+      routeStatus,
+      navigatorLease,
       participants: participants.rows.map((participant) => ({
         id: participant.id,
         displayName: participant.display_name,
@@ -743,7 +1257,7 @@ export class DatabaseRaidService implements RaidService {
       expectedVersion: number | null
       fromState: RaidState | null
       mutatesState: boolean
-      response: RaidCommandResponse | RaidReadinessResponse
+      response: RaidCommandResponse | RaidReadinessResponse | RaidLeaseResponse
     },
   ): Promise<void> {
     await client.query(
@@ -778,6 +1292,81 @@ export class DatabaseRaidService implements RaidService {
     ])
   }
 
+  private async storeRouteBatchReceipt(
+    client: PoolClient,
+    input: {
+      actorUserId: string
+      operationId: string
+      raidId: string
+      leaseId: string
+      requestFingerprint: string
+      response: RouteBatchResponse
+    },
+  ): Promise<void> {
+    await client.query(
+      `INSERT INTO raid_route_batch_receipts
+        (id, actor_user_id, operation_id, raid_id, lease_id, request_fingerprint,
+         response_json)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+      [
+        randomUUID(),
+        input.actorUserId,
+        input.operationId,
+        input.raidId,
+        input.leaseId,
+        input.requestFingerprint,
+        input.response,
+      ],
+    )
+  }
+
+  private async replayRouteBatch(
+    client: PoolClient,
+    actorUserId: string,
+    operationId: string,
+    requestFingerprint: string,
+  ): Promise<RouteBatchResponse | null> {
+    const result = await client.query<{
+      request_fingerprint: string
+      response_json: RouteBatchResponse
+      access_active: boolean
+    }>(
+      `SELECT b.request_fingerprint, b.response_json,
+         (k.archived_at IS NULL AND m.user_id IS NOT NULL) AS access_active
+       FROM raid_route_batch_receipts b
+       JOIN raids r ON r.id = b.raid_id
+       JOIN kabandas k ON k.id = r.kabanda_id
+       LEFT JOIN kabanda_memberships m
+         ON m.kabanda_id = r.kabanda_id AND m.user_id = b.actor_user_id
+           AND m.removed_at IS NULL
+       WHERE b.actor_user_id = $1 AND b.operation_id = $2`,
+      [actorUserId, operationId],
+    )
+    const receipt = result.rows[0]
+    if (!receipt) {
+      const other = await client.query<{ access_active: boolean }>(
+        `SELECT (k.archived_at IS NULL AND m.user_id IS NOT NULL) AS access_active
+         FROM raid_command_receipts rc
+         JOIN raids r ON r.id = rc.raid_id
+         JOIN kabandas k ON k.id = r.kabanda_id
+         LEFT JOIN kabanda_memberships m
+           ON m.kabanda_id = r.kabanda_id AND m.user_id = rc.actor_user_id
+             AND m.removed_at IS NULL
+         WHERE rc.actor_user_id = $1 AND rc.operation_id = $2`,
+        [actorUserId, operationId],
+      )
+      const conflicting = other.rows[0]
+      if (!conflicting) return null
+      if (!conflicting.access_active) throw this.notFound()
+      throw new RaidError('IDEMPOTENCY_CONFLICT', 409, 'Ключ уже использован для другой команды')
+    }
+    if (!receipt.access_active) throw this.notFound()
+    if (receipt.request_fingerprint !== requestFingerprint) {
+      throw new RaidError('IDEMPOTENCY_CONFLICT', 409, 'Ключ уже использован для другого batch')
+    }
+    return receipt.response_json
+  }
+
   private async replay<T>(
     client: PoolClient,
     actorUserId: string,
@@ -801,7 +1390,23 @@ export class DatabaseRaidService implements RaidService {
       [actorUserId, operationId],
     )
     const receipt = result.rows[0]
-    if (!receipt) return null
+    if (!receipt) {
+      const other = await client.query<{ access_active: boolean }>(
+        `SELECT (k.archived_at IS NULL AND m.user_id IS NOT NULL) AS access_active
+         FROM raid_route_batch_receipts b
+         JOIN raids r ON r.id = b.raid_id
+         JOIN kabandas k ON k.id = r.kabanda_id
+         LEFT JOIN kabanda_memberships m
+           ON m.kabanda_id = r.kabanda_id AND m.user_id = b.actor_user_id
+             AND m.removed_at IS NULL
+         WHERE b.actor_user_id = $1 AND b.operation_id = $2`,
+        [actorUserId, operationId],
+      )
+      const conflicting = other.rows[0]
+      if (!conflicting) return null
+      if (!conflicting.access_active) throw this.notFound()
+      throw new RaidError('IDEMPOTENCY_CONFLICT', 409, 'Ключ уже использован для route batch')
+    }
     if (!receipt.access_active) throw this.notFound()
     if (receipt.request_fingerprint !== requestFingerprint) {
       throw new RaidError('IDEMPOTENCY_CONFLICT', 409, 'Ключ уже использован для другой команды')

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -52,6 +52,9 @@ function createRaids(overrides: Partial<RaidService> = {}): RaidService {
     createDraft: vi.fn(),
     command: vi.fn(),
     reportReadiness: vi.fn(),
+    acquireNavigatorLease: vi.fn(),
+    recoverNavigatorLease: vi.fn(),
+    submitRouteBatch: vi.fn(),
     getRaid: vi.fn(),
     getCurrent: vi.fn().mockResolvedValue(null),
     listActionable: vi.fn().mockResolvedValue([]),
@@ -399,6 +402,103 @@ describe('API foundation', () => {
       '81297402-898c-48d6-bc78-c74b6b38205c',
       payload,
       'readiness-operation',
+    )
+  })
+
+  it('passes a bounded route batch without echoing private coordinates', async () => {
+    const submitRouteBatch = vi.fn().mockResolvedValue({
+      batchId: '6ca90319-e4ea-43a3-acd9-48055411bd80',
+      accepted: [{ operationId: 'sample-operation-one', acceptedAt: '2026-08-28T12:00:01.000Z' }],
+      duplicates: [],
+      rejected: [],
+      routeStatus: {
+        status: 'fresh',
+        navigatorUserId: user.id,
+        generation: 1,
+        lastSampleAt: '2026-08-28T12:00:00.000Z',
+        lastReceivedAt: '2026-08-28T12:00:01.000Z',
+        acceptedSampleCount: 1,
+        missingSequenceCount: 0,
+      },
+      serverAt: '2026-08-28T12:00:01.000Z',
+    })
+    const app = await createTestApp(
+      createAuth({ getUser: vi.fn().mockResolvedValue(user) }),
+      createKabandas(),
+      createRaids({ submitRouteBatch }),
+    )
+    const payload = {
+      schemaVersion: 1,
+      leaseId: '9ad92175-8a47-4131-86ad-10ed765f8168',
+      clientInstanceId: '7bc3d6a1-181e-4d14-a62e-16324b6a9a4f',
+      samples: [
+        {
+          operationId: 'sample-operation-one',
+          sequence: 1,
+          capturedAt: '2026-08-28T12:00:00.000Z',
+          latitude: 56.85,
+          longitude: 53.2,
+          accuracyM: 8,
+        },
+      ],
+    } as const
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/raids/81297402-898c-48d6-bc78-c74b6b38205c/route/batches',
+      headers: {
+        origin: testOrigin,
+        cookie: 'kabanda_session=session',
+        'idempotency-key': 'route-batch-operation',
+      },
+      payload,
+    })
+    expect(response.statusCode).toBe(200)
+    expect(submitRouteBatch).toHaveBeenCalledWith(
+      user.id,
+      '81297402-898c-48d6-bc78-c74b6b38205c',
+      payload,
+      'route-batch-operation',
+    )
+    expect(JSON.stringify(response.json())).not.toContain('56.85')
+    expect(JSON.stringify(response.json())).not.toContain('53.2')
+  })
+
+  it('registers the canonical route lease acquire endpoint', async () => {
+    const acquireNavigatorLease = vi.fn().mockResolvedValue({
+      receipt: {
+        operationId: 'route-acquire-operation',
+        command: 'acquire-route',
+        serverAt: '2026-08-28T12:00:00.000Z',
+      },
+      raid: { id: '81297402-898c-48d6-bc78-c74b6b38205c' },
+    })
+    const app = await createTestApp(
+      createAuth({ getUser: vi.fn().mockResolvedValue(user) }),
+      createKabandas(),
+      createRaids({ acquireNavigatorLease }),
+    )
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/raids/81297402-898c-48d6-bc78-c74b6b38205c/route/lease/acquire',
+      headers: {
+        origin: testOrigin,
+        cookie: 'kabanda_session=session',
+        'idempotency-key': 'route-acquire-operation',
+      },
+      payload: {
+        expectedVersion: 5,
+        clientInstanceId: '7bc3d6a1-181e-4d14-a62e-16324b6a9a4f',
+      },
+    })
+    expect(response.statusCode).toBe(200)
+    expect(acquireNavigatorLease).toHaveBeenCalledWith(
+      user.id,
+      '81297402-898c-48d6-bc78-c74b6b38205c',
+      {
+        expectedVersion: 5,
+        clientInstanceId: '7bc3d6a1-181e-4d14-a62e-16324b6a9a4f',
+      },
+      'route-acquire-operation',
     )
   })
 })

--- a/apps/api/test/kabandas.postgres.test.ts
+++ b/apps/api/test/kabandas.postgres.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { randomUUID } from 'node:crypto'
 import { Pool } from 'pg'
 import { DatabaseKabandaService, KabandaError, type ManifestPoint } from '../src/kabandas.js'
 import { DatabaseRaidService } from '../src/raids.js'
@@ -96,6 +97,25 @@ async function readyRaid(ownerId: string, kabandaId: string, suffix: string) {
     { expectedVersion: ready.raid.version, ...readiness() },
     `readiness-${suffix}`,
   )
+}
+
+async function activeOwnerRaid(ownerId: string, kabandaId: string, suffix: string) {
+  const ready = await readyRaid(ownerId, kabandaId, suffix)
+  const started = await raidService!.command(
+    ownerId,
+    ready.raid.id,
+    'start',
+    { expectedVersion: ready.raid.version },
+    `start-${suffix}`,
+  )
+  const clientInstanceId = randomUUID()
+  const acquired = await raidService!.acquireNavigatorLease(
+    ownerId,
+    started.raid.id,
+    { expectedVersion: started.raid.version, clientInstanceId },
+    `acquire-${suffix}`,
+  )
+  return { acquired, clientInstanceId, leaseId: acquired.raid.navigatorLease!.id }
 }
 
 describePostgres('Kabandas and points PostgreSQL invariants', () => {
@@ -622,6 +642,414 @@ describePostgres('Kabandas and points PostgreSQL invariants', () => {
     await expect(
       raidService!.listActionable(second.ownerId, first.kabanda.id),
     ).rejects.toMatchObject({ code: 'RAID_NOT_FOUND' })
+  })
+
+  it('accepts reordered route samples once and replays an immutable batch receipt', async () => {
+    const { ownerId, kabanda } = await ownerAndKabanda('route-batch')
+    const { acquired, clientInstanceId, leaseId } = await activeOwnerRaid(
+      ownerId,
+      kabanda.id,
+      'route-batch',
+    )
+    const capturedAt = new Date().toISOString()
+    const firstInput = {
+      schemaVersion: 1 as const,
+      leaseId,
+      clientInstanceId,
+      samples: [
+        {
+          operationId: 'route-sample-three',
+          sequence: 3,
+          capturedAt,
+          latitude: 56.85,
+          longitude: 53.2,
+          accuracyM: 8,
+        },
+        {
+          operationId: 'route-sample-one',
+          sequence: 1,
+          capturedAt,
+          latitude: 56.8501,
+          longitude: 53.2001,
+          accuracyM: 8,
+        },
+      ],
+    }
+    const first = await raidService!.submitRouteBatch(
+      ownerId,
+      acquired.raid.id,
+      firstInput,
+      'route-batch-first',
+    )
+    expect(first.batchId).toBe('route-batch-first')
+    await expect(
+      raidService!.submitRouteBatch(
+        ownerId,
+        acquired.raid.id,
+        firstInput,
+        'route-batch-first',
+      ),
+    ).resolves.toEqual(first)
+    await expect(
+      raidService!.command(
+        ownerId,
+        acquired.raid.id,
+        'pause',
+        { expectedVersion: acquired.raid.version },
+        'route-batch-first',
+      ),
+    ).rejects.toMatchObject({ code: 'IDEMPOTENCY_CONFLICT' })
+    await raidService!.acquireNavigatorLease(
+      ownerId,
+      acquired.raid.id,
+      { expectedVersion: acquired.raid.version, clientInstanceId },
+      'route-command-shared-key',
+    )
+    await expect(
+      raidService!.submitRouteBatch(
+        ownerId,
+        acquired.raid.id,
+        {
+          schemaVersion: 1,
+          leaseId,
+          clientInstanceId,
+          samples: [{
+            operationId: 'route-cross-namespace-sample',
+            sequence: 4,
+            capturedAt: new Date().toISOString(),
+            latitude: 56.85,
+            longitude: 53.2,
+            accuracyM: 8,
+          }],
+        },
+        'route-command-shared-key',
+      ),
+    ).rejects.toMatchObject({ code: 'IDEMPOTENCY_CONFLICT' })
+    expect(first.accepted).toHaveLength(2)
+    expect(first.routeStatus).toMatchObject({ status: 'fresh', missingSequenceCount: 1 })
+
+    const filled = await raidService!.submitRouteBatch(
+      ownerId,
+      acquired.raid.id,
+      {
+        schemaVersion: 1,
+        leaseId,
+        clientInstanceId,
+        samples: [
+          {
+            operationId: 'route-sample-two',
+            sequence: 2,
+            capturedAt: new Date().toISOString(),
+            latitude: 56.8502,
+            longitude: 53.2002,
+            accuracyM: 8,
+          },
+        ],
+      },
+      'route-batch-fill-gap',
+    )
+    expect(filled.routeStatus.missingSequenceCount).toBe(0)
+    await expect(
+      raidService!.submitRouteBatch(
+        ownerId,
+        acquired.raid.id,
+        {
+          schemaVersion: 1,
+          leaseId,
+          clientInstanceId,
+          samples: [
+            {
+              operationId: 'route-sample-two-conflict',
+              sequence: 2,
+              capturedAt: new Date().toISOString(),
+              latitude: 56.86,
+              longitude: 53.21,
+              accuracyM: 9,
+            },
+          ],
+        },
+        'route-batch-conflict',
+      ),
+    ).rejects.toMatchObject({ code: 'ROUTE_SAMPLE_CONFLICT' })
+    await expect(
+      raidService!.submitRouteBatch(
+        ownerId,
+        acquired.raid.id,
+        {
+          schemaVersion: 1,
+          leaseId,
+          clientInstanceId,
+          samples: [
+            {
+              operationId: 'route-outside-izhevsk',
+              sequence: 4,
+              capturedAt: new Date().toISOString(),
+              latitude: 55.75,
+              longitude: 37.62,
+              accuracyM: 8,
+            },
+          ],
+        },
+        'route-batch-outside',
+      ),
+    ).rejects.toMatchObject({ code: '23514' })
+    expect(
+      Number(
+        (
+          await pool!.query('SELECT count(*) FROM raid_route_samples WHERE raid_id = $1', [
+            acquired.raid.id,
+          ])
+        ).rows[0]?.count,
+      ),
+    ).toBe(3)
+  })
+
+  it('closes route leases across pause, resume and explicit recovery', async () => {
+    const { ownerId, kabanda } = await ownerAndKabanda('route-cutover')
+    const active = await activeOwnerRaid(ownerId, kabanda.id, 'route-cutover')
+    const paused = await raidService!.command(
+      ownerId,
+      active.acquired.raid.id,
+      'pause',
+      { expectedVersion: active.acquired.raid.version },
+      'route-pause-cutover',
+    )
+    expect(paused.raid.routeStatus.status).toBe('paused')
+    await expect(
+      raidService!.submitRouteBatch(
+        ownerId,
+        paused.raid.id,
+        {
+          schemaVersion: 1,
+          leaseId: active.leaseId,
+          clientInstanceId: active.clientInstanceId,
+          samples: [
+            {
+              operationId: 'paused-old-sample',
+              sequence: 1,
+              capturedAt: new Date().toISOString(),
+              latitude: 56.85,
+              longitude: 53.2,
+              accuracyM: 8,
+            },
+          ],
+        },
+        'paused-old-batch',
+      ),
+    ).rejects.toMatchObject({ code: 'NAVIGATOR_LEASE_SUPERSEDED' })
+
+    const resumed = await raidService!.command(
+      ownerId,
+      paused.raid.id,
+      'resume',
+      { expectedVersion: paused.raid.version },
+      'route-resume-generation',
+    )
+    expect(resumed.raid.routeStatus.status).toBe('awaiting_lease')
+    expect(resumed.raid.navigatorLease!.generation).toBe(2)
+    await expect(
+      raidService!.submitRouteBatch(
+        ownerId,
+        resumed.raid.id,
+        {
+          schemaVersion: 1,
+          leaseId: active.leaseId,
+          clientInstanceId: active.clientInstanceId,
+          samples: [
+            {
+              operationId: 'resumed-old-sample',
+              sequence: 1,
+              capturedAt: new Date().toISOString(),
+              latitude: 56.85,
+              longitude: 53.2,
+              accuracyM: 8,
+            },
+          ],
+        },
+        'resumed-old-batch',
+      ),
+    ).rejects.toMatchObject({ code: 'NAVIGATOR_LEASE_SUPERSEDED' })
+
+    const nextClient = randomUUID()
+    const acquired = await raidService!.acquireNavigatorLease(
+      ownerId,
+      resumed.raid.id,
+      { expectedVersion: resumed.raid.version, clientInstanceId: nextClient },
+      'route-acquire-after-resume',
+    )
+    const recoveredClient = randomUUID()
+    const recovered = await raidService!.recoverNavigatorLease(
+      ownerId,
+      resumed.raid.id,
+      { expectedVersion: resumed.raid.version, clientInstanceId: recoveredClient },
+      'route-explicit-recover',
+    )
+    expect(recovered.raid.navigatorLease!.generation).toBe(3)
+    await expect(
+      raidService!.submitRouteBatch(
+        ownerId,
+        resumed.raid.id,
+        {
+          schemaVersion: 1,
+          leaseId: acquired.raid.navigatorLease!.id,
+          clientInstanceId: nextClient,
+          samples: [
+            {
+              operationId: 'recovered-old-sample',
+              sequence: 1,
+              capturedAt: new Date().toISOString(),
+              latitude: 56.85,
+              longitude: 53.2,
+              accuracyM: 8,
+            },
+          ],
+        },
+        'recovered-old-batch',
+      ),
+    ).rejects.toMatchObject({ code: 'NAVIGATOR_LEASE_SUPERSEDED' })
+  })
+
+  it('cuts over handoff atomically and privacy-gates a removed navigator receipt', async () => {
+    const { ownerId, kabanda } = await ownerAndKabanda('route-handoff')
+    const memberId = await user('route-handoff-member@example.com')
+    const invite = await service!.createInvite(ownerId, kabanda.id, 1)
+    const preview = await service!.previewInvite(invite.token, true)
+    await service!.acceptInvite(memberId, preview.continuation, 'handoff-member-join')
+    const created = await raidService!.createDraft(
+      ownerId,
+      kabanda.id,
+      { title: 'Handoff route' },
+      'handoff-route-create',
+    )
+    await raidService!.command(
+      ownerId,
+      created.raid.id,
+      'open-lobby',
+      { expectedVersion: 1 },
+      'handoff-route-lobby',
+    )
+    await raidService!.command(
+      memberId,
+      created.raid.id,
+      'accept',
+      { expectedVersion: 2 },
+      'handoff-route-accept',
+    )
+    await raidService!.command(
+      ownerId,
+      created.raid.id,
+      'assign-navigator',
+      { expectedVersion: 3, navigatorUserId: ownerId },
+      'handoff-route-initial-nav',
+    )
+    await raidService!.command(
+      ownerId,
+      created.raid.id,
+      'ready',
+      { expectedVersion: 4 },
+      'handoff-route-ready',
+    )
+    await raidService!.reportReadiness(
+      ownerId,
+      created.raid.id,
+      { expectedVersion: 5, ...readiness() },
+      'handoff-route-readiness',
+    )
+    const started = await raidService!.command(
+      ownerId,
+      created.raid.id,
+      'start',
+      { expectedVersion: 5 },
+      'handoff-route-start',
+    )
+    const ownerClient = randomUUID()
+    const ownerLease = await raidService!.acquireNavigatorLease(
+      ownerId,
+      created.raid.id,
+      { expectedVersion: 6, clientInstanceId: ownerClient },
+      'handoff-route-owner-acquire',
+    )
+    const handedOff = await raidService!.command(
+      ownerId,
+      created.raid.id,
+      'handoff-navigator',
+      { expectedVersion: 6, navigatorUserId: memberId },
+      'handoff-route-command',
+    )
+    expect(handedOff.raid).toMatchObject({ version: 7, navigatorUserId: memberId })
+    await expect(
+      raidService!.submitRouteBatch(
+        ownerId,
+        created.raid.id,
+        {
+          schemaVersion: 1,
+          leaseId: ownerLease.raid.navigatorLease!.id,
+          clientInstanceId: ownerClient,
+          samples: [
+            {
+              operationId: 'handoff-old-operation',
+              sequence: 1,
+              capturedAt: new Date().toISOString(),
+              latitude: 56.85,
+              longitude: 53.2,
+              accuracyM: 8,
+            },
+          ],
+        },
+        'handoff-old-batch',
+      ),
+    ).rejects.toMatchObject({ code: 'NAVIGATOR_LEASE_SUPERSEDED' })
+
+    const memberClients = [randomUUID(), randomUUID()]
+    const claims = await Promise.allSettled(
+      memberClients.map((clientInstanceId, index) =>
+        raidService!.acquireNavigatorLease(
+          memberId,
+          created.raid.id,
+          { expectedVersion: 7, clientInstanceId },
+          `handoff-member-acquire-${index}`,
+        ),
+      ),
+    )
+    expect(claims.filter(({ status }) => status === 'fulfilled')).toHaveLength(1)
+    expect(claims.filter(({ status }) => status === 'rejected')).toHaveLength(1)
+    const winnerIndex = claims.findIndex(({ status }) => status === 'fulfilled')
+    const memberClient = memberClients[winnerIndex]!
+    const winner = claims[winnerIndex]
+    if (!winner || winner.status !== 'fulfilled') throw new Error('Lease claim had no winner')
+    const memberLease = winner.value
+    const memberInput = {
+      schemaVersion: 1 as const,
+      leaseId: memberLease.raid.navigatorLease!.id,
+      clientInstanceId: memberClient,
+      samples: [
+        {
+          operationId: 'handoff-member-operation',
+          sequence: 1,
+          capturedAt: new Date().toISOString(),
+          latitude: 56.851,
+          longitude: 53.201,
+          accuracyM: 7,
+        },
+      ],
+    }
+    const memberBatch = await raidService!.submitRouteBatch(
+      memberId,
+      created.raid.id,
+      memberInput,
+      'handoff-member-batch',
+    )
+    expect(memberBatch.accepted).toHaveLength(1)
+    await service!.removeMember(ownerId, kabanda.id, memberId)
+    await expect(
+      raidService!.submitRouteBatch(
+        memberId,
+        created.raid.id,
+        memberInput,
+        'handoff-member-batch',
+      ),
+    ).rejects.toMatchObject({ code: 'RAID_NOT_FOUND' })
+    expect(started.raid.routeStatus.status).toBe('awaiting_lease')
   })
 
   it('does not replay a private receipt after membership removal', async () => {

--- a/apps/api/test/kabandas.postgres.test.ts
+++ b/apps/api/test/kabandas.postgres.test.ts
@@ -877,6 +877,16 @@ describePostgres('Kabandas and points PostgreSQL invariants', () => {
       { expectedVersion: resumed.raid.version, clientInstanceId: nextClient },
       'route-acquire-after-resume',
     )
+    await expect(
+      raidService!.recoverNavigatorLease(
+        ownerId,
+        resumed.raid.id,
+        { expectedVersion: resumed.raid.version, clientInstanceId: nextClient },
+        'route-recover-same-client',
+      ),
+    ).rejects.toMatchObject({ code: 'NAVIGATOR_LEASE_ALREADY_CURRENT' })
+    const unchanged = await raidService!.getRaid(ownerId, resumed.raid.id)
+    expect(unchanged.navigatorLease).toEqual(acquired.raid.navigatorLease)
     const recoveredClient = randomUUID()
     const recovered = await raidService!.recoverNavigatorLease(
       ownerId,

--- a/apps/pwa/src/app/App.tsx
+++ b/apps/pwa/src/app/App.tsx
@@ -4,6 +4,8 @@ import { PrototypePage } from '../features/prototype/PrototypePage'
 import { InvitePage } from '../features/kabandas/InvitePage'
 import { KabandasPage } from '../features/kabandas/KabandasPage'
 import { RaidApp } from '../features/raids/RaidApp'
+import { PwaUpdateGate } from '../features/raids/PwaUpdateGate'
+import { RecordingRuntimeProvider } from '../features/raids/recording/runtime'
 import { parseRaidRoute } from '../features/raids/routing'
 
 export function App() {
@@ -11,6 +13,10 @@ export function App() {
   if (window.location.pathname.endsWith('/prototype')) return <PrototypePage />
   if (window.location.pathname.endsWith('/invite')) return <InvitePage />
   if (window.location.pathname.endsWith('/lab')) return <CapabilityLabPage />
+  return <RecordingRuntimeProvider><AppRoute /><PwaUpdateGate /></RecordingRuntimeProvider>
+}
+
+function AppRoute() {
   const raidRoute = parseRaidRoute(window.location.search)
   if (raidRoute.kind !== 'home') return <RaidApp route={raidRoute} />
   return <KabandasPage />

--- a/apps/pwa/src/features/offline/db.ts
+++ b/apps/pwa/src/features/offline/db.ts
@@ -4,7 +4,11 @@ import type {
   LocalIdentity,
   OutboxOperation,
   PointCollectionProjection,
+  RecorderSessionRecord,
+  RecorderClientRecord,
+  RecorderWriterLeaseRecord,
   RaidProjectionRecord,
+  RouteOutboxRecord,
 } from './types'
 
 class KabandaOfflineDatabase extends Dexie {
@@ -13,6 +17,10 @@ class KabandaOfflineDatabase extends Dexie {
   outbox!: EntityTable<OutboxOperation, 'id'>
   pointCollections!: EntityTable<PointCollectionProjection, 'key'>
   raidProjections!: EntityTable<RaidProjectionRecord, 'key'>
+  routeOutbox!: EntityTable<RouteOutboxRecord, 'id'>
+  recorderSessions!: EntityTable<RecorderSessionRecord, 'key'>
+  recorderClients!: EntityTable<RecorderClientRecord, 'key'>
+  recorderWriterLeases!: EntityTable<RecorderWriterLeaseRecord, 'key'>
 
   constructor() {
     super('kabanda-offline')
@@ -44,6 +52,24 @@ class KabandaOfflineDatabase extends Dexie {
         'key, identityId, kabandaId, collectionId, savedAt, [identityId+kabandaId+collectionId]',
       raidProjections:
         'key, identityId, raidId, kabandaId, state, savedAt, [identityId+raidId], [identityId+kabandaId+savedAt], [identityId+savedAt]',
+    })
+    this.version(5).stores({
+      identities: 'userId, activatedAt',
+      identityContext: 'key, userId, changedAt',
+      outbox:
+        'id, identityId, kind, aggregateId, status, createdAt, [identityId+status+createdAt]',
+      pointCollections:
+        'key, identityId, kabandaId, collectionId, savedAt, [identityId+kabandaId+collectionId]',
+      raidProjections:
+        'key, identityId, raidId, kabandaId, state, savedAt, [identityId+raidId], [identityId+kabandaId+savedAt], [identityId+savedAt]',
+      routeOutbox:
+        'id, identityId, raidId, navigatorLeaseId, status, batchId, sequence, [identityId+raidId+navigatorLeaseId+status+sequence]',
+      recorderSessions:
+        'key, identityId, raidId, navigatorLeaseId, updatedAt, [identityId+raidId+updatedAt]',
+      recorderClients:
+        'key, identityId, raidId, updatedAt, [identityId+raidId]',
+      recorderWriterLeases:
+        'key, identityId, raidId, navigatorLeaseId, holderTabId, expiresAt',
     })
   }
 }

--- a/apps/pwa/src/features/offline/types.ts
+++ b/apps/pwa/src/features/offline/types.ts
@@ -42,3 +42,75 @@ export interface RaidProjectionRecord {
   savedAt: string
   projection: unknown
 }
+
+export type RouteOutboxStatus =
+  | 'pending'
+  | 'sending'
+  | 'retryable'
+  | 'accepted'
+  | 'rejected'
+
+export interface RouteOutboxRecord {
+  id: string
+  identityId: string
+  kabandaId: string
+  raidId: string
+  navigatorLeaseId: string
+  leaseGeneration: number
+  clientInstanceId: string
+  sequence: number
+  capturedAt: string
+  latitude: number
+  longitude: number
+  accuracyM: number
+  speedMps: number | null
+  headingDeg: number | null
+  status: RouteOutboxStatus
+  batchId: string | null
+  attempts: number
+  nextAttemptAt: string | null
+  claimUntil: string | null
+  lastErrorCode?: string
+  acceptedAt?: string
+}
+
+export interface RecorderSessionRecord {
+  key: string
+  identityId: string
+  kabandaId: string
+  raidId: string
+  navigatorLeaseId: string
+  leaseGeneration: number
+  clientInstanceId: string
+  wanted: boolean
+  nextSequence: number
+  lastPersistedSampleAt: string | null
+  lastLatitude: number | null
+  lastLongitude: number | null
+  preliminaryDistanceM: number
+  updatedAt: string
+}
+
+export interface RecorderClientRecord {
+  key: string
+  identityId: string
+  kabandaId: string
+  raidId: string
+  clientInstanceId: string
+  leaseActionFingerprint: string | null
+  leaseActionKey: string | null
+  updatedAt: string
+}
+
+export interface RecorderWriterLeaseRecord {
+  key: string
+  identityId: string
+  raidId: string
+  navigatorLeaseId: string
+  leaseGeneration: number
+  holderTabId: string
+  writerGeneration: number
+  fenceToken: string
+  expiresAt: string
+  updatedAt: string
+}

--- a/apps/pwa/src/features/raids/PwaUpdateGate.tsx
+++ b/apps/pwa/src/features/raids/PwaUpdateGate.tsx
@@ -1,0 +1,20 @@
+import { useRegisterSW } from 'virtual:pwa-register/react'
+import { shouldDeferServiceWorkerUpdate } from './recording/state'
+import { useRecordingRuntime } from './recording/runtime'
+
+export function PwaUpdateGate() {
+  const { phase } = useRecordingRuntime()
+  const {
+    needRefresh: [needRefresh],
+    updateServiceWorker,
+  } = useRegisterSW({ immediate: true })
+  if (!needRefresh) return null
+  const deferred = shouldDeferServiceWorkerUpdate(phase)
+  return (
+    <aside className="pwa-update-gate" role="status" aria-live="polite">
+      <strong>Доступна новая версия</strong>
+      <span>{deferred ? 'Обновление отложено, пока страница пишет маршрут.' : 'Можно безопасно обновить приложение.'}</span>
+      {!deferred && <button type="button" onClick={() => void updateServiceWorker(true)}>Обновить</button>}
+    </aside>
+  )
+}

--- a/apps/pwa/src/features/raids/RaidApp.tsx
+++ b/apps/pwa/src/features/raids/RaidApp.tsx
@@ -54,6 +54,7 @@ import type {
   ReadinessReportInput,
   ReadinessStatus,
 } from './types'
+import { ActiveRaidPanel } from './recording/ActiveRaidPanel'
 import './raids.css'
 
 type RaidIdentity = { id: string }
@@ -292,6 +293,7 @@ function RaidDetailPage({
     report: RaidReadinessSummary
   } | null>(null)
   const [navigatorId, setNavigatorId] = useState('')
+  const [handoffNavigatorId, setHandoffNavigatorId] = useState('')
   const operationKeys = useRef(new Map<string, string>())
   const pendingReadiness = useRef<{
     key: string
@@ -431,6 +433,9 @@ function RaidDetailPage({
 
   const readinessRows = localFacts ? buildReadinessRows(localFacts) : []
   const navigatorCandidates = raid.participants.filter(({ state }) => state === 'accepted' || state === 'ready')
+  const handoffCandidates = raid.participants.filter(
+    ({ id, state }) => state === 'active' && id !== raid.navigatorUserId,
+  )
   const readinessStatus: ReadinessStatus = raid.navigatorBlockers.length
     ? 'fail'
     : raid.navigatorReady
@@ -483,10 +488,50 @@ function RaidDetailPage({
       )}
 
       {(raid.state === 'active' || raid.state === 'paused' || raid.state === 'finalizing') && (
-        <section className="kb-card raid-active-summary"><p className="kb-kicker">Рейд подтверждён сервером</p><h2>{raid.state === 'active' ? 'Команда в пути' : raid.state === 'paused' ? 'Запись на паузе' : 'Собираем итог'}</h2><p className="kb-muted">Навигатор: {navigatorParticipant?.displayName ?? 'не назначен'}. Tracking и чекины появятся в следующем срезе — здесь не имитируем их локальным флагом.</p></section>
+        <ActiveRaidPanel
+          identityId={user.id}
+          raid={raid}
+          staleProjection={resource.stale}
+          serverPrimary={primary}
+          operationPending={Boolean(operation)}
+          onServerPrimary={() => void handlePrimary()}
+          onCanonicalRefresh={resource.refresh}
+          onApplyRaid={resource.applyRaid}
+        />
       )}
 
-      {primary && (
+      {allowed.has('handoff-navigator') && !resource.stale && handoffCandidates.length > 0 && (
+        <section className="kb-card raid-handoff">
+          <p className="kb-kicker">Передача навигации</p>
+          <h2>Сменить устройство и навигатора</h2>
+          <p className="kb-muted">
+            После подтверждения старый lease закроется сразу. Его неприсланные точки уже не войдут в канонический маршрут.
+          </p>
+          <div className="raid-assign">
+            <label htmlFor="handoff-navigator">Новый навигатор</label>
+            <select
+              id="handoff-navigator"
+              value={handoffNavigatorId}
+              onChange={(event) => setHandoffNavigatorId(event.target.value)}
+            >
+              <option value="">Выберите активного участника</option>
+              {handoffCandidates.map((participant) => (
+                <option key={participant.id} value={participant.id}>{participant.displayName}</option>
+              ))}
+            </select>
+            <button
+              type="button"
+              disabled={!handoffNavigatorId || operation === 'handoff-navigator'}
+              onClick={() => window.confirm('Передать запись маршрута другому навигатору сейчас?') &&
+                applyCommand('handoff-navigator', { navigatorUserId: handoffNavigatorId })}
+            >
+              {operation === 'handoff-navigator' ? 'Передаём…' : 'Передать маршрут'}
+            </button>
+          </div>
+        </section>
+      )}
+
+      {primary && raid.state !== 'active' && raid.state !== 'paused' && raid.state !== 'finalizing' && (
         <button className="kb-primary raid-primary raid-sticky" type="button" disabled={Boolean(operation) || (primary.kind === 'command' && primary.command === 'start' && !navigator.onLine)} onClick={handlePrimary}>{operation ? 'Подтверждаем…' : primary.label}</button>
       )}
       {allowed.has('cancel') && !resource.stale && <button className="raid-cancel" type="button" disabled={operation === 'cancel'} onClick={() => window.confirm('Отменить рейд для всей команды?') && applyCommand('cancel')}>Отменить рейд</button>}

--- a/apps/pwa/src/features/raids/api.ts
+++ b/apps/pwa/src/features/raids/api.ts
@@ -3,6 +3,9 @@ import type {
   CreateRaidInput,
   RaidAllowedAction,
   RaidProjection,
+  RouteBatchInput,
+  RouteBatchResponse,
+  RouteLeaseResponse,
   ReadinessReportInput,
   ReadinessReportResponse,
 } from './types'
@@ -23,6 +26,38 @@ export async function createRaid(
   return response.raid
 }
 
+export function requestRouteLease(
+  raidId: string,
+  action: 'acquire' | 'recover',
+  expectedVersion: number,
+  clientInstanceId: string,
+  idempotencyKey: string,
+): Promise<RouteLeaseResponse> {
+  return requestJson<RouteLeaseResponse>(
+    `/api/raids/${encodeURIComponent(raidId)}/route/lease/${action}`,
+    {
+      method: 'POST',
+      headers: { 'Idempotency-Key': idempotencyKey },
+      body: JSON.stringify({ expectedVersion, clientInstanceId }),
+    },
+  )
+}
+
+export function sendRouteBatch(
+  raidId: string,
+  batchId: string,
+  input: RouteBatchInput,
+): Promise<RouteBatchResponse> {
+  return requestJson<RouteBatchResponse>(
+    `/api/raids/${encodeURIComponent(raidId)}/route/batches`,
+    {
+      method: 'POST',
+      headers: { 'Idempotency-Key': batchId },
+      body: JSON.stringify(input),
+    },
+  )
+}
+
 export async function listActionableRaids(kabandaId: string): Promise<RaidProjection[]> {
   const response = await requestJson<{ raids: RaidProjection[] }>(
     `/api/kabandas/${encodeURIComponent(kabandaId)}/raids?scope=actionable`,
@@ -39,7 +74,7 @@ export async function getRaid(raidId: string): Promise<RaidProjection> {
 
 export async function sendRaidCommand(
   raidId: string,
-  command: Extract<RaidAllowedAction, 'open-lobby' | 'assign-navigator' | 'start' | 'pause' | 'resume' | 'cancel'>,
+  command: Extract<RaidAllowedAction, 'open-lobby' | 'assign-navigator' | 'start' | 'pause' | 'resume' | 'cancel' | 'handoff-navigator'>,
   expectedVersion: number,
   idempotencyKey: string,
   extra?: { navigatorUserId: string },

--- a/apps/pwa/src/features/raids/cache.ts
+++ b/apps/pwa/src/features/raids/cache.ts
@@ -26,6 +26,9 @@ function isRaidProjection(value: unknown): value is RaidProjection {
     typeof raid.title === 'string' &&
     typeof raid.state === 'string' &&
     typeof raid.version === 'number' &&
+    Boolean(raid.routeStatus) &&
+    typeof raid.routeStatus?.status === 'string' &&
+    (raid.navigatorLease === null || typeof raid.navigatorLease?.id === 'string') &&
     Array.isArray(raid.allowedActions) &&
     Array.isArray(raid.participants)
   )

--- a/apps/pwa/src/features/raids/raids.css
+++ b/apps/pwa/src/features/raids/raids.css
@@ -341,6 +341,90 @@
   background: transparent !important;
 }
 
+.route-recorder {
+  display: grid;
+  gap: 14px;
+}
+
+.route-recorder__signal {
+  border: 1px solid var(--kb-line);
+  border-radius: 999px;
+  color: var(--kb-muted);
+  font-size: .72rem;
+  font-weight: 750;
+  letter-spacing: .06em;
+  padding: 6px 9px;
+  text-transform: uppercase;
+}
+
+.route-recorder__signal--fresh {
+  background: #e9f5ec;
+  border-color: #b7d8c0;
+  color: #28643d;
+}
+
+.route-recorder__signal--stale,
+.route-recorder__signal--blocked,
+.route-recorder__signal--error {
+  background: #fff0ed;
+  border-color: #efc0b7;
+  color: #9d3f2e;
+}
+
+.route-recorder__metrics {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.route-recorder__metrics div {
+  background: var(--kb-surface-subtle, #f1f2f0);
+  border-radius: 12px;
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+  padding: 11px;
+}
+
+.route-recorder__metrics span {
+  color: var(--kb-muted);
+  font-size: .72rem;
+}
+
+.route-recorder__metrics strong {
+  font-size: .94rem;
+  overflow-wrap: anywhere;
+}
+
+.route-recorder__wake {
+  color: var(--kb-muted);
+  font-size: .82rem;
+  margin: 0;
+}
+
+.route-recorder__wake--held { color: #28643d; }
+
+.pwa-update-gate {
+  align-items: flex-start;
+  background: #232a35;
+  border-radius: 14px;
+  bottom: max(12px, env(safe-area-inset-bottom));
+  box-shadow: 0 12px 32px rgb(20 25 33 / 24%);
+  color: #fff;
+  display: grid;
+  gap: 5px;
+  left: 50%;
+  max-width: min(420px, calc(100vw - 24px));
+  padding: 13px 15px;
+  position: fixed;
+  transform: translateX(-50%);
+  width: 100%;
+  z-index: 30;
+}
+
+.pwa-update-gate span { color: #d7dbe2; font-size: .82rem; }
+.pwa-update-gate button { justify-self: start; margin-top: 4px; }
+
 .raid-auth,
 .raid-empty {
   width: min(100%, 540px);

--- a/apps/pwa/src/features/raids/recording/ActiveRaidPanel.tsx
+++ b/apps/pwa/src/features/raids/recording/ActiveRaidPanel.tsx
@@ -1,0 +1,68 @@
+import type { RaidPrimaryAction } from '../state'
+import type { RaidProjection } from '../types'
+import { routeStatusLabel, selectActivePrimaryAction, wakeLockLabel } from './state'
+import { useRouteRecorder } from './useRouteRecorder'
+
+export function ActiveRaidPanel({
+  identityId,
+  raid,
+  staleProjection,
+  serverPrimary,
+  operationPending,
+  onServerPrimary,
+  onCanonicalRefresh,
+  onApplyRaid,
+}: {
+  identityId: string
+  raid: RaidProjection
+  staleProjection: boolean
+  serverPrimary: RaidPrimaryAction | null
+  operationPending: boolean
+  onServerPrimary: () => void
+  onCanonicalRefresh: () => Promise<unknown>
+  onApplyRaid: (raid: RaidProjection) => Promise<unknown>
+}) {
+  const recorder = useRouteRecorder({ identityId, raid, staleProjection, onCanonicalRefresh, onApplyRaid })
+  const serverActionAvailable = serverPrimary?.kind === 'command' || serverPrimary?.kind === 'refresh'
+  const primary = selectActivePrimaryAction(recorder.phase, serverActionAvailable)
+  const lastSample = recorder.lastPersistedSampleAt
+    ? new Date(recorder.lastPersistedSampleAt).toLocaleTimeString('ru-RU')
+    : 'ещё нет'
+  const distance = recorder.preliminaryDistanceM >= 1_000
+    ? `${(recorder.preliminaryDistanceM / 1_000).toFixed(2)} км`
+    : `${Math.round(recorder.preliminaryDistanceM)} м`
+
+  return (
+    <section className="kb-card route-recorder" data-phase={recorder.phase}>
+      <div className="kb-section-head">
+        <div><p className="kb-kicker">Маршрут навигатора</p><h2>{routeStatusLabel(recorder.phase)}</h2></div>
+        <span className={`route-recorder__signal route-recorder__signal--${recorder.phase}`}>
+          {recorder.phase === 'fresh' ? 'fresh' : recorder.phase}
+        </span>
+      </div>
+      <p className="kb-muted">
+        GPS пишет только эта видимая страница. Выключенный экран и фон не считаются поддержанными без полевого evidence.
+      </p>
+      <div className="route-recorder__metrics">
+        <div><span>Последний sample</span><strong>{lastSample}</strong></div>
+        <div><span>Локально ждут receipt</span><strong>{recorder.pendingCount}</strong></div>
+        <div><span>Предварительно на устройстве</span><strong>≈ {distance}</strong></div>
+        <div><span>Принято сервером</span><strong>{recorder.routeStatus.acceptedSampleCount}</strong></div>
+      </div>
+      <p className={`route-recorder__wake route-recorder__wake--${recorder.wakeLock}`}>
+        {wakeLockLabel(recorder.wakeLock)}. Это не обещание фонового GPS.
+      </p>
+      {recorder.message && <p className="kb-error" role="alert">{recorder.message}</p>}
+      {primary === 'recover' && (
+        <button className="kb-primary raid-primary" type="button" onClick={recorder.recover}>
+          {recorder.phase === 'standby' ? 'Продолжить здесь' : 'Возобновить запись'}
+        </button>
+      )}
+      {primary === 'server' && serverPrimary && (
+        <button className="kb-primary raid-primary" type="button" disabled={operationPending} onClick={onServerPrimary}>
+          {operationPending ? 'Подтверждаем…' : serverPrimary.label}
+        </button>
+      )}
+    </section>
+  )
+}

--- a/apps/pwa/src/features/raids/recording/replay.ts
+++ b/apps/pwa/src/features/raids/recording/replay.ts
@@ -1,0 +1,81 @@
+import { ApiError } from '../../../lib/http'
+import type { RouteOutboxRecord } from '../../offline/types'
+import { sendRouteBatch } from '../api'
+import type { RouteBatchInput, RouteStatusProjection } from '../types'
+import {
+  claimRouteBatch,
+  markRouteBatchRetryable,
+  settleRouteBatch,
+  terminalizeRouteLease,
+} from './store'
+import type { RecorderContext, WriterFence } from './types'
+
+export type ReplayResult =
+  | { kind: 'idle' }
+  | { kind: 'accepted'; routeStatus: RouteStatusProjection }
+  | { kind: 'retryable' }
+  | { kind: 'terminal'; code: string; authRequired: boolean }
+  | { kind: 'fence-lost' }
+
+function toInput(
+  leaseId: string,
+  clientInstanceId: string,
+  rows: RouteOutboxRecord[],
+): RouteBatchInput {
+  return {
+    schemaVersion: 1,
+    leaseId,
+    clientInstanceId,
+    samples: rows.map((row) => ({
+      operationId: row.id,
+      sequence: row.sequence,
+      capturedAt: row.capturedAt,
+      latitude: row.latitude,
+      longitude: row.longitude,
+      accuracyM: row.accuracyM,
+      ...(row.speedMps === null ? {} : { speedMps: row.speedMps }),
+      ...(row.headingDeg === null ? {} : { headingDeg: row.headingDeg }),
+    })),
+  }
+}
+
+export async function replayRouteBatch(
+  context: RecorderContext,
+  fence: WriterFence,
+  now = Date.now(),
+): Promise<ReplayResult> {
+  const batch = await claimRouteBatch(context, fence, now, 50)
+  if (!batch) return { kind: 'idle' }
+  try {
+    const response = await sendRouteBatch(
+      context.raidId,
+      batch.batchId,
+      toInput(context.navigatorLeaseId, batch.clientInstanceId, batch.rows),
+    )
+    const settled = await settleRouteBatch(context, fence, batch.batchId, response)
+    return settled
+      ? { kind: 'accepted', routeStatus: response.routeStatus }
+      : { kind: 'fence-lost' }
+  } catch (error) {
+    const terminal = error instanceof ApiError && (
+      error.status === 401 ||
+      error.status === 403 ||
+      error.code === 'NAVIGATOR_LEASE_STALE'
+    )
+    if (terminal) {
+      await terminalizeRouteLease(context, fence, error.code, error.status !== 401 && error.status !== 403)
+      return { kind: 'terminal', code: error.code, authRequired: error.status === 401 }
+    }
+    if (error instanceof ApiError && error.status < 500) {
+      await terminalizeRouteLease(context, fence, error.code, true)
+      return { kind: 'terminal', code: error.code, authRequired: false }
+    }
+    const marked = await markRouteBatchRetryable(
+      context,
+      fence,
+      batch.batchId,
+      error instanceof ApiError ? error.code : 'NETWORK_ERROR',
+    )
+    return marked ? { kind: 'retryable' } : { kind: 'fence-lost' }
+  }
+}

--- a/apps/pwa/src/features/raids/recording/runtime.tsx
+++ b/apps/pwa/src/features/raids/recording/runtime.tsx
@@ -1,0 +1,22 @@
+import { createContext, useContext, useMemo, useState, type ReactNode } from 'react'
+import type { RecorderPhase } from './types'
+
+interface RecordingRuntimeValue {
+  phase: RecorderPhase
+  setPhase: (phase: RecorderPhase) => void
+}
+
+const RecordingRuntimeContext = createContext<RecordingRuntimeValue>({
+  phase: 'ineligible',
+  setPhase: () => undefined,
+})
+
+export function RecordingRuntimeProvider({ children }: { children: ReactNode }) {
+  const [phase, setPhase] = useState<RecorderPhase>('ineligible')
+  const value = useMemo(() => ({ phase, setPhase }), [phase])
+  return <RecordingRuntimeContext.Provider value={value}>{children}</RecordingRuntimeContext.Provider>
+}
+
+export function useRecordingRuntime() {
+  return useContext(RecordingRuntimeContext)
+}

--- a/apps/pwa/src/features/raids/recording/state.test.ts
+++ b/apps/pwa/src/features/raids/recording/state.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import {
+  deriveRecorderPhase,
+  isPersistedSampleFresh,
+  selectActivePrimaryAction,
+  shouldDeferServiceWorkerUpdate,
+} from './state'
+
+describe('route recorder truth', () => {
+  const now = Date.parse('2026-08-28T08:00:15.000Z')
+
+  it('becomes fresh only from a durable sample younger than 15 seconds', () => {
+    expect(isPersistedSampleFresh(null, now)).toBe(false)
+    expect(isPersistedSampleFresh('2026-08-28T08:00:00.001Z', now)).toBe(true)
+    expect(isPersistedSampleFresh('2026-08-28T08:00:00.000Z', now)).toBe(false)
+    expect(isPersistedSampleFresh('2026-08-28T08:00:21.000Z', now)).toBe(false)
+  })
+
+  it('does not infer green from an active watch without a persisted sample', () => {
+    expect(deriveRecorderPhase({
+      eligible: true,
+      paused: false,
+      visible: true,
+      ownsWriterLease: true,
+      watchActive: true,
+      lastPersistedSampleAt: null,
+      blocked: false,
+      failed: false,
+      recovering: false,
+      now,
+    })).toBe('stale')
+  })
+
+  it('keeps exactly one primary action and defers updates while recording is unsafe', () => {
+    expect(selectActivePrimaryAction('stale', true)).toBe('recover')
+    expect(selectActivePrimaryAction('fresh', true)).toBe('server')
+    expect(selectActivePrimaryAction('fresh', false)).toBeNull()
+    expect(shouldDeferServiceWorkerUpdate('fresh')).toBe(true)
+    expect(shouldDeferServiceWorkerUpdate('stale')).toBe(true)
+    expect(shouldDeferServiceWorkerUpdate('paused')).toBe(false)
+  })
+})

--- a/apps/pwa/src/features/raids/recording/state.ts
+++ b/apps/pwa/src/features/raids/recording/state.ts
@@ -1,0 +1,76 @@
+import type { RecorderPhase, WakeLockPhase } from './types'
+
+export const ROUTE_STALE_AFTER_MS = 15_000
+
+export function isPersistedSampleFresh(
+  lastPersistedSampleAt: string | null,
+  now = Date.now(),
+): boolean {
+  if (!lastPersistedSampleAt) return false
+  const capturedAt = Date.parse(lastPersistedSampleAt)
+  return Number.isFinite(capturedAt) && capturedAt <= now + 5_000 && now - capturedAt < ROUTE_STALE_AFTER_MS
+}
+
+export function deriveRecorderPhase(input: {
+  eligible: boolean
+  paused: boolean
+  visible: boolean
+  ownsWriterLease: boolean
+  watchActive: boolean
+  lastPersistedSampleAt: string | null
+  blocked: boolean
+  failed: boolean
+  recovering: boolean
+  now?: number
+}): RecorderPhase {
+  if (!input.eligible) return 'ineligible'
+  if (input.paused) return 'paused'
+  if (input.blocked) return 'blocked'
+  if (input.failed) return 'error'
+  if (!input.visible || !input.ownsWriterLease) return 'standby'
+  if (input.recovering) return 'recovering'
+  if (!input.watchActive) return 'waiting'
+  return isPersistedSampleFresh(input.lastPersistedSampleAt, input.now) ? 'fresh' : 'stale'
+}
+
+export type RecorderPrimaryAction = 'recover' | 'server' | null
+
+export function selectActivePrimaryAction(
+  phase: RecorderPhase,
+  hasServerPrimary: boolean,
+): RecorderPrimaryAction {
+  if (phase === 'standby' || phase === 'stale' || phase === 'blocked' || phase === 'error') {
+    return 'recover'
+  }
+  return hasServerPrimary ? 'server' : null
+}
+
+export function shouldDeferServiceWorkerUpdate(
+  phase: RecorderPhase,
+): boolean {
+  return phase === 'standby' || phase === 'recovering' || phase === 'waiting' || phase === 'fresh' || phase === 'stale'
+}
+
+export function routeStatusLabel(phase: RecorderPhase): string {
+  return {
+    ineligible: 'Маршрут пишет выбранный навигатор',
+    standby: 'Запись в другой вкладке или приостановлена страницей',
+    recovering: 'Восстанавливаем запись',
+    waiting: 'Ждём первую координату',
+    fresh: 'Маршрут записывается',
+    stale: 'Свежей координаты нет',
+    blocked: 'Геолокация заблокирована',
+    error: 'Запись маршрута остановилась',
+    paused: 'Маршрут на паузе',
+  }[phase]
+}
+
+export function wakeLockLabel(phase: WakeLockPhase): string {
+  return {
+    unsupported: 'Wake Lock не поддерживается',
+    requesting: 'Запрашиваем Wake Lock',
+    held: 'Экран удерживается открытым',
+    released: 'Wake Lock отпущен системой',
+    failed: 'Wake Lock включить не удалось',
+  }[phase]
+}

--- a/apps/pwa/src/features/raids/recording/store.test.ts
+++ b/apps/pwa/src/features/raids/recording/store.test.ts
@@ -1,0 +1,126 @@
+import 'fake-indexeddb/auto'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { offlineDb } from '../../offline/db'
+import { activateIdentity } from '../../offline/ledger'
+import type { RouteBatchResponse } from '../types'
+import {
+  acquireWriterLease,
+  claimRouteBatch,
+  getOrCreateRecorderSession,
+  getOrCreateRouteLeaseAttempt,
+  completeRouteLeaseAttempt,
+  markRouteBatchRetryable,
+  persistRouteSample,
+  settleRouteBatch,
+  WRITER_LEASE_TTL_MS,
+} from './store'
+import type { CapturedRouteSample, RecorderContext } from './types'
+
+const context: RecorderContext = {
+  identityId: 'user-a',
+  kabandaId: 'kabanda-a',
+  raidId: 'raid-a',
+  navigatorLeaseId: 'lease-a',
+  leaseGeneration: 1,
+}
+
+const sample = (index: number): CapturedRouteSample => ({
+  capturedAt: new Date(Date.parse('2026-08-28T08:00:00.000Z') + index * 1_000).toISOString(),
+  latitude: 56.85 + index * 0.00001,
+  longitude: 53.2 + index * 0.00001,
+  accuracyM: 12,
+  speedMps: 4,
+  headingDeg: 90,
+})
+
+describe('fenced route storage', () => {
+  beforeEach(async () => {
+    await offlineDb.delete()
+    await offlineDb.open()
+    await activateIdentity(context.identityId)
+  })
+
+  afterEach(async () => {
+    await offlineDb.delete()
+  })
+
+  it('rejects a late callback after another tab acquires a higher writer generation', async () => {
+    const now = Date.parse('2026-08-28T08:00:00.000Z')
+    await getOrCreateRecorderSession(context, now)
+    const tabA = await acquireWriterLease(context, 'tab-a', now)
+    expect(tabA).not.toBeNull()
+    expect(await persistRouteSample(context, tabA!, sample(1), now + 1_000)).toMatchObject({ sequence: 1 })
+    expect(await acquireWriterLease(context, 'tab-b', now + 2_000)).toBeNull()
+
+    const tabB = await acquireWriterLease(context, 'tab-b', now + WRITER_LEASE_TTL_MS + 1)
+    expect(tabB?.writerGeneration).toBe((tabA?.writerGeneration ?? 0) + 1)
+    expect(tabB?.fenceToken).not.toBe(tabA?.fenceToken)
+    expect(await persistRouteSample(context, tabA!, sample(2), now + WRITER_LEASE_TTL_MS + 2)).toBeNull()
+    expect(await persistRouteSample(context, tabB!, sample(2), now + WRITER_LEASE_TTL_MS + 2)).toMatchObject({ sequence: 2 })
+  })
+
+  it('keeps client and idempotency stable across reload retry, then rotates after receipt', async () => {
+    const first = await getOrCreateRouteLeaseAttempt('user-a', 'kabanda-a', 'raid-a', 'acquire', 7)
+    const retry = await getOrCreateRouteLeaseAttempt('user-a', 'kabanda-a', 'raid-a', 'acquire', 7)
+    expect(retry).toEqual(first)
+    await completeRouteLeaseAttempt('user-a', 'raid-a', first!.fingerprint)
+    const nextVersion = await getOrCreateRouteLeaseAttempt('user-a', 'kabanda-a', 'raid-a', 'acquire', 8)
+    expect(nextVersion?.clientInstanceId).toBe(first?.clientInstanceId)
+    expect(nextVersion?.idempotencyKey).not.toBe(first?.idempotencyKey)
+  })
+
+  it('fails closed after an identity switch', async () => {
+    const now = Date.parse('2026-08-28T08:00:00.000Z')
+    await getOrCreateRecorderSession(context, now)
+    const fence = await acquireWriterLease(context, 'tab-a', now)
+    await activateIdentity('user-b')
+    expect(await persistRouteSample(context, fence!, sample(1), now + 1_000)).toBeNull()
+    expect(await claimRouteBatch(context, fence!, now + 1_000)).toBeNull()
+  })
+
+  it('claims no more than 50 isolated samples and retries the exact batch id', async () => {
+    const now = Date.parse('2026-08-28T08:00:00.000Z')
+    await getOrCreateRecorderSession(context, now)
+    const fence = await acquireWriterLease(context, 'tab-a', now)
+    for (let index = 1; index <= 55; index += 1) {
+      await persistRouteSample(context, fence!, sample(index), now + 1_000)
+    }
+    const first = await claimRouteBatch(context, fence!, now + 1_100, 100)
+    expect(first?.rows).toHaveLength(50)
+    expect(new Set(first?.rows.map(({ identityId, raidId, navigatorLeaseId }) => `${identityId}:${raidId}:${navigatorLeaseId}`))).toEqual(new Set(['user-a:raid-a:lease-a']))
+    await markRouteBatchRetryable(context, fence!, first!.batchId, 'NETWORK_ERROR', now + 1_200)
+    const retry = await claimRouteBatch(context, fence!, now + 3_300)
+    expect(retry?.batchId).toBe(first?.batchId)
+    expect(retry?.rows.map(({ id }) => id)).toEqual(first?.rows.map(({ id }) => id))
+  })
+
+  it('settles only a complete exact receipt', async () => {
+    const now = Date.parse('2026-08-28T08:00:00.000Z')
+    await getOrCreateRecorderSession(context, now)
+    const fence = await acquireWriterLease(context, 'tab-a', now)
+    await persistRouteSample(context, fence!, sample(1), now + 1_000)
+    await persistRouteSample(context, fence!, sample(2), now + 1_000)
+    const batch = await claimRouteBatch(context, fence!, now + 1_100)
+    const incomplete: RouteBatchResponse = {
+      batchId: batch!.batchId,
+      accepted: [{ operationId: batch!.rows[0]!.id, acceptedAt: '2026-08-28T08:00:02.000Z' }],
+      duplicates: [],
+      rejected: [],
+      routeStatus: { status: 'fresh', lastSampleAt: '2026-08-28T08:00:02.000Z', lastReceivedAt: '2026-08-28T08:00:02.100Z', acceptedSampleCount: 1, missingSequenceCount: 0 },
+      serverAt: '2026-08-28T08:00:02.000Z',
+    }
+    expect(await settleRouteBatch(context, fence!, batch!.batchId, incomplete, now + 1_200)).toBe(false)
+    expect((await offlineDb.routeOutbox.where('batchId').equals(batch!.batchId).toArray()).every(({ status }) => status === 'sending')).toBe(true)
+
+    const complete: RouteBatchResponse = {
+      ...incomplete,
+      accepted: [
+        incomplete.accepted[0]!,
+        { operationId: batch!.rows[1]!.id, acceptedAt: '2026-08-28T08:00:02.000Z' },
+      ],
+      routeStatus: { ...incomplete.routeStatus, acceptedSampleCount: 2 },
+    }
+    expect(await settleRouteBatch(context, fence!, batch!.batchId, complete, now + 1_300)).toBe(true)
+    expect((await offlineDb.routeOutbox.where('batchId').equals(batch!.batchId).toArray()).every(({ status }) => status === 'accepted')).toBe(true)
+  })
+})

--- a/apps/pwa/src/features/raids/recording/store.ts
+++ b/apps/pwa/src/features/raids/recording/store.ts
@@ -1,0 +1,558 @@
+import Dexie from 'dexie'
+import { offlineDb } from '../../offline/db'
+import type {
+  RecorderSessionRecord,
+  RecorderClientRecord,
+  RecorderWriterLeaseRecord,
+  RouteOutboxRecord,
+} from '../../offline/types'
+import type { RouteBatchResponse } from '../types'
+import type {
+  CapturedRouteSample,
+  ClaimedRouteBatch,
+  RecorderContext,
+  RecorderLocalStats,
+  WriterFence,
+} from './types'
+
+export const WRITER_LEASE_TTL_MS = 12_000
+export const WRITER_LEASE_RENEW_MS = 4_000
+const BATCH_CLAIM_MS = 30_000
+
+function writerKey(identityId: string, raidId: string): string {
+  return JSON.stringify([identityId, raidId])
+}
+
+function sessionKey(context: RecorderContext): string {
+  return JSON.stringify([
+    context.identityId,
+    context.raidId,
+    context.navigatorLeaseId,
+    context.leaseGeneration,
+  ])
+}
+
+function clientKey(identityId: string, raidId: string): string {
+  return JSON.stringify([identityId, raidId])
+}
+
+export interface RouteLeaseAttempt {
+  clientInstanceId: string
+  idempotencyKey: string
+  fingerprint: string
+}
+
+export async function getOrCreateRouteLeaseAttempt(
+  identityId: string,
+  kabandaId: string,
+  raidId: string,
+  action: 'acquire' | 'recover',
+  expectedVersion: number,
+  now = Date.now(),
+): Promise<RouteLeaseAttempt | null> {
+  return offlineDb.transaction(
+    'rw',
+    offlineDb.identityContext,
+    offlineDb.recorderClients,
+    async () => {
+      if (!(await activeIdentityMatches(identityId))) return null
+      const key = clientKey(identityId, raidId)
+      const existing = await offlineDb.recorderClients.get(key)
+      const clientInstanceId = existing?.clientInstanceId ?? crypto.randomUUID()
+      const fingerprint = JSON.stringify([action, expectedVersion, clientInstanceId])
+      const idempotencyKey = existing?.leaseActionFingerprint === fingerprint && existing.leaseActionKey
+        ? existing.leaseActionKey
+        : crypto.randomUUID()
+      const record: RecorderClientRecord = {
+        key,
+        identityId,
+        kabandaId,
+        raidId,
+        clientInstanceId,
+        leaseActionFingerprint: fingerprint,
+        leaseActionKey: idempotencyKey,
+        updatedAt: new Date(now).toISOString(),
+      }
+      await offlineDb.recorderClients.put(record)
+      return { clientInstanceId, idempotencyKey, fingerprint }
+    },
+  )
+}
+
+export async function completeRouteLeaseAttempt(
+  identityId: string,
+  raidId: string,
+  fingerprint: string,
+  now = Date.now(),
+): Promise<void> {
+  await offlineDb.transaction('rw', offlineDb.identityContext, offlineDb.recorderClients, async () => {
+    if (!(await activeIdentityMatches(identityId))) return
+    const key = clientKey(identityId, raidId)
+    const record = await offlineDb.recorderClients.get(key)
+    if (!record || record.leaseActionFingerprint !== fingerprint) return
+    await offlineDb.recorderClients.put({
+      ...record,
+      leaseActionFingerprint: null,
+      leaseActionKey: null,
+      updatedAt: new Date(now).toISOString(),
+    })
+  })
+}
+
+export async function findRecorderSession(identityId: string, raidId: string) {
+  if (!(await activeIdentityMatches(identityId))) return null
+  return offlineDb.recorderSessions
+    .where('[identityId+raidId+updatedAt]')
+    .between([identityId, raidId, Dexie.minKey], [identityId, raidId, Dexie.maxKey], true, true)
+    .reverse()
+    .first()
+}
+
+type LeaseContext = {
+  identityId: string
+  raidId: string
+  navigatorLeaseId: string
+  leaseGeneration: number
+}
+
+function sameContext(record: LeaseContext, context: LeaseContext): boolean {
+  return record.identityId === context.identityId &&
+    record.raidId === context.raidId &&
+    record.navigatorLeaseId === context.navigatorLeaseId &&
+    record.leaseGeneration === context.leaseGeneration
+}
+
+async function activeIdentityMatches(identityId: string): Promise<boolean> {
+  return (await offlineDb.identityContext.get('active'))?.userId === identityId
+}
+
+function fenceMatches(
+  record: RecorderWriterLeaseRecord | undefined,
+  fence: WriterFence,
+  now: number,
+): record is RecorderWriterLeaseRecord {
+  return Boolean(
+    record &&
+    sameContext(record, fence) &&
+    record.holderTabId === fence.holderTabId &&
+    record.writerGeneration === fence.writerGeneration &&
+    record.fenceToken === fence.fenceToken &&
+    Date.parse(record.expiresAt) > now,
+  )
+}
+
+function exposeFence(record: RecorderWriterLeaseRecord): WriterFence {
+  return { ...record }
+}
+
+export async function getOrCreateRecorderSession(
+  context: RecorderContext,
+  now = Date.now(),
+): Promise<RecorderSessionRecord | null> {
+  return offlineDb.transaction(
+    'rw',
+    offlineDb.identityContext,
+    offlineDb.recorderClients,
+    offlineDb.recorderSessions,
+    async () => {
+      if (!(await activeIdentityMatches(context.identityId))) return null
+      const key = sessionKey(context)
+      const existing = await offlineDb.recorderSessions.get(key)
+      if (existing) {
+        const next = { ...existing, wanted: true, updatedAt: new Date(now).toISOString() }
+        await offlineDb.recorderSessions.put(next)
+        return next
+      }
+      const clientRecord = await offlineDb.recorderClients.get(clientKey(context.identityId, context.raidId))
+      const clientInstanceId = clientRecord?.clientInstanceId ?? crypto.randomUUID()
+      if (!clientRecord) {
+        await offlineDb.recorderClients.add({
+          key: clientKey(context.identityId, context.raidId),
+          identityId: context.identityId,
+          kabandaId: context.kabandaId,
+          raidId: context.raidId,
+          clientInstanceId,
+          leaseActionFingerprint: null,
+          leaseActionKey: null,
+          updatedAt: new Date(now).toISOString(),
+        })
+      }
+      const created: RecorderSessionRecord = {
+        key,
+        ...context,
+        clientInstanceId,
+        wanted: true,
+        nextSequence: 0,
+        lastPersistedSampleAt: null,
+        lastLatitude: null,
+        lastLongitude: null,
+        preliminaryDistanceM: 0,
+        updatedAt: new Date(now).toISOString(),
+      }
+      await offlineDb.recorderSessions.add(created)
+      return created
+    },
+  )
+}
+
+export async function setRecorderWanted(
+  context: RecorderContext,
+  wanted: boolean,
+  now = Date.now(),
+): Promise<void> {
+  await offlineDb.transaction(
+    'rw',
+    offlineDb.identityContext,
+    offlineDb.recorderSessions,
+    async () => {
+      if (!(await activeIdentityMatches(context.identityId))) return
+      const record = await offlineDb.recorderSessions.get(sessionKey(context))
+      if (record) await offlineDb.recorderSessions.put({ ...record, wanted, updatedAt: new Date(now).toISOString() })
+    },
+  )
+}
+
+export async function acquireWriterLease(
+  context: RecorderContext,
+  holderTabId: string,
+  now = Date.now(),
+): Promise<WriterFence | null> {
+  return offlineDb.transaction(
+    'rw',
+    offlineDb.identityContext,
+    offlineDb.recorderWriterLeases,
+    async () => {
+      if (!(await activeIdentityMatches(context.identityId))) return null
+      const key = writerKey(context.identityId, context.raidId)
+      const current = await offlineDb.recorderWriterLeases.get(key)
+      const currentActive = current && Date.parse(current.expiresAt) > now
+      const sameHolderAndLease = current &&
+        current.holderTabId === holderTabId &&
+        sameContext(current, context)
+      if (currentActive && !sameHolderAndLease && sameContext(current, context)) return null
+
+      const acquired: RecorderWriterLeaseRecord = {
+        key,
+        ...context,
+        holderTabId,
+        writerGeneration: (current?.writerGeneration ?? 0) + 1,
+        fenceToken: crypto.randomUUID(),
+        expiresAt: new Date(now + WRITER_LEASE_TTL_MS).toISOString(),
+        updatedAt: new Date(now).toISOString(),
+      }
+      await offlineDb.recorderWriterLeases.put(acquired)
+      return exposeFence(acquired)
+    },
+  )
+}
+
+export async function renewWriterLease(
+  fence: WriterFence,
+  now = Date.now(),
+): Promise<WriterFence | null> {
+  return offlineDb.transaction(
+    'rw',
+    offlineDb.identityContext,
+    offlineDb.recorderWriterLeases,
+    async () => {
+      if (!(await activeIdentityMatches(fence.identityId))) return null
+      const record = await offlineDb.recorderWriterLeases.get(fence.key)
+      if (!fenceMatches(record, fence, now)) return null
+      const renewed = {
+        ...record,
+        expiresAt: new Date(now + WRITER_LEASE_TTL_MS).toISOString(),
+        updatedAt: new Date(now).toISOString(),
+      }
+      await offlineDb.recorderWriterLeases.put(renewed)
+      return exposeFence(renewed)
+    },
+  )
+}
+
+export async function releaseWriterLease(
+  fence: WriterFence,
+  now = Date.now(),
+): Promise<void> {
+  await offlineDb.transaction('rw', offlineDb.recorderWriterLeases, async () => {
+    const record = await offlineDb.recorderWriterLeases.get(fence.key)
+    if (!record ||
+      record.holderTabId !== fence.holderTabId ||
+      record.writerGeneration !== fence.writerGeneration ||
+      record.fenceToken !== fence.fenceToken) return
+    await offlineDb.recorderWriterLeases.put({
+      ...record,
+      expiresAt: new Date(now).toISOString(),
+      updatedAt: new Date(now).toISOString(),
+    })
+  })
+}
+
+export function distanceMeters(
+  from: { latitude: number; longitude: number },
+  to: { latitude: number; longitude: number },
+): number {
+  const radians = Math.PI / 180
+  const lat1 = from.latitude * radians
+  const lat2 = to.latitude * radians
+  const deltaLat = (to.latitude - from.latitude) * radians
+  const deltaLng = (to.longitude - from.longitude) * radians
+  const a = Math.sin(deltaLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(deltaLng / 2) ** 2
+  return 6_371_000 * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+}
+
+export async function persistRouteSample(
+  context: RecorderContext,
+  fence: WriterFence,
+  sample: CapturedRouteSample,
+  now = Date.now(),
+): Promise<RouteOutboxRecord | null> {
+  if (![sample.latitude, sample.longitude, sample.accuracyM].every(Number.isFinite)) return null
+  return offlineDb.transaction(
+    'rw',
+    offlineDb.identityContext,
+    offlineDb.recorderWriterLeases,
+    offlineDb.recorderSessions,
+    offlineDb.routeOutbox,
+    async () => {
+      if (!(await activeIdentityMatches(context.identityId))) return null
+      const writer = await offlineDb.recorderWriterLeases.get(fence.key)
+      if (!fenceMatches(writer, fence, now) || !sameContext(fence, context)) return null
+      const session = await offlineDb.recorderSessions.get(sessionKey(context))
+      if (!session || !sameContext(session, context) || !session.wanted) return null
+      const sequence = session.nextSequence + 1
+      const id = crypto.randomUUID()
+      const record: RouteOutboxRecord = {
+        id,
+        ...context,
+        clientInstanceId: session.clientInstanceId,
+        sequence,
+        ...sample,
+        status: 'pending',
+        batchId: null,
+        attempts: 0,
+        nextAttemptAt: null,
+        claimUntil: null,
+      }
+      const addedDistance = session.lastLatitude === null || session.lastLongitude === null
+        ? 0
+        : distanceMeters(
+            { latitude: session.lastLatitude, longitude: session.lastLongitude },
+            sample,
+          )
+      await offlineDb.routeOutbox.add(record)
+      await offlineDb.recorderSessions.put({
+        ...session,
+        nextSequence: sequence,
+        lastPersistedSampleAt: sample.capturedAt,
+        lastLatitude: sample.latitude,
+        lastLongitude: sample.longitude,
+        preliminaryDistanceM: session.preliminaryDistanceM + addedDistance,
+        updatedAt: new Date(now).toISOString(),
+      })
+      return record
+    },
+  )
+}
+
+async function rowsForStatus(
+  context: RecorderContext,
+  status: RouteOutboxRecord['status'],
+): Promise<RouteOutboxRecord[]> {
+  return offlineDb.routeOutbox
+    .where('[identityId+raidId+navigatorLeaseId+status+sequence]')
+    .between(
+      [context.identityId, context.raidId, context.navigatorLeaseId, status, Dexie.minKey],
+      [context.identityId, context.raidId, context.navigatorLeaseId, status, Dexie.maxKey],
+      true,
+      true,
+    )
+    .filter((row) => row.leaseGeneration === context.leaseGeneration)
+    .sortBy('sequence')
+}
+
+export async function claimRouteBatch(
+  context: RecorderContext,
+  fence: WriterFence,
+  now = Date.now(),
+  limit = 50,
+): Promise<ClaimedRouteBatch | null> {
+  const boundedLimit = Math.max(1, Math.min(50, limit))
+  return offlineDb.transaction(
+    'rw',
+    offlineDb.identityContext,
+    offlineDb.recorderWriterLeases,
+    offlineDb.recorderSessions,
+    offlineDb.routeOutbox,
+    async () => {
+      if (!(await activeIdentityMatches(context.identityId))) return null
+      const writer = await offlineDb.recorderWriterLeases.get(fence.key)
+      if (!fenceMatches(writer, fence, now) || !sameContext(fence, context)) return null
+
+      const sending = await rowsForStatus(context, 'sending')
+      const expired = sending.filter((row) => row.claimUntil && Date.parse(row.claimUntil) <= now)
+      if (expired.length) {
+        await offlineDb.routeOutbox.bulkPut(expired.map((row) => ({ ...row, status: 'retryable' as const })))
+      }
+
+      const retryable = (await rowsForStatus(context, 'retryable'))
+        .filter((row) => !row.nextAttemptAt || Date.parse(row.nextAttemptAt) <= now)
+      const retryBatchId = retryable.find(({ batchId }) => batchId)?.batchId ?? null
+      let rows = retryBatchId
+        ? retryable.filter(({ batchId }) => batchId === retryBatchId)
+        : (await rowsForStatus(context, 'pending')).filter(({ batchId }) => batchId === null).slice(0, boundedLimit)
+      if (!rows.length) return null
+      if (rows.length > 50) rows = rows.slice(0, 50)
+      const batchId = retryBatchId ?? crypto.randomUUID()
+      const claimUntil = new Date(now + BATCH_CLAIM_MS).toISOString()
+      const claimed = rows.map((row) => ({
+        ...row,
+        batchId,
+        status: 'sending' as const,
+        attempts: row.attempts + 1,
+        claimUntil,
+        nextAttemptAt: null,
+      }))
+      await offlineDb.routeOutbox.bulkPut(claimed)
+      const session = await offlineDb.recorderSessions.get(sessionKey(context))
+      if (!session) return null
+      return { batchId, context, clientInstanceId: session.clientInstanceId, rows: claimed }
+    },
+  )
+}
+
+function retryDelayMs(attempts: number): number {
+  return [2_000, 5_000, 15_000, 30_000, 60_000][Math.min(Math.max(attempts - 1, 0), 4)] ?? 60_000
+}
+
+export async function markRouteBatchRetryable(
+  context: RecorderContext,
+  fence: WriterFence,
+  batchId: string,
+  errorCode: string,
+  now = Date.now(),
+): Promise<boolean> {
+  return offlineDb.transaction(
+    'rw',
+    offlineDb.identityContext,
+    offlineDb.recorderWriterLeases,
+    offlineDb.routeOutbox,
+    async () => {
+      if (!(await activeIdentityMatches(context.identityId))) return false
+      const writer = await offlineDb.recorderWriterLeases.get(fence.key)
+      if (!fenceMatches(writer, fence, now)) return false
+      const rows = (await offlineDb.routeOutbox.where('batchId').equals(batchId).toArray())
+        .filter((row) => sameContext(row, context) && row.status === 'sending')
+      if (!rows.length) return false
+      await offlineDb.routeOutbox.bulkPut(rows.map((row) => ({
+        ...row,
+        status: 'retryable' as const,
+        claimUntil: null,
+        nextAttemptAt: new Date(now + retryDelayMs(row.attempts)).toISOString(),
+        lastErrorCode: errorCode,
+      })))
+      return true
+    },
+  )
+}
+
+export async function settleRouteBatch(
+  context: RecorderContext,
+  fence: WriterFence,
+  expectedBatchId: string,
+  response: RouteBatchResponse,
+  now = Date.now(),
+): Promise<boolean> {
+  if (response.batchId !== expectedBatchId) return false
+  return offlineDb.transaction(
+    'rw',
+    offlineDb.identityContext,
+    offlineDb.recorderWriterLeases,
+    offlineDb.routeOutbox,
+    async () => {
+      if (!(await activeIdentityMatches(context.identityId))) return false
+      const writer = await offlineDb.recorderWriterLeases.get(fence.key)
+      if (!fenceMatches(writer, fence, now)) return false
+      const rows = (await offlineDb.routeOutbox.where('batchId').equals(expectedBatchId).toArray())
+        .filter((row) => sameContext(row, context) && row.status === 'sending')
+      const accepted = new Map(response.accepted.map((item) => [item.operationId, item.acceptedAt]))
+      const duplicates = new Set(response.duplicates.map((item) => item.operationId))
+      const rejected = new Map(response.rejected.map((item) => [item.operationId, item.code]))
+      const classified = new Set([...accepted.keys(), ...duplicates, ...rejected.keys()])
+      if (!rows.length || rows.some(({ id }) => !classified.has(id)) || classified.size !== rows.length) return false
+      await offlineDb.routeOutbox.bulkPut(rows.map((row) => {
+        const rejection = rejected.get(row.id)
+        if (rejection) return {
+          ...row,
+          status: 'rejected' as const,
+          claimUntil: null,
+          lastErrorCode: rejection,
+        }
+        return {
+          ...row,
+          status: 'accepted' as const,
+          claimUntil: null,
+          acceptedAt: accepted.get(row.id) ?? response.serverAt,
+          lastErrorCode: undefined,
+        }
+      }))
+      return true
+    },
+  )
+}
+
+export async function terminalizeRouteLease(
+  context: RecorderContext,
+  fence: WriterFence,
+  errorCode: string,
+  rejectOpen: boolean,
+  now = Date.now(),
+): Promise<void> {
+  await offlineDb.transaction(
+    'rw',
+    offlineDb.identityContext,
+    offlineDb.recorderWriterLeases,
+    offlineDb.recorderSessions,
+    offlineDb.routeOutbox,
+    async () => {
+      if (!(await activeIdentityMatches(context.identityId))) return
+      const writer = await offlineDb.recorderWriterLeases.get(fence.key)
+      if (!fenceMatches(writer, fence, now) || !sameContext(fence, context)) return
+      const session = await offlineDb.recorderSessions.get(sessionKey(context))
+      if (session) await offlineDb.recorderSessions.put({ ...session, wanted: false, updatedAt: new Date(now).toISOString() })
+      const rows = [
+        ...(await rowsForStatus(context, 'pending')),
+        ...(await rowsForStatus(context, 'sending')),
+        ...(await rowsForStatus(context, 'retryable')),
+      ]
+      await offlineDb.routeOutbox.bulkPut(rows.map((row) => ({
+        ...row,
+        status: rejectOpen
+          ? 'rejected' as const
+          : row.status === 'sending' ? 'retryable' as const : row.status,
+        claimUntil: null,
+        lastErrorCode: errorCode,
+      })))
+    },
+  )
+}
+
+export async function getRecorderLocalStats(
+  context: RecorderContext,
+): Promise<RecorderLocalStats> {
+  if (!(await activeIdentityMatches(context.identityId))) {
+    return { pendingCount: 0, preliminaryDistanceM: 0, lastPersistedSampleAt: null }
+  }
+  const session = await offlineDb.recorderSessions.get(sessionKey(context))
+  if (!session) return { pendingCount: 0, preliminaryDistanceM: 0, lastPersistedSampleAt: null }
+  const rows = [
+    ...(await rowsForStatus(context, 'pending')),
+    ...(await rowsForStatus(context, 'sending')),
+    ...(await rowsForStatus(context, 'retryable')),
+  ]
+  return {
+    pendingCount: rows.length,
+    preliminaryDistanceM: session.preliminaryDistanceM,
+    lastPersistedSampleAt: session.lastPersistedSampleAt,
+  }
+}

--- a/apps/pwa/src/features/raids/recording/types.ts
+++ b/apps/pwa/src/features/raids/recording/types.ts
@@ -1,0 +1,76 @@
+import type {
+  RecorderSessionRecord,
+  RecorderWriterLeaseRecord,
+  RouteOutboxRecord,
+} from '../../offline/types'
+import type { RouteStatusProjection } from '../types'
+
+export interface RecorderContext {
+  identityId: string
+  kabandaId: string
+  raidId: string
+  navigatorLeaseId: string
+  leaseGeneration: number
+}
+
+export interface WriterFence {
+  key: string
+  identityId: string
+  raidId: string
+  navigatorLeaseId: string
+  leaseGeneration: number
+  holderTabId: string
+  writerGeneration: number
+  fenceToken: string
+  expiresAt: string
+}
+
+export interface CapturedRouteSample {
+  capturedAt: string
+  latitude: number
+  longitude: number
+  accuracyM: number
+  speedMps: number | null
+  headingDeg: number | null
+}
+
+export interface ClaimedRouteBatch {
+  batchId: string
+  context: RecorderContext
+  clientInstanceId: string
+  rows: RouteOutboxRecord[]
+}
+
+export interface RecorderLocalStats {
+  pendingCount: number
+  preliminaryDistanceM: number
+  lastPersistedSampleAt: string | null
+}
+
+export type RecorderPhase =
+  | 'ineligible'
+  | 'standby'
+  | 'recovering'
+  | 'waiting'
+  | 'fresh'
+  | 'stale'
+  | 'blocked'
+  | 'error'
+  | 'paused'
+
+export type WakeLockPhase = 'unsupported' | 'requesting' | 'held' | 'released' | 'failed'
+
+export interface RouteRecorderView {
+  phase: RecorderPhase
+  wakeLock: WakeLockPhase
+  pendingCount: number
+  preliminaryDistanceM: number
+  lastPersistedSampleAt: string | null
+  routeStatus: RouteStatusProjection
+  message: string | null
+  recover: () => void
+  flush: () => void
+}
+
+export type StoredRecorderSession = RecorderSessionRecord
+export type StoredWriterLease = RecorderWriterLeaseRecord

--- a/apps/pwa/src/features/raids/recording/useRouteRecorder.ts
+++ b/apps/pwa/src/features/raids/recording/useRouteRecorder.ts
@@ -1,0 +1,470 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ApiError } from '../../../lib/http'
+import { requestRouteLease } from '../api'
+import type { RaidProjection, RouteStatusProjection } from '../types'
+import { replayRouteBatch } from './replay'
+import { deriveRecorderPhase, isPersistedSampleFresh } from './state'
+import {
+  acquireWriterLease,
+  completeRouteLeaseAttempt,
+  findRecorderSession,
+  getOrCreateRouteLeaseAttempt,
+  getOrCreateRecorderSession,
+  getRecorderLocalStats,
+  persistRouteSample,
+  releaseWriterLease,
+  renewWriterLease,
+  setRecorderWanted,
+  WRITER_LEASE_RENEW_MS,
+} from './store'
+import type {
+  RecorderContext,
+  RecorderLocalStats,
+  RecorderPhase,
+  RouteRecorderView,
+  WakeLockPhase,
+  WriterFence,
+} from './types'
+import { useRecordingRuntime } from './runtime'
+
+const emptyStats: RecorderLocalStats = {
+  pendingCount: 0,
+  preliminaryDistanceM: 0,
+  lastPersistedSampleAt: null,
+}
+
+function fallbackRouteStatus(raid: RaidProjection | null): RouteStatusProjection {
+  if (raid?.routeStatus) return raid.routeStatus
+  return { status: 'awaiting_lease', lastSampleAt: null, lastReceivedAt: null, acceptedSampleCount: 0, missingSequenceCount: 0 }
+}
+
+function getTabId(): string {
+  const key = 'kabanda:route-recorder-tab:v1'
+  try {
+    const current = sessionStorage.getItem(key)
+    if (current) return current
+    const created = crypto.randomUUID()
+    sessionStorage.setItem(key, created)
+    return created
+  } catch {
+    return crypto.randomUUID()
+  }
+}
+
+export function useRouteRecorder(input: {
+  identityId: string
+  raid: RaidProjection
+  staleProjection: boolean
+  onCanonicalRefresh: () => Promise<unknown>
+  onApplyRaid: (raid: RaidProjection) => Promise<unknown>
+}): RouteRecorderView {
+  const { identityId, raid, staleProjection, onCanonicalRefresh, onApplyRaid } = input
+  const [phase, setPhase] = useState<RecorderPhase>(raid.state === 'paused' ? 'paused' : 'recovering')
+  const [wakeLock, setWakeLock] = useState<WakeLockPhase>('released')
+  const [stats, setStats] = useState<RecorderLocalStats>(emptyStats)
+  const [routeStatus, setRouteStatus] = useState<RouteStatusProjection>(() => fallbackRouteStatus(raid))
+  const [message, setMessage] = useState<string | null>(null)
+  const [recoverNonce, setRecoverNonce] = useState(0)
+  const leaseRequestInFlight = useRef(false)
+  const flushRef = useRef<() => void>(() => undefined)
+  const previousContext = useRef<RecorderContext | null>(null)
+  const { setPhase: setRuntimePhase } = useRecordingRuntime()
+  const tabId = useRef(getTabId()).current
+
+  const context = useMemo<RecorderContext | null>(() => {
+    if (!raid.navigatorLease) return null
+    return {
+      identityId,
+      kabandaId: raid.kabandaId,
+      raidId: raid.id,
+      navigatorLeaseId: raid.navigatorLease.id,
+      leaseGeneration: raid.navigatorLease.generation,
+    }
+  }, [identityId, raid.id, raid.kabandaId, raid.navigatorLease])
+  const contextKey = context
+    ? `${context.identityId}:${context.raidId}:${context.navigatorLeaseId}:${context.leaseGeneration}`
+    : 'none'
+  const eligible = Boolean(
+    context &&
+    raid.state === 'active' &&
+    raid.navigatorUserId === identityId &&
+    !staleProjection,
+  )
+
+  const canRequestServerLease = raid.state === 'active' && raid.navigatorUserId === identityId &&
+    !staleProjection && navigator.onLine
+
+  const requestServerLease = useCallback(async (action: 'acquire' | 'recover') => {
+    if (!canRequestServerLease || leaseRequestInFlight.current) return false
+    leaseRequestInFlight.current = true
+    setPhase('recovering')
+    setMessage(null)
+    try {
+      const attempt = await getOrCreateRouteLeaseAttempt(
+        identityId,
+        raid.kabandaId,
+        raid.id,
+        action,
+        raid.version,
+      )
+      if (!attempt) return false
+      const response = await requestRouteLease(
+        raid.id,
+        action,
+        raid.version,
+        attempt.clientInstanceId,
+        attempt.idempotencyKey,
+      )
+      if (response.raid.navigatorLease) {
+        await getOrCreateRecorderSession({
+          identityId,
+          kabandaId: response.raid.kabandaId,
+          raidId: response.raid.id,
+          navigatorLeaseId: response.raid.navigatorLease.id,
+          leaseGeneration: response.raid.navigatorLease.generation,
+        })
+      }
+      await completeRouteLeaseAttempt(identityId, raid.id, attempt.fingerprint)
+      await onApplyRaid(response.raid)
+      return true
+    } catch (error) {
+      if (error instanceof ApiError && error.code === 'NAVIGATOR_LEASE_HELD') {
+        setPhase('standby')
+        setMessage('Маршрут уже пишет другое устройство. Восстановление здесь завершит его lease.')
+      } else {
+        setPhase('error')
+        setMessage(error instanceof ApiError ? error.message : 'Не удалось подтвердить lease навигатора.')
+      }
+      return false
+    } finally {
+      leaseRequestInFlight.current = false
+    }
+  }, [canRequestServerLease, identityId, onApplyRaid, raid.id, raid.kabandaId, raid.version])
+
+  useEffect(() => {
+    if (canRequestServerLease && !raid.navigatorLease) void requestServerLease('acquire')
+  }, [canRequestServerLease, raid.navigatorLease, requestServerLease])
+
+  useEffect(() => {
+    setRouteStatus(fallbackRouteStatus(raid))
+  }, [raid.routeStatus])
+
+  useEffect(() => {
+    setRuntimePhase(phase)
+  }, [phase, setRuntimePhase])
+
+  useEffect(() => () => setRuntimePhase('ineligible'), [setRuntimePhase])
+
+  useEffect(() => {
+    const previous = previousContext.current
+    if (previous && (!context || !(
+      previous.identityId === context.identityId &&
+      previous.raidId === context.raidId &&
+      previous.navigatorLeaseId === context.navigatorLeaseId &&
+      previous.leaseGeneration === context.leaseGeneration
+    ))) void setRecorderWanted(previous, false)
+    if (context) previousContext.current = context
+    if (raid.state === 'active') return
+    if (previous) void setRecorderWanted(previous, false)
+  }, [contextKey, raid.state])
+
+  useEffect(() => {
+    if (!eligible || !context) {
+      setPhase(raid.state === 'paused' ? 'paused' : 'ineligible')
+      setStats(emptyStats)
+      flushRef.current = () => undefined
+      return
+    }
+
+    let cancelled = false
+    let fence: WriterFence | null = null
+    let watchId: number | null = null
+    let wakeSentinel: WakeLockSentinel | null = null
+    let starting = false
+    let replaying = false
+    let blocked = false
+    let failed = false
+    let recovering = true
+    let lastPersistedSampleAt: string | null = null
+
+    const safeSetPhase = (next: RecorderPhase) => {
+      if (!cancelled) setPhase(next)
+    }
+    const refreshStats = async () => {
+      const next = await getRecorderLocalStats(context)
+      if (cancelled) return next
+      lastPersistedSampleAt = next.lastPersistedSampleAt
+      setStats(next)
+      return next
+    }
+    const updateDerivedPhase = () => {
+      safeSetPhase(deriveRecorderPhase({
+        eligible: true,
+        paused: false,
+        visible: document.visibilityState === 'visible',
+        ownsWriterLease: Boolean(fence),
+        watchActive: watchId !== null,
+        lastPersistedSampleAt,
+        blocked,
+        failed,
+        recovering,
+      }))
+    }
+    const stopWatch = () => {
+      if (watchId !== null) navigator.geolocation?.clearWatch(watchId)
+      watchId = null
+    }
+    const releaseWakeLock = async () => {
+      const current = wakeSentinel
+      wakeSentinel = null
+      if (current && !current.released) await current.release().catch(() => undefined)
+      if (!cancelled) setWakeLock('released')
+    }
+    const releaseLocalWriter = async () => {
+      const current = fence
+      fence = null
+      if (current) await releaseWriterLease(current)
+    }
+    const stopPageRecorder = async (releaseWriter: boolean) => {
+      stopWatch()
+      await releaseWakeLock()
+      if (releaseWriter) await releaseLocalWriter()
+    }
+    const requestWakeLock = async () => {
+      if (!('wakeLock' in navigator)) {
+        if (!cancelled) setWakeLock('unsupported')
+        return
+      }
+      if (!cancelled) setWakeLock('requesting')
+      try {
+        const sentinel = await navigator.wakeLock.request('screen')
+        if (cancelled || document.visibilityState !== 'visible') {
+          await sentinel.release().catch(() => undefined)
+          return
+        }
+        wakeSentinel = sentinel
+        setWakeLock('held')
+        sentinel.addEventListener('release', () => {
+          if (wakeSentinel === sentinel) wakeSentinel = null
+          if (!cancelled) setWakeLock('released')
+        })
+      } catch {
+        if (!cancelled) setWakeLock('failed')
+      }
+    }
+    const flush = async () => {
+      if (cancelled || replaying || !fence || !navigator.onLine) return
+      replaying = true
+      try {
+        for (let count = 0; count < 3 && fence && !cancelled; count += 1) {
+          const result = await replayRouteBatch(context, fence)
+          if (result.kind === 'accepted') {
+            setRouteStatus(result.routeStatus)
+            await refreshStats()
+            continue
+          }
+          if (result.kind === 'terminal') {
+            failed = true
+            setMessage(result.authRequired
+              ? 'Сессия истекла. Локальные точки сохранены; войдите снова для безопасного replay.'
+              : 'Сервер завершил lease навигатора. Запись остановлена, состояние рейда обновляется.')
+            await stopPageRecorder(true)
+            updateDerivedPhase()
+            if (result.authRequired) {
+              window.location.reload()
+              return
+            }
+            await onCanonicalRefresh()
+          } else if (result.kind === 'fence-lost') {
+            fence = null
+            await stopPageRecorder(false)
+            updateDerivedPhase()
+          }
+          break
+        }
+      } finally {
+        replaying = false
+      }
+    }
+    flushRef.current = () => void flush()
+
+    const startPageRecorder = async () => {
+      if (cancelled || starting || document.visibilityState !== 'visible') return
+      if (fence && watchId !== null) return
+      starting = true
+      blocked = false
+      failed = false
+      recovering = true
+      safeSetPhase('recovering')
+      try {
+        const previousSession = await findRecorderSession(context.identityId, context.raidId)
+        const matchesServerLease = previousSession &&
+          previousSession.navigatorLeaseId === context.navigatorLeaseId &&
+          previousSession.leaseGeneration === context.leaseGeneration
+        if (!matchesServerLease) {
+          await requestServerLease('acquire')
+          return
+        }
+        const session = await getOrCreateRecorderSession(context)
+        if (!session || cancelled) return
+        const acquired = await acquireWriterLease(context, tabId)
+        if (!acquired || cancelled) {
+          safeSetPhase('standby')
+          return
+        }
+        fence = acquired
+        await refreshStats()
+        await requestWakeLock()
+        if (!navigator.geolocation) {
+          blocked = true
+          setMessage('Geolocation API недоступен. Маршрут не записывается.')
+          await stopPageRecorder(true)
+          updateDerivedPhase()
+          return
+        }
+        if (cancelled || document.visibilityState !== 'visible') return
+        watchId = navigator.geolocation.watchPosition(
+          (position) => {
+            const callbackFence = fence
+            if (!callbackFence || cancelled) return
+            void persistRouteSample(
+              context,
+              callbackFence,
+              {
+                capturedAt: new Date(position.timestamp).toISOString(),
+                latitude: position.coords.latitude,
+                longitude: position.coords.longitude,
+                accuracyM: position.coords.accuracy,
+                speedMps: Number.isFinite(position.coords.speed) ? position.coords.speed : null,
+                headingDeg: Number.isFinite(position.coords.heading) ? position.coords.heading : null,
+              },
+            ).then(async (record) => {
+              if (cancelled) return
+              if (!record) {
+                fence = null
+                await stopPageRecorder(false)
+                safeSetPhase('standby')
+                return
+              }
+              if (
+                !fence ||
+                fence.writerGeneration !== callbackFence.writerGeneration ||
+                fence.fenceToken !== callbackFence.fenceToken ||
+                watchId === null ||
+                document.visibilityState !== 'visible'
+              ) return
+              recovering = false
+              lastPersistedSampleAt = record.capturedAt
+              const nextStats = await refreshStats()
+              safeSetPhase(isPersistedSampleFresh(record.capturedAt) ? 'fresh' : 'stale')
+              if (nextStats.pendingCount >= 20) await flush()
+            }).catch(() => {
+              if (cancelled) return
+              recovering = false
+              failed = true
+              setMessage('Не удалось сохранить GPS в памяти устройства. Запись остановлена без потери уже сохранённых точек.')
+              void stopPageRecorder(true).then(updateDerivedPhase)
+            })
+          },
+          (error) => {
+            if (cancelled) return
+            recovering = false
+            blocked = error.code === error.PERMISSION_DENIED
+            failed = !blocked
+            setMessage(blocked
+              ? 'Доступ к геолокации запрещён. Разрешите его в настройках браузера.'
+              : `GPS остановился: ${error.message || 'неизвестная ошибка'}`)
+            void stopPageRecorder(true).then(updateDerivedPhase)
+          },
+          { enableHighAccuracy: true, maximumAge: 0, timeout: 15_000 },
+        )
+        recovering = false
+        updateDerivedPhase()
+        void flush()
+      } finally {
+        starting = false
+      }
+    }
+
+    const handleVisibility = () => {
+      if (document.visibilityState !== 'visible') {
+        void stopPageRecorder(true).then(updateDerivedPhase)
+      } else {
+        void startPageRecorder()
+        void flush()
+      }
+    }
+    const handleResume = () => {
+      if (document.visibilityState === 'visible') {
+        void startPageRecorder()
+        void flush()
+      }
+    }
+    document.addEventListener('visibilitychange', handleVisibility)
+    window.addEventListener('online', handleResume)
+    window.addEventListener('focus', handleResume)
+    window.addEventListener('pageshow', handleResume)
+
+    const leaseTimer = window.setInterval(() => {
+      if (!fence && document.visibilityState === 'visible') {
+        void startPageRecorder()
+        return
+      }
+      if (!fence) return
+      const current = fence
+      void renewWriterLease(current).then((renewed) => {
+        if (cancelled) return
+        if (!renewed) {
+          fence = null
+          void stopPageRecorder(false).then(() => safeSetPhase('standby'))
+        } else {
+          fence = renewed
+        }
+      })
+    }, WRITER_LEASE_RENEW_MS)
+    const freshnessTimer = window.setInterval(updateDerivedPhase, 1_000)
+    const replayTimer = window.setInterval(() => void flush(), 5_000)
+    void startPageRecorder()
+
+    return () => {
+      cancelled = true
+      flushRef.current = () => undefined
+      document.removeEventListener('visibilitychange', handleVisibility)
+      window.removeEventListener('online', handleResume)
+      window.removeEventListener('focus', handleResume)
+      window.removeEventListener('pageshow', handleResume)
+      window.clearInterval(leaseTimer)
+      window.clearInterval(freshnessTimer)
+      window.clearInterval(replayTimer)
+      stopWatch()
+      const currentWake = wakeSentinel
+      const currentFence = fence
+      if (currentWake && !currentWake.released) void currentWake.release().catch(() => undefined)
+      if (currentFence) void releaseWriterLease(currentFence)
+    }
+  }, [contextKey, eligible, raid.state, recoverNonce, requestServerLease, tabId])
+
+  const recover = useCallback(() => {
+    if (!raid.navigatorLease) {
+      void requestServerLease('acquire')
+      return
+    }
+    if (phase === 'standby' && message?.includes('другое устройство')) {
+      void requestServerLease('recover')
+      return
+    }
+    setRecoverNonce((value) => value + 1)
+  }, [message, phase, raid.navigatorLease, requestServerLease])
+  const flush = useCallback(() => flushRef.current(), [])
+  return {
+    phase,
+    wakeLock,
+    pendingCount: stats.pendingCount,
+    preliminaryDistanceM: stats.preliminaryDistanceM,
+    lastPersistedSampleAt: stats.lastPersistedSampleAt,
+    routeStatus,
+    message,
+    recover,
+    flush,
+  }
+}

--- a/apps/pwa/src/features/raids/state.test.ts
+++ b/apps/pwa/src/features/raids/state.test.ts
@@ -21,6 +21,14 @@ const raid: RaidProjection = {
   navigatorReady: false,
   navigatorBlockers: [],
   navigatorWarnings: [],
+  routeStatus: {
+    status: 'awaiting_lease',
+    lastSampleAt: null,
+    lastReceivedAt: null,
+    acceptedSampleCount: 0,
+    missingSequenceCount: 0,
+  },
+  navigatorLease: null,
   participants: [],
   allowedActions: [],
 }

--- a/apps/pwa/src/features/raids/types.ts
+++ b/apps/pwa/src/features/raids/types.ts
@@ -24,6 +24,7 @@ export type RaidAllowedAction =
   | 'pause'
   | 'resume'
   | 'cancel'
+  | 'handoff-navigator'
   | 'accept'
   | 'decline'
   | 'ready'
@@ -44,6 +45,22 @@ export interface RaidReadinessSummary {
   raidVersion: number
 }
 
+export type RouteStatusCode = 'awaiting_lease' | 'fresh' | 'stale' | 'paused' | 'stopped'
+
+export interface RouteStatusProjection {
+  status: RouteStatusCode
+  lastSampleAt: string | null
+  lastReceivedAt: string | null
+  acceptedSampleCount: number
+  missingSequenceCount: number
+}
+
+export interface NavigatorLeaseProjection {
+  id: string
+  generation: number
+  issuedAt: string
+}
+
 export interface RaidProjection {
   id: string
   kabandaId: string
@@ -57,8 +74,51 @@ export interface RaidProjection {
   navigatorReady: boolean
   navigatorBlockers: string[]
   navigatorWarnings: string[]
+  routeStatus: RouteStatusProjection
+  navigatorLease: NavigatorLeaseProjection | null
   participants: RaidParticipant[]
   allowedActions: RaidAllowedAction[]
+}
+
+export interface RouteBatchSample {
+  operationId: string
+  sequence: number
+  capturedAt: string
+  latitude: number
+  longitude: number
+  accuracyM: number
+  speedMps?: number
+  headingDeg?: number
+}
+
+export interface RouteBatchInput {
+  schemaVersion: 1
+  leaseId: string
+  clientInstanceId: string
+  samples: RouteBatchSample[]
+}
+
+export interface RouteBatchResponse {
+  batchId: string
+  accepted: Array<{ operationId: string; acceptedAt: string }>
+  duplicates: Array<{ operationId: string }>
+  rejected: Array<{ operationId: string; code: string }>
+  routeStatus: RouteStatusProjection
+  serverAt: string
+}
+
+export interface RouteLeaseResponse {
+  receipt: {
+    operationId: string
+    command: 'acquire-route' | 'recover-route'
+    serverAt: string
+  }
+  raid: RaidProjection
+}
+
+export interface HandoffNavigatorInput {
+  expectedVersion: number
+  navigatorUserId: string
 }
 
 export interface CreateRaidInput {

--- a/docs/architecture/VP_ARCHITECTURE.md
+++ b/docs/architecture/VP_ARCHITECTURE.md
@@ -78,6 +78,78 @@ packages/domain    — чистые правила без React/Fastify/PostgreS
   преждевременные finalize/complete routes и не изображает готовый результат. Participant leave также
   добавляется вместе с правилами credit/cutoff в последующем полевом срезе, а не как безусловная кнопка.
 
+## Граница #35: активный рейд, recorder и offline replay
+
+Для закрытой альфы до 20 человек маршрут синхронизируется обычными same-origin HTTP-командами и
+видимым polling канонической проекции. WebSocket/SSE, Redis, отдельный broker и live-позиции участников
+не нужны. Page runtime записывает GPS; service worker может только ускорить replay той же application-owned
+очереди и никогда не владеет geolocation, raid state или navigator lease.
+
+### Server lease и fencing
+
+- На рейд существует не более одного активного server-issued route lease. Lease привязан к raid,
+  canonical navigator, identity, `clientInstanceId` и монотонной generation/epoch.
+- Потеря сети не завершает lease и не передаёт роль автоматически. Конкурирующий tab/device получает
+  deterministic conflict; takeover возможен только named recovery или handoff.
+- Pause, handoff и recover выполняются fail-closed: сервер под row lock фиксирует собственный cutover,
+  закрывает текущую generation и больше не принимает для неё batches. Client `capturedAt`, local clock и
+  поздно доставленный outbox не могут расширить lease interval назад или вперёд.
+- Resume никогда не переоткрывает старый lease. Даже тот же navigator получает новую generation через
+  acquire; старые operation IDs и local sequence остаются fenced в прежней generation.
+- Offline replay допустим только для того же actor и всё ещё активного lease той же generation. Если
+  другой клиент уже выполнил pause/handoff/recover, сервер возвращает bounded terminal rejection;
+  локальная операция остаётся диагностическим evidence/`needs_action`, но не становится canonical route.
+
+### HTTP и DTO contract
+
+- `GET /api/raids/:raidId` добавляет bounded `RaidRouteStatus`: generation, navigator, server ingestion
+  health, last accepted sample time/count и server-allowed actions; raw coordinates и `clientInstanceId`
+  не выдаются. Local recorder truth остаётся только в PWA runtime.
+- `POST /api/raids/:raidId/route/lease/acquire` принимает `RouteLeaseRequest` и возвращает
+  `RouteLeaseResponse`. Повтор того же operation возвращает immutable prior response.
+- `POST /api/raids/:raidId/route/lease/recover` использует те же DTO, явно fence-ит прежнюю generation
+  и создаёт новую только после server authorization.
+- `POST /api/raids/:raidId/route/batches` принимает bounded `RouteBatchInput` с `RouteSampleInput[]`
+  (не более 50 samples и 64 KiB) и возвращает immutable `RouteBatchReceipt`.
+- `POST /api/raids/:raidId/commands/handoff-navigator` принимает `HandoffNavigatorInput`, закрывает
+  прежний lease и меняет canonical navigator в одной транзакции. Новый navigator затем acquire-ит
+  собственную generation.
+- Все mutation requests используют `Idempotency-Key`; повтор с тем же fingerprint возвращает prior
+  receipt, а reuse ключа с другим payload получает conflict. Lease/batch writes не доверяют client totals.
+
+### Данные и local durability
+
+- PostgreSQL хранит `raid_route_leases`, `raid_route_batches` и `raid_route_samples`. Unique active-lease
+  constraint и `(lease_id, local_seq)` защищают one-recorder и no-duplicate invariants; координаты приватны.
+- Dexie хранит identity-bound `recorderSessions`, `routeSamples`, versioned outbox и короткий sender lock.
+  Sample сначала durable-записывается в IndexedDB и лишь затем может сделать recorder зелёным.
+- Local recorder имеет только runtime states
+  `idle | starting | recording | stale | paused | stopped | error`; это не второй raid lifecycle.
+  `recording` требует canonical navigator/active lease, живой `watchPosition`, granted permission,
+  свежий locally durable sample и отсутствие известного lifecycle/storage failure.
+- Без свежего durable sample дольше ADR-порога (предварительно 15 секунд) recorder становится `stale`.
+  Permission revoke, IndexedDB failure, incompatible schema и fenced lease не могут оставлять зелёный UI.
+- Replay запускается на startup, `pageshow`, foreground/visible, `online` и manual retry. Background Sync
+  остаётся optional acceleration. 401 приостанавливает очередь; account switch никогда не меняет actor.
+- Service-worker update показывается как deferred и не вызывает принудительный reload во время active
+  recorder или несовместимой pending queue.
+
+### Active shell и границы следующих delivery
+
+- Active shell показывает raid/navigator, честный recorder state, online/offline, locally saved/syncing count,
+  bounded route preview и не более одного primary action. Local time/distance помечаются `предварительно ·
+  на телефоне` и не смешиваются с canonical totals.
+- #35 не публикует background/lock-screen GPS promise. Supported navigator mode остаётся experimental до
+  физического решения #30/ADR-0001.
+- #36 добавляет check-in, canonical eligible/nearest point, media payloads/endpoints и настоящий point
+  progress. #35 только готовит versioned outbox boundary и не изображает эти операции выполненными.
+- #37 добавляет `finalizing/completed`, канонические distance/time, history и result card. #35 не считает
+  live provisional metrics финальным результатом.
+
+Code acceptance #35 покрывает mocked geolocation/lifecycle, PostgreSQL auth/idempotency/fencing, Dexie
+reload/replay, account isolation, service-worker update gate и mobile shell. Product/field acceptance остаётся
+открытым до отдельного 60–90-минутного physical smoke на реальных iPhone и Android по матрице #30.
+
 ## Локальная среда
 
 `infra/compose.yaml` поднимает PostGIS, S3-compatible MinIO и Mailpit. Приложения запускаются обычным pnpm workspace. Managed-провайдеры выбираются перед staging без изменения доменных контрактов.

--- a/docs/product/raid-lifecycle.md
+++ b/docs/product/raid-lifecycle.md
@@ -47,8 +47,32 @@ invited -> accepted -> ready -> active -> left
 - Для старта нужен свежий server-owned readiness report текущего навигатора и текущей версии lobby.
   Смена навигатора или версии делает старый report неприменимым; неподтверждённый background GPS не
   считается зелёной capability.
-- Handoff создаёт явную точку cutover. Старый lease больше не принимает route batches.
+- Каждый lease принадлежит одной монотонной generation. Canonical server time, а не client `capturedAt`,
+  определяет cutover и право batch на ingestion.
+- Handoff создаёт явную server-time точку cutover и fail-closed закрывает старую generation. Старый lease
+  больше не принимает route batches, даже если клиент пометил samples временем до handoff.
+- Recover — явный fenced takeover, а не автоматическое следствие timeout/offline. Он закрывает прежнюю
+  generation и требует новый acquire; прежний tab/device не может продолжить canonical upload.
 - Потеря связи не передаёт роль автоматически. PWA показывает stale GPS и предлагает pause или явный handoff.
+
+## Local recorder #35
+
+```text
+idle -> starting -> recording
+          |          +-> stale -> starting
+          |          +-> paused -> starting
+          |          +-> stopped
+          +----------+-> error
+```
+
+- Это runtime truth PWA, а не второй server raid lifecycle.
+- `recording` допустим только для canonical navigator с active lease той же generation, живым
+  `watchPosition`, granted permission и свежим sample, durable-записанным в identity-bound IndexedDB.
+- Временный marker, работающий timer или наличие `watchId` без свежего durable sample не являются
+  доказательством записи. После ADR-порога без sample состояние становится `stale`.
+- Permission revoke, page lifecycle warning, IndexedDB/quota failure, incompatible schema и lease fencing
+  переводят recorder из зелёного состояния до recovery.
+- Service worker не записывает GPS и не может переводить recorder в `recording`.
 
 ## Чекин
 
@@ -78,10 +102,20 @@ pending -> sending -> accepted
 - `accepted` означает серверный receipt, а не успешный fetch без разбора ответа.
 - Logout/account switch блокирует replay операций другой identity.
 - Background Sync ускоряет replay, но запуск приложения, возврат в foreground и событие online обязаны инициировать его независимо.
+- Route operation несёт lease ID и generation. Offline replay разрешён только пока на сервере активен тот
+  же lease того же actor; pause/handoff/recover fence-ят прежнюю очередь.
+- Fenced route operation не переписывается под новую generation. Она получает terminal rejection/
+  `needs_action` и сохраняется локально как диагностическое evidence до явной cleanup policy.
 
 ## Пауза, завершение и восстановление
 
 - Pause/finish требуют явного подтверждения и актуальной версии рейда.
+- Pause fail-closed фиксирует server-time cutover и закрывает активную route generation. Pending batches
+  старой generation после pause не становятся canonical задним числом.
+- Resume создаёт новую route generation через lease acquire, даже если navigator не изменился. Старый
+  sequence/idempotency namespace не переиспользуется.
+- Handoff/recover также закрывают прежнюю generation до выдачи новой; клиентское время не определяет
+  границу и не может обойти fencing.
 - Offline finish сохраняется как pending command. После reconnect сервер применяет или детерминированно отклоняет его по текущему состоянию.
 - `finalizing` ждёт bounded набор ранее созданных route/check-in/media операций и показывает, что итог ещё собирается.
 - После `completed` рейд не открывается заново. Исправления имеют отдельную audit lineage.
@@ -96,3 +130,5 @@ pending -> sending -> accepted
 5. Повторная доставка operation не создаёт повторный credit, media или distance.
 6. Данные до join и после leave не начисляются участнику.
 7. Private route/media никогда не попадают в общий app-shell cache.
+8. Pause, handoff и recover не доверяют client clock и необратимо fence-ят прежнюю route generation.
+9. Local sample становится `saved` только после IndexedDB commit, а canonical — только после server receipt.

--- a/docs/testing/pwa-device-matrix.md
+++ b/docs/testing/pwa-device-matrix.md
@@ -2,6 +2,18 @@
 
 Статус: pending physical devices. Автоматические браузерные тесты не закрывают эту матрицу.
 
+## Отдельно от code acceptance #35
+
+- Unit/integration/browser tests могут закрыть DTO, authorization, lease fencing, duplicate replay,
+  IndexedDB durability, truth-state transitions и service-worker update gate, но не доказывают пригодность
+  PWA для реальной 60–90-минутной поездки.
+- Field acceptance #35 остаётся открытым до завершения сценария `Screen-awake + Wake Lock` на обоих
+  обязательных устройствах, а также замеров lock/background gaps, battery и storage.
+- После code acceptance тот же 60–90-минутный маршрут повторяется в настоящем active-raid recorder #35:
+  Capability Lab даёт platform evidence, но один не закрывает end-to-end lease/outbox/replay acceptance.
+- Пока IOS-1 и AND-1 имеют статус `Pending`, нельзя заявлять поддержку background/lock-screen GPS.
+  Допустима только экспериментальная формулировка `standalone + screen awake + Wake Lock при наличии`.
+
 ## Подготовка
 
 1. Открыть HTTPS URL Capability Lab.
@@ -58,4 +70,3 @@
 - [ ] `NO-GO`
 
 Решение нельзя выбирать до приложенного evidence с обоих обязательных устройств.
-

--- a/infra/postgres/migrations/0005_route_tracking.sql
+++ b/infra/postgres/migrations/0005_route_tracking.sql
@@ -1,0 +1,91 @@
+CREATE TABLE raid_navigator_leases (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  raid_id uuid NOT NULL REFERENCES raids(id) ON DELETE CASCADE,
+  navigator_user_id uuid NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  client_instance_id uuid,
+  generation integer NOT NULL CHECK (generation > 0),
+  issued_at timestamptz NOT NULL DEFAULT now(),
+  claimed_at timestamptz,
+  heartbeat_expires_at timestamptz,
+  ended_at timestamptz,
+  ended_reason text CHECK (
+    ended_reason IS NULL OR ended_reason IN ('pause', 'cancel', 'handoff', 'recover')
+  ),
+  cutover_sequence bigint CHECK (cutover_sequence IS NULL OR cutover_sequence >= 0),
+  max_accepted_sequence bigint NOT NULL DEFAULT 0 CHECK (max_accepted_sequence >= 0),
+  accepted_sample_count integer NOT NULL DEFAULT 0 CHECK (accepted_sample_count >= 0),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (raid_id, id),
+  UNIQUE (raid_id, generation),
+  CHECK (
+    (client_instance_id IS NULL AND claimed_at IS NULL AND heartbeat_expires_at IS NULL)
+    OR
+    (client_instance_id IS NOT NULL AND claimed_at IS NOT NULL AND heartbeat_expires_at IS NOT NULL)
+  ),
+  CHECK (ended_at IS NULL OR ended_at >= issued_at)
+);
+
+CREATE UNIQUE INDEX raid_navigator_one_current_idx
+  ON raid_navigator_leases (raid_id) WHERE ended_at IS NULL;
+CREATE INDEX raid_navigator_lease_actor_idx
+  ON raid_navigator_leases (navigator_user_id, raid_id, generation DESC);
+
+CREATE TABLE raid_activity_windows (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  raid_id uuid NOT NULL REFERENCES raids(id) ON DELETE CASCADE,
+  opened_at timestamptz NOT NULL,
+  closed_at timestamptz,
+  opened_version integer NOT NULL CHECK (opened_version > 0),
+  closed_version integer CHECK (closed_version IS NULL OR closed_version >= opened_version),
+  CHECK (closed_at IS NULL OR closed_at >= opened_at)
+);
+
+CREATE UNIQUE INDEX raid_activity_one_open_idx
+  ON raid_activity_windows (raid_id) WHERE closed_at IS NULL;
+CREATE INDEX raid_activity_timeline_idx
+  ON raid_activity_windows (raid_id, opened_at, closed_at);
+
+CREATE TABLE raid_route_batch_receipts (
+  id uuid PRIMARY KEY,
+  actor_user_id uuid NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  operation_id text NOT NULL CHECK (char_length(operation_id) BETWEEN 8 AND 100),
+  raid_id uuid NOT NULL REFERENCES raids(id) ON DELETE RESTRICT,
+  lease_id uuid NOT NULL,
+  request_fingerprint char(64) NOT NULL,
+  response_json jsonb NOT NULL CHECK (octet_length(response_json::text) <= 65536),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (actor_user_id, operation_id),
+  FOREIGN KEY (raid_id, lease_id)
+    REFERENCES raid_navigator_leases(raid_id, id) ON DELETE RESTRICT
+);
+
+CREATE INDEX raid_route_batch_audit_idx
+  ON raid_route_batch_receipts (raid_id, created_at, id);
+
+CREATE TABLE raid_route_samples (
+  raid_id uuid NOT NULL REFERENCES raids(id) ON DELETE CASCADE,
+  lease_id uuid NOT NULL,
+  operation_id text NOT NULL CHECK (char_length(operation_id) BETWEEN 8 AND 100),
+  sequence bigint NOT NULL CHECK (sequence > 0),
+  captured_at timestamptz NOT NULL,
+  received_at timestamptz NOT NULL DEFAULT now(),
+  geom geography(Point, 4326) NOT NULL,
+  accuracy_m double precision NOT NULL CHECK (accuracy_m >= 0 AND accuracy_m <= 10000),
+  speed_mps double precision CHECK (speed_mps IS NULL OR speed_mps >= 0),
+  heading_deg double precision CHECK (
+    heading_deg IS NULL OR (heading_deg >= 0 AND heading_deg < 360)
+  ),
+  payload_hash char(64) NOT NULL,
+  PRIMARY KEY (lease_id, sequence),
+  UNIQUE (raid_id, operation_id),
+  FOREIGN KEY (raid_id, lease_id)
+    REFERENCES raid_navigator_leases(raid_id, id) ON DELETE RESTRICT,
+  CHECK (
+    ST_Y(geom::geometry) BETWEEN 56.7 AND 57.0
+    AND ST_X(geom::geometry) BETWEEN 53.0 AND 53.4
+  )
+);
+
+CREATE INDEX raid_route_samples_timeline_idx
+  ON raid_route_samples (raid_id, captured_at, lease_id, sequence);
+CREATE INDEX raid_route_samples_geom_idx ON raid_route_samples USING gist (geom);

--- a/packages/domain/src/index.test.ts
+++ b/packages/domain/src/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   getRaidAllowedActions,
+  getRouteStatusCode,
   isBoundedIzhevskQuery,
   isRaidStateTransitionAllowed,
   normalizeEmail,
@@ -44,6 +45,7 @@ describe('raid lifecycle', () => {
     expect(isRaidStateTransitionAllowed('lobby', 'start')).toBe(true)
     expect(isRaidStateTransitionAllowed('planned', 'open-lobby')).toBe(true)
     expect(isRaidStateTransitionAllowed('active', 'pause')).toBe(true)
+    expect(isRaidStateTransitionAllowed('active', 'handoff-navigator')).toBe(true)
     expect(isRaidStateTransitionAllowed('paused', 'resume')).toBe(true)
     expect(isRaidStateTransitionAllowed('completed', 'cancel')).toBe(false)
     expect(isRaidStateTransitionAllowed('cancelled', 'open-lobby')).toBe(false)
@@ -74,5 +76,32 @@ describe('raid lifecycle', () => {
         navigatorReady: true,
       }),
     ).toContain('start')
+  })
+
+  it('fails route health closed across lease and pause boundaries', () => {
+    expect(
+      getRouteStatusCode({
+        raidState: 'active',
+        leaseClaimed: true,
+        leaseHeartbeatFresh: true,
+        sampleAgeSeconds: 10,
+      }),
+    ).toBe('fresh')
+    expect(
+      getRouteStatusCode({
+        raidState: 'active',
+        leaseClaimed: false,
+        leaseHeartbeatFresh: false,
+        sampleAgeSeconds: null,
+      }),
+    ).toBe('awaiting_lease')
+    expect(
+      getRouteStatusCode({
+        raidState: 'paused',
+        leaseClaimed: true,
+        leaseHeartbeatFresh: true,
+        sampleAgeSeconds: 1,
+      }),
+    ).toBe('paused')
   })
 })

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -71,6 +71,7 @@ export type RaidAction =
   | 'decline'
   | 'ready'
   | 'assign-navigator'
+  | 'handoff-navigator'
   | 'start'
   | 'pause'
   | 'resume'
@@ -88,6 +89,8 @@ export function isRaidStateTransitionAllowed(state: RaidState, action: RaidActio
       return state === 'lobby'
     case 'pause':
       return state === 'active'
+    case 'handoff-navigator':
+      return state === 'active' || state === 'paused'
     case 'resume':
       return state === 'paused'
     case 'cancel':
@@ -110,6 +113,9 @@ export function getRaidAllowedActions(input: {
     }
     if (input.state === 'active') actions.push('pause')
     if (input.state === 'paused') actions.push('resume')
+    if (input.state === 'active' || input.state === 'paused') {
+      actions.push('handoff-navigator')
+    }
     if (isRaidStateTransitionAllowed(input.state, 'cancel')) actions.push('cancel')
   }
   if (input.state === 'lobby' && input.participantState === 'invited') {
@@ -119,4 +125,19 @@ export function getRaidAllowedActions(input: {
     actions.push('ready')
   }
   return actions
+}
+
+export type RouteStatusCode = 'awaiting_lease' | 'fresh' | 'stale' | 'paused' | 'stopped'
+
+export function getRouteStatusCode(input: {
+  raidState: RaidState
+  leaseClaimed: boolean
+  leaseHeartbeatFresh: boolean
+  sampleAgeSeconds: number | null
+}): RouteStatusCode {
+  if (input.raidState === 'paused') return 'paused'
+  if (input.raidState !== 'active') return 'stopped'
+  if (!input.leaseClaimed) return 'awaiting_lease'
+  if (!input.leaseHeartbeatFresh) return 'stale'
+  return input.sampleAgeSeconds !== null && input.sampleAgeSeconds <= 15 ? 'fresh' : 'stale'
 }


### PR DESCRIPTION
Tracks #35

Stacked on #43 / codex/vp-5-raid-lobby.

Implements the lean VP route recorder:
- one server-issued navigator lease with fail-closed pause, recover and handoff cutovers;
- bounded PostGIS route batches with immutable coordinate-free receipts;
- identity-bound Dexie outbox, exact lost-response replay and fenced multi-tab writer;
- production watchPosition, honest Wake Lock and 15-second durable freshness;
- mobile active shell, deferred service-worker updates and organizer handoff UI.

Local evidence:
- pnpm check passed: domain 10, API 16, PWA 57 tests; builds passed;
- pnpm audit --prod: no known vulnerabilities;
- mobile 390x844 GPS smoke: fresh after durable sample, pending 0, one primary CTA, no overflow/errors;
- lost-response/reload smoke: pending 1 to 0 with the same batch key and sample set;
- handoff smoke: active target + expectedVersion, old recorder became ineligible.

PostGIS 17-scenario suite is delegated to GitHub CI because Docker is unavailable locally. Physical iPhone/Android 60-90 minute and lock/background/battery/storage evidence remains open under #30; no background-GPS claim.

No merge or deploy in this PR.