### PR TITLE
[VP 8/9] Завершить рейд и сохранить результат

### DIFF
--- a/apps/api/src/raid-routes.ts
+++ b/apps/api/src/raid-routes.ts
@@ -2,8 +2,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import { z } from 'zod'
 import type { AuthService } from './auth.js'
 import type { ApiConfig } from './config.js'
-import type { RaidAction } from '@kabanda/domain'
-import type { RaidCommandInput, RaidService } from './raids.js'
+import type { RaidCommandAction, RaidCommandInput, RaidService } from './raids.js'
 
 type RouteDependencies = {
   auth: AuthService
@@ -19,6 +18,26 @@ const createRaidSchema = z.object({
   scheduledAt: z.iso.datetime({ offset: true }).nullable().optional(),
 })
 const commandSchema = z.object({ expectedVersion: z.coerce.number().int().positive() })
+const finishSchema = commandSchema
+  .extend({
+    inventory: z.object({
+      routePending: z.coerce.number().int().min(0).max(10_000),
+      checkInsPending: z.coerce.number().int().min(0).max(10_000),
+      mediaPending: z.coerce.number().int().min(0).max(10_000),
+      needsAction: z.coerce.number().int().min(0).max(10_000),
+    }),
+    confirmPartial: z.boolean(),
+  })
+  .superRefine((value, context) => {
+    const pending =
+      value.inventory.routePending +
+      value.inventory.checkInsPending +
+      value.inventory.mediaPending +
+      value.inventory.needsAction
+    if (pending > 0 && !value.confirmPartial) {
+      context.addIssue({ code: 'custom', message: 'Partial finish must be confirmed' })
+    }
+  })
 const assignNavigatorSchema = commandSchema.extend({ navigatorUserId: z.uuid() })
 const navigatorLeaseSchema = commandSchema.extend({ clientInstanceId: z.uuid() })
 const readinessSchema = commandSchema.extend({
@@ -90,6 +109,10 @@ const mediaListSchema = z.object({
   limit: z.coerce.number().int().min(1).max(50).default(24),
   cursor: z.string().trim().max(200).optional(),
 })
+const historySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+  cursor: z.string().trim().max(240).optional(),
+})
 
 function authRequired(reply: FastifyReply) {
   return reply.status(401).send({
@@ -110,7 +133,7 @@ async function execute(
   request: FastifyRequest,
   reply: FastifyReply,
   dependencies: RouteDependencies,
-  action: RaidAction,
+  action: RaidCommandAction,
   input: RaidCommandInput,
 ) {
   const user = await currentUser(request, dependencies)
@@ -155,11 +178,53 @@ export async function registerRaidRoutes(
     return { raids: await dependencies.raids.listActionable(user.id, kabandaId) }
   })
 
+  app.get('/api/kabandas/:kabandaId/raids/history', async (request, reply) => {
+    const user = await currentUser(request, dependencies)
+    if (!user) return authRequired(reply)
+    const kabandaId = resourceIdSchema.parse(
+      (request.params as { kabandaId: string }).kabandaId,
+    )
+    const query = historySchema.parse(request.query)
+    return reply
+      .header('Cache-Control', 'private, no-store')
+      .send(await dependencies.raids.listHistory(user.id, kabandaId, query.limit, query.cursor))
+  })
+
+  app.get('/api/kabandas/:kabandaId/progress', async (request, reply) => {
+    const user = await currentUser(request, dependencies)
+    if (!user) return authRequired(reply)
+    const kabandaId = resourceIdSchema.parse(
+      (request.params as { kabandaId: string }).kabandaId,
+    )
+    return reply
+      .header('Cache-Control', 'private, no-store')
+      .send(await dependencies.raids.getProgress(user.id, kabandaId))
+  })
+
   app.get('/api/raids/:raidId', async (request, reply) => {
     const user = await currentUser(request, dependencies)
     if (!user) return authRequired(reply)
     const raidId = resourceIdSchema.parse((request.params as { raidId: string }).raidId)
     return { raid: await dependencies.raids.getRaid(user.id, raidId) }
+  })
+
+  app.get('/api/raids/:raidId/result', async (request, reply) => {
+    const user = await currentUser(request, dependencies)
+    if (!user) return authRequired(reply)
+    const raidId = resourceIdSchema.parse((request.params as { raidId: string }).raidId)
+    return reply
+      .header('Cache-Control', 'private, no-store')
+      .send({ result: await dependencies.raids.getResult(user.id, raidId) })
+  })
+
+  app.get('/api/raids/:raidId/share-card', async (request, reply) => {
+    const user = await currentUser(request, dependencies)
+    if (!user) return authRequired(reply)
+    const raidId = resourceIdSchema.parse((request.params as { raidId: string }).raidId)
+    return reply
+      .header('Cache-Control', 'private, no-store')
+      .type('image/png')
+      .send(await dependencies.raids.getShareCard(user.id, raidId))
   })
 
   app.get('/api/raids/:raidId/check-ins/nearby', async (request, reply) => {
@@ -387,6 +452,41 @@ export async function registerRaidRoutes(
   app.post('/api/raids/:raidId/commands/resume', async (request, reply) =>
     execute(request, reply, dependencies, 'resume', commandSchema.parse(request.body)),
   )
+  app.post('/api/raids/:raidId/commands/finish', async (request, reply) => {
+    const user = await currentUser(request, dependencies)
+    if (!user) return authRequired(reply)
+    const raidId = resourceIdSchema.parse((request.params as { raidId: string }).raidId)
+    return dependencies.raids.finishRaid(
+      user.id,
+      raidId,
+      finishSchema.parse(request.body),
+      operationId(request),
+    )
+  })
+  app.post('/api/raids/:raidId/finalization/settle', async (request, reply) => {
+    const user = await currentUser(request, dependencies)
+    if (!user) return authRequired(reply)
+    const raidId = resourceIdSchema.parse((request.params as { raidId: string }).raidId)
+    const input = commandSchema.parse(request.body)
+    return dependencies.raids.settleFinalization(
+      user.id,
+      raidId,
+      input.expectedVersion,
+      operationId(request),
+    )
+  })
+  app.post('/api/raids/:raidId/participants/me/leave', async (request, reply) => {
+    const user = await currentUser(request, dependencies)
+    if (!user) return authRequired(reply)
+    const raidId = resourceIdSchema.parse((request.params as { raidId: string }).raidId)
+    const input = commandSchema.parse(request.body)
+    return dependencies.raids.leaveRaid(
+      user.id,
+      raidId,
+      input.expectedVersion,
+      operationId(request),
+    )
+  })
   app.post('/api/raids/:raidId/commands/cancel', async (request, reply) =>
     execute(request, reply, dependencies, 'cancel', commandSchema.parse(request.body)),
   )

--- a/apps/api/src/raids.ts
+++ b/apps/api/src/raids.ts
@@ -33,6 +33,40 @@ export function deriveMediaUploadCapability(
     .digest('base64url')
 }
 
+export function escapeShareCardXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;')
+}
+
+export async function renderRaidShareCard(result: RaidResult): Promise<Buffer> {
+  const title = escapeShareCardXml(result.raid.title.slice(0, 120))
+  const date = escapeShareCardXml(result.raid.completedAt.slice(0, 10))
+  const distanceKm = (result.team.distanceMeters / 1000).toFixed(1)
+  const durationMinutes = Math.round(result.team.durationSeconds / 60)
+  const svg = Buffer.from(`<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630">
+    <rect width="1200" height="630" fill="#1a1410"/>
+    <rect x="42" y="42" width="1116" height="546" rx="34" fill="#f4e9d4"/>
+    <text x="92" y="126" font-family="DejaVu Sans, sans-serif" font-size="46" font-weight="700" fill="#3b2c22">KABANDA</text>
+    <text x="92" y="202" font-family="DejaVu Sans, sans-serif" font-size="42" font-weight="700" fill="#245d3b">${title}</text>
+    <text x="92" y="254" font-family="DejaVu Sans, sans-serif" font-size="25" fill="#795c3f">${date}</text>
+    <text x="92" y="366" font-family="DejaVu Sans, sans-serif" font-size="26" fill="#795c3f">DISTANCE</text>
+    <text x="92" y="428" font-family="DejaVu Sans, sans-serif" font-size="48" font-weight="700" fill="#245d3b">${distanceKm} km</text>
+    <text x="390" y="366" font-family="DejaVu Sans, sans-serif" font-size="26" fill="#795c3f">TIME</text>
+    <text x="390" y="428" font-family="DejaVu Sans, sans-serif" font-size="48" font-weight="700" fill="#245d3b">${durationMinutes} min</text>
+    <text x="680" y="366" font-family="DejaVu Sans, sans-serif" font-size="26" fill="#795c3f">POINTS</text>
+    <text x="680" y="428" font-family="DejaVu Sans, sans-serif" font-size="48" font-weight="700" fill="#245d3b">${result.team.uniquePoints}</text>
+    <text x="940" y="366" font-family="DejaVu Sans, sans-serif" font-size="26" fill="#795c3f">TEAM</text>
+    <text x="940" y="428" font-family="DejaVu Sans, sans-serif" font-size="48" font-weight="700" fill="#245d3b">${result.participants.length}</text>
+  </svg>`)
+  return sharp(svg, { density: 144 })
+    .png({ compressionLevel: 9, adaptiveFiltering: false })
+    .toBuffer()
+}
+
 export type CreateRaidInput = {
   title: string
   description?: string | null | undefined
@@ -55,6 +89,11 @@ export type RaidCommandInput = {
   expectedVersion: number
   navigatorUserId?: string
 }
+
+export type RaidCommandAction = Exclude<
+  RaidAction,
+  'finish' | 'leave' | 'settle-finalization'
+>
 
 export type NavigatorLeaseInput = {
   expectedVersion: number
@@ -102,6 +141,55 @@ export type RaidParticipantProjection = {
   state: RaidParticipantState
 }
 
+export type RaidPendingCounts = { claims: number; fallbacks: number; media: number }
+export type RaidFinalizationProjection = {
+  status: 'collecting'
+  partial: boolean
+  pendingCounts: RaidPendingCounts
+  deadlineAt: string
+  canSettle: boolean
+}
+
+export type RaidMetrics = {
+  durationSeconds: number
+  distanceMeters: number
+  uniquePoints: number
+  photos: number
+}
+
+export type RaidResult = {
+  schemaVersion: 1
+  raid: {
+    id: string
+    kabandaId: string
+    title: string
+    startedAt: string
+    completedAt: string
+    partial: boolean
+  }
+  team: RaidMetrics
+  personal: RaidMetrics
+  participants: Array<{ userId: string; displayName: string; metrics: RaidMetrics }>
+}
+
+export type FinishRaidInput = {
+  expectedVersion: number
+  inventory: {
+    routePending: number
+    checkInsPending: number
+    mediaPending: number
+    needsAction: number
+  }
+  confirmPartial: boolean
+}
+
+export type FinishRaidResponse = {
+  raid: RaidProjection
+  finalization: RaidFinalizationProjection
+}
+
+export type SettleRaidResponse = { raid: RaidProjection; result: RaidResult }
+
 export type RaidProjection = {
   id: string
   kabandaId: string
@@ -115,6 +203,7 @@ export type RaidProjection = {
   navigatorReady: boolean
   navigatorBlockers: string[]
   navigatorWarnings: string[]
+  finalization: RaidFinalizationProjection | null
   routeStatus: RouteStatusProjection
   navigatorLease: NavigatorLeaseProjection | null
   participants: RaidParticipantProjection[]
@@ -199,6 +288,16 @@ export type FallbackProjection = {
   reason: string
   expiresAt: string
 }
+
+export function resolveExpiringStatus(
+  status: string,
+  pendingStatus: 'pending' | 'pending_verifier',
+  expired: boolean,
+): string {
+  return status === 'expired_finalization' || (status === pendingStatus && expired)
+    ? 'expired'
+    : status
+}
 export type MediaProjection = {
   id: string
   uploaderUserId: string
@@ -220,6 +319,44 @@ export type MediaIntentInput = {
   attemptId?: string | undefined
 }
 
+export type ProcessedMedia = {
+  data: Buffer
+  info: { width: number; height: number; size: number }
+}
+
+export type MediaProcessor = (
+  bytes: Buffer,
+  declaredContentType: MediaIntentInput['contentType'],
+) => Promise<ProcessedMedia>
+
+const processMedia: MediaProcessor = async (bytes, declaredContentType) => {
+  const image = sharp(bytes, { failOn: 'error', limitInputPixels: 12_000_000 })
+  const metadata = await image.metadata()
+  if (
+    !metadata.width ||
+    !metadata.height ||
+    metadata.width > 8_000 ||
+    metadata.height > 8_000 ||
+    metadata.width * metadata.height > 12_000_000 ||
+    !['jpeg', 'png', 'webp'].includes(metadata.format ?? '') ||
+    (({ jpeg: 'image/jpeg', png: 'image/png', webp: 'image/webp' } as Record<
+      string,
+      string
+    >)[metadata.format ?? ''] !== declaredContentType)
+  ) {
+    throw new RaidError('MEDIA_INVALID', 400, 'Неподдерживаемое изображение')
+  }
+  const processed = await image
+    .rotate()
+    .resize({ width: 2_048, height: 2_048, fit: 'inside', withoutEnlargement: true })
+    .jpeg({ quality: 82, mozjpeg: true })
+    .toBuffer({ resolveWithObject: true })
+  if (processed.data.length > 3 * 1024 * 1024) {
+    throw new RaidError('MEDIA_OUTPUT_TOO_LARGE', 400, 'Фотография слишком большая')
+  }
+  return processed
+}
+
 type RaidRow = {
   id: string
   kabanda_id: string
@@ -228,6 +365,11 @@ type RaidRow = {
   title: string
   description: string | null
   scheduled_at: Date | null
+  started_at: Date | null
+  finalizing_at: Date | null
+  finalization_deadline_at: Date | null
+  finalization_partial: boolean
+  server_now: Date
   state: RaidState
   version: number
   membership_role: 'owner' | 'member'
@@ -292,7 +434,7 @@ export interface RaidService {
   command(
     actorUserId: string,
     raidId: string,
-    action: RaidAction,
+    action: RaidCommandAction,
     input: RaidCommandInput,
     operationId: string,
   ): Promise<RaidCommandResponse>
@@ -335,12 +477,20 @@ export interface RaidService {
   listMedia(actorUserId: string, raidId: string, limit: number, cursor?: string): Promise<{ media: MediaProjection[]; nextCursor: string | null }>
   readMedia(actorUserId: string, raidId: string, mediaId: string): Promise<{ bytes: Buffer; contentType: 'image/jpeg' }>
   tombstoneMedia(actorUserId: string, raidId: string, mediaId: string, operationId: string): Promise<{ deleted: true }>
+  finishRaid(actorUserId: string, raidId: string, input: FinishRaidInput, operationId: string): Promise<{ raid: RaidProjection; finalization: RaidFinalizationProjection }>
+  settleFinalization(actorUserId: string, raidId: string, expectedVersion: number, operationId: string): Promise<{ raid: RaidProjection; result: RaidResult }>
+  leaveRaid(actorUserId: string, raidId: string, expectedVersion: number, operationId: string): Promise<{ raid: RaidProjection }>
+  getResult(actorUserId: string, raidId: string): Promise<RaidResult>
+  listHistory(actorUserId: string, kabandaId: string, limit: number, cursor?: string): Promise<{ raids: Array<{ raidId: string; title: string; completedAt: string; partial: boolean; team: RaidMetrics; personal: RaidMetrics }>; nextCursor: string | null }>
+  getProgress(actorUserId: string, kabandaId: string): Promise<{ progress: { team: RaidMetrics & { completedRaids: number }; personal: RaidMetrics & { completedRaids: number } } }>
+  getShareCard(actorUserId: string, raidId: string): Promise<Buffer>
 }
 
 export class DatabaseRaidService implements RaidService {
   constructor(
     private readonly pool: Pool,
     private readonly mediaCapabilitySecret: string,
+    private readonly mediaProcessor: MediaProcessor = processMedia,
   ) {}
 
   async createDraft(
@@ -412,7 +562,7 @@ export class DatabaseRaidService implements RaidService {
   async command(
     actorUserId: string,
     raidId: string,
-    action: RaidAction,
+    action: RaidCommandAction,
     input: RaidCommandInput,
     operationId: string,
   ): Promise<RaidCommandResponse> {
@@ -952,12 +1102,12 @@ export class DatabaseRaidService implements RaidService {
     const client = await this.pool.connect()
     try {
       const raid = await this.lockRaid(client, actorUserId, raidId)
-      this.requireActiveParticipant(raid)
+      this.requireFinalizationCommitParticipant(raid)
       const rows = await client.query(
-        `SELECT id, attempt_id, user_id, status, expires_at
+        `SELECT id, attempt_id, user_id, status, expires_at, false AS expired
          FROM raid_checkin_claims
          WHERE raid_id = $1 AND user_id = $2 AND status = 'pending'
-           AND expires_at > now()
+           AND expires_at > clock_timestamp()
          ORDER BY created_at, id LIMIT 20`,
         [raid.id, actorUserId],
       )
@@ -980,31 +1130,36 @@ export class DatabaseRaidService implements RaidService {
       const replay = await this.replayFeature<{ claim: ClaimProjection; credit?: CreditProjection }>(client, actorUserId, operationId, requestFingerprint)
       if (replay) return replay
       const raid = await this.lockRaid(client, actorUserId, raidId)
-      this.requireActiveParticipant(raid)
+      this.requireFinalizationCommitParticipant(raid)
       const result = await client.query<{
         id: string
         attempt_id: string
         user_id: string
         status: string
         expires_at: Date
+        available: boolean
         point_snapshot_id: string
       }>(
         `SELECT c.id, c.attempt_id, c.user_id, c.status, c.expires_at,
-           a.point_snapshot_id
+           c.expires_at > clock_timestamp() AS available, a.point_snapshot_id
          FROM raid_checkin_claims c JOIN raid_checkin_attempts a ON a.id = c.attempt_id
          WHERE c.id = $1 AND c.raid_id = $2 FOR UPDATE OF c`,
         [claimId, raid.id],
       )
       const row = result.rows[0]
       if (!row || row.user_id !== actorUserId) throw this.notFound()
-      if (row.status !== 'pending' || row.expires_at.getTime() <= Date.now()) {
+      if (row.status !== 'pending' || !row.available) {
         throw new RaidError('CLAIM_UNAVAILABLE', 409, 'Подтверждение уже недоступно')
       }
       await client.query(
         `UPDATE raid_checkin_claims SET status = $2, responded_at = now() WHERE id = $1`,
         [row.id, decision === 'confirm' ? 'confirmed' : 'declined'],
       )
-      const claim = this.claimProjection({ ...row, status: decision === 'confirm' ? 'confirmed' : 'declined' })
+      const claim = this.claimProjection({
+        ...row,
+        expired: !row.available,
+        status: decision === 'confirm' ? 'confirmed' : 'declined',
+      })
       const response: { claim: ClaimProjection; credit?: CreditProjection } = { claim }
       if (decision === 'confirm') {
         const credit = (await this.insertCredits(client, raid.id, row.point_snapshot_id, row.attempt_id, [actorUserId], 'claim'))[0]
@@ -1060,6 +1215,7 @@ export class DatabaseRaidService implements RaidService {
         status: string
         reason: string
         expires_at: Date
+        expired: boolean
       }>
       try {
         inserted = await client.query(
@@ -1067,7 +1223,8 @@ export class DatabaseRaidService implements RaidService {
             (raid_id, attempt_id, media_id, requester_user_id, verifier_user_id,
              present_participant_ids, reason)
            VALUES ($1, $2, $3, $4, $5, $6::uuid[], $7)
-           RETURNING id, attempt_id, media_id, verifier_user_id, status, reason, expires_at`,
+           RETURNING id, attempt_id, media_id, verifier_user_id, status, reason, expires_at,
+             expires_at <= clock_timestamp() AS expired`,
           [
             raid.id,
             input.attemptId,
@@ -1104,12 +1261,13 @@ export class DatabaseRaidService implements RaidService {
     const client = await this.pool.connect()
     try {
       const raid = await this.lockRaid(client, actorUserId, raidId)
-      this.requireActiveParticipant(raid)
+      this.requireFinalizationCommitParticipant(raid)
       const rows = await client.query(
-        `SELECT id, attempt_id, media_id, verifier_user_id, status, reason, expires_at
+        `SELECT id, attempt_id, media_id, verifier_user_id, status, reason, expires_at,
+           false AS expired
          FROM raid_checkin_fallbacks
          WHERE raid_id = $1 AND verifier_user_id = $2 AND status = 'pending_verifier'
-           AND expires_at > now()
+           AND expires_at > clock_timestamp()
          ORDER BY created_at, id LIMIT 20`,
         [raid.id, actorUserId],
       )
@@ -1132,7 +1290,7 @@ export class DatabaseRaidService implements RaidService {
       const replay = await this.replayFeature<{ fallback: FallbackProjection; credits?: CreditProjection[] }>(client, actorUserId, operationId, requestFingerprint)
       if (replay) return replay
       const raid = await this.lockRaid(client, actorUserId, raidId)
-      this.requireActiveParticipant(raid)
+      this.requireFinalizationCommitParticipant(raid)
       const result = await client.query<{
         id: string
         attempt_id: string
@@ -1143,18 +1301,20 @@ export class DatabaseRaidService implements RaidService {
         status: string
         reason: string
         expires_at: Date
+        available: boolean
         point_snapshot_id: string
       }>(
         `SELECT f.id, f.attempt_id, f.media_id, f.requester_user_id,
            f.verifier_user_id, f.present_participant_ids, f.status, f.reason,
-           f.expires_at, a.point_snapshot_id
+           f.expires_at, f.expires_at > clock_timestamp() AS available,
+           a.point_snapshot_id
          FROM raid_checkin_fallbacks f JOIN raid_checkin_attempts a ON a.id = f.attempt_id
          WHERE f.id = $1 AND f.raid_id = $2 FOR UPDATE OF f`,
         [fallbackId, raid.id],
       )
       const row = result.rows[0]
       if (!row || row.verifier_user_id !== actorUserId) throw this.notFound()
-      if (row.status !== 'pending_verifier' || row.expires_at.getTime() <= Date.now()) {
+      if (row.status !== 'pending_verifier' || !row.available) {
         throw new RaidError('FALLBACK_UNAVAILABLE', 409, 'Проверка уже недоступна')
       }
       if (decision === 'confirm') {
@@ -1178,7 +1338,11 @@ export class DatabaseRaidService implements RaidService {
         [row.id, decision === 'confirm' ? 'confirmed' : 'declined'],
       )
       const response: { fallback: FallbackProjection; credits?: CreditProjection[] } = {
-        fallback: this.fallbackProjection({ ...row, status: decision === 'confirm' ? 'confirmed' : 'declined' }),
+        fallback: this.fallbackProjection({
+          ...row,
+          expired: !row.available,
+          status: decision === 'confirm' ? 'confirmed' : 'declined',
+        }),
       }
       if (decision === 'confirm') {
         const creditedIds = [row.requester_user_id, ...row.present_participant_ids]
@@ -1232,8 +1396,9 @@ export class DatabaseRaidService implements RaidService {
         `SELECT count(*) FROM raid_media
          WHERE raid_id = $1 AND (
            state = 'ready'
-           OR (state = 'pending_upload' AND upload_expires_at > now())
-           OR (state = 'processing' AND processing_started_at > now() - interval '2 minutes')
+           OR (state = 'pending_upload' AND upload_expires_at > clock_timestamp())
+           OR (state = 'processing'
+             AND processing_started_at > clock_timestamp() - interval '2 minutes')
          )`,
         [raid.id],
       )
@@ -1303,7 +1468,7 @@ export class DatabaseRaidService implements RaidService {
     }
     const claim = await transaction(this.pool, async (client) => {
       const raid = await this.lockRaid(client, actorUserId, raidId)
-      this.requireActiveParticipant(raid)
+      this.requireFinalizationCommitParticipant(raid)
       const result = await client.query<{
         id: string
         uploader_user_id: string
@@ -1312,11 +1477,16 @@ export class DatabaseRaidService implements RaidService {
         declared_content_type: string
         upload_capability_hash: string
         upload_expires_at: Date
+        upload_available: boolean
         state: string
         processing_started_at: Date | null
+        processing_fresh: boolean
       }>(
         `SELECT id, uploader_user_id, source_sha256, declared_size_bytes, declared_content_type,
-           upload_capability_hash, upload_expires_at, state, processing_started_at
+           upload_capability_hash, upload_expires_at,
+           upload_expires_at > clock_timestamp() AS upload_available,
+           state, processing_started_at,
+           processing_started_at > clock_timestamp() - interval '2 minutes' AS processing_fresh
          FROM raid_media WHERE id = $1 AND raid_id = $2 FOR UPDATE`,
         [intentId, raid.id],
       )
@@ -1328,77 +1498,101 @@ export class DatabaseRaidService implements RaidService {
       }
       if (media.state === 'ready') return { ready: true as const }
       if (media.state === 'tombstoned') throw this.notFound()
-      if (media.state === 'pending_upload' && media.upload_expires_at.getTime() <= Date.now()) {
+      if (media.state === 'pending_upload' && !media.upload_available) {
         throw new RaidError('MEDIA_INTENT_EXPIRED', 409, 'Загрузка просрочена')
       }
       if (
         media.state === 'processing' &&
-        media.processing_started_at &&
-        media.processing_started_at.getTime() > Date.now() - 120_000
+        media.processing_fresh
       ) {
         throw new RaidError('MEDIA_PROCESSING', 409, 'Фотография уже обрабатывается')
       }
-      await client.query(
-        `UPDATE raid_media SET state = 'processing', processing_started_at = now()
-         WHERE id = $1`,
-        [media.id],
+      const processingToken = randomUUID()
+      const claimed = await client.query(
+        `UPDATE raid_media SET state = 'processing', processing_started_at = clock_timestamp(),
+           processing_token = $2
+         WHERE id = $1 AND (
+           state = 'pending_upload' OR
+           (state = 'processing' AND processing_started_at <= clock_timestamp() - interval '2 minutes')
+         )
+         RETURNING id`,
+        [media.id, processingToken],
       )
-      return { ready: false as const, declaredContentType: media.declared_content_type }
+      if (!claimed.rowCount) {
+        throw new RaidError(
+          'MEDIA_PROCESSING_SUPERSEDED',
+          409,
+          'Обработку фотографии уже продолжил другой запрос',
+        )
+      }
+      return {
+        ready: false as const,
+        declaredContentType: media.declared_content_type as MediaIntentInput['contentType'],
+        processingToken,
+      }
     })
     if (claim.ready) return { media: await this.mediaProjectionById(actorUserId, raidId, intentId) }
 
-    let processed: { data: Buffer; info: { width: number; height: number; size: number } }
+    let processed: ProcessedMedia
     try {
-      const image = sharp(bytes, { failOn: 'error', limitInputPixels: 12_000_000 })
-      const metadata = await image.metadata()
-      if (
-        !metadata.width ||
-        !metadata.height ||
-        metadata.width > 8_000 ||
-        metadata.height > 8_000 ||
-        metadata.width * metadata.height > 12_000_000 ||
-        !['jpeg', 'png', 'webp'].includes(metadata.format ?? '') ||
-        (({ jpeg: 'image/jpeg', png: 'image/png', webp: 'image/webp' } as Record<
-          string,
-          string
-        >)[metadata.format ?? ''] !== claim.declaredContentType)
-      ) {
-        throw new RaidError('MEDIA_INVALID', 400, 'Неподдерживаемое изображение')
-      }
-      processed = await image
-        .rotate()
-        .resize({ width: 2_048, height: 2_048, fit: 'inside', withoutEnlargement: true })
-        .jpeg({ quality: 82, mozjpeg: true })
-        .toBuffer({ resolveWithObject: true })
-      if (processed.data.length > 3 * 1024 * 1024) {
-        throw new RaidError('MEDIA_OUTPUT_TOO_LARGE', 400, 'Фотография слишком большая')
-      }
+      processed = await this.mediaProcessor(bytes, claim.declaredContentType)
     } catch (error) {
-      await this.pool.query(
-        `UPDATE raid_media SET state = 'pending_upload', processing_started_at = NULL
-         WHERE id = $1 AND state = 'processing'`,
-        [intentId],
-      )
+      try {
+        await transaction(this.pool, async (client) => {
+          const raid = await this.lockRaid(client, actorUserId, raidId)
+          const ownership = await client.query<{ owns_processing: boolean }>(
+            `SELECT state = 'processing' AND processing_token = $3::uuid AS owns_processing
+             FROM raid_media WHERE id = $1 AND raid_id = $2 FOR UPDATE`,
+            [intentId, raidId, claim.processingToken],
+          )
+          if (!ownership.rows[0]?.owns_processing) {
+            throw new RaidError(
+              'MEDIA_PROCESSING_SUPERSEDED',
+              409,
+              'Обработку фотографии уже продолжил другой запрос',
+            )
+          }
+          const commitWindowOpen =
+            raid.participant_state === 'active' &&
+            (raid.state === 'active' ||
+              (raid.state === 'finalizing' &&
+                Boolean(
+                  raid.finalization_deadline_at &&
+                    raid.finalization_deadline_at.getTime() > raid.server_now.getTime(),
+                )))
+          if (commitWindowOpen) {
+            await client.query(
+              `UPDATE raid_media SET state = 'pending_upload', processing_started_at = NULL,
+                 processing_token = NULL
+               WHERE id = $1 AND raid_id = $2 AND state = 'processing'
+                 AND processing_token = $3::uuid`,
+              [intentId, raidId, claim.processingToken],
+            )
+          }
+        })
+      } catch (resetError) {
+        if (
+          resetError instanceof RaidError &&
+          resetError.code === 'MEDIA_PROCESSING_SUPERSEDED'
+        ) {
+          throw resetError
+        }
+        if (!(resetError instanceof RaidError)) throw resetError
+      }
       if (error instanceof RaidError) throw error
       throw new RaidError('MEDIA_INVALID', 400, 'Не удалось прочитать изображение')
     }
     await transaction(this.pool, async (client) => {
       const raid = await this.lockRaid(client, actorUserId, raidId)
-      this.requireActiveParticipant(raid)
-      const row = await client.query<{ state: string }>(
-        'SELECT state FROM raid_media WHERE id = $1 AND raid_id = $2 FOR UPDATE',
-        [intentId, raidId],
-      )
-      if (!row.rows[0]) throw this.notFound()
-      if (row.rows[0].state === 'ready') return
-      if (row.rows[0].state !== 'processing') {
-        throw new RaidError('MEDIA_STATE_CONFLICT', 409, 'Состояние загрузки изменилось')
-      }
-      await client.query(
+      this.requireFinalizationCommitParticipant(raid)
+      const committed = await client.query(
         `UPDATE raid_media SET state = 'ready', content_bytes = $2,
            content_type = 'image/jpeg', size_bytes = $3, width = $4, height = $5,
-           content_sha256 = $6, ready_at = now(), processing_started_at = NULL
-         WHERE id = $1`,
+           content_sha256 = $6, ready_at = clock_timestamp(), processing_started_at = NULL,
+           processing_token = NULL
+         WHERE id = $1 AND raid_id = $7 AND state = 'processing'
+           AND processing_token = $8::uuid
+         RETURNING id`,
         [
           intentId,
           processed.data,
@@ -1406,8 +1600,17 @@ export class DatabaseRaidService implements RaidService {
           processed.info.width,
           processed.info.height,
           createHash('sha256').update(processed.data).digest('hex'),
+          raidId,
+          claim.processingToken,
         ],
       )
+      if (!committed.rowCount) {
+        throw new RaidError(
+          'MEDIA_PROCESSING_SUPERSEDED',
+          409,
+          'Обработку фотографии уже продолжил другой запрос',
+        )
+      }
     })
     return { media: await this.mediaProjectionById(actorUserId, raidId, intentId) }
   }
@@ -1509,6 +1712,13 @@ export class DatabaseRaidService implements RaidService {
       if (row.uploader_user_id !== actorUserId && raid.membership_role !== 'owner') {
         throw this.notFound()
       }
+      if (
+        raid.state === 'finalizing' &&
+        (!raid.finalization_deadline_at ||
+          raid.finalization_deadline_at.getTime() <= raid.server_now.getTime())
+      ) {
+        throw new RaidError('FINALIZATION_CLOSED', 409, 'Окно завершения уже закрыто')
+      }
       const fallbackEvidence = await client.query(
         `SELECT 1 FROM raid_checkin_fallbacks
          WHERE media_id = $1 AND status <> 'declined' LIMIT 1`,
@@ -1532,10 +1742,377 @@ export class DatabaseRaidService implements RaidService {
     })
   }
 
+  async finishRaid(
+    actorUserId: string,
+    raidId: string,
+    input: FinishRaidInput,
+    operationId: string,
+  ): Promise<FinishRaidResponse> {
+    const requestFingerprint = fingerprint('finish', raidId, input)
+    return transaction(this.pool, async (client) => {
+      await this.lockOperation(client, actorUserId, operationId)
+      const replay = await this.replay<FinishRaidResponse>(
+        client,
+        actorUserId,
+        operationId,
+        requestFingerprint,
+      )
+      if (replay) return replay
+      const raid = await this.lockRaid(client, actorUserId, raidId)
+      this.requireOrganizer(raid, actorUserId)
+      this.requireVersion(raid, input.expectedVersion)
+      if (raid.state !== 'active' && raid.state !== 'paused') {
+        throw this.invalidTransition(raid)
+      }
+      const inventoryTotal =
+        input.inventory.routePending +
+        input.inventory.checkInsPending +
+        input.inventory.mediaPending +
+        input.inventory.needsAction
+      const partial = inventoryTotal > 0
+      if (partial && !input.confirmPartial) {
+        throw new RaidError(
+          'FINALIZATION_PARTIAL_CONFIRMATION_REQUIRED',
+          409,
+          'Подтверди завершение с несинхронизированными данными',
+        )
+      }
+      const nextVersion = raid.version + 1
+      await this.closeActivityWindow(client, raid.id, nextVersion)
+      await this.closeCurrentLease(client, raid.id, 'finish')
+      const finalized = await client.query<{ finalizing_at: Date; finalization_deadline_at: Date }>(
+        `UPDATE raids SET state = 'finalizing', version = $2,
+           finalizing_at = clock_timestamp(),
+           finalization_deadline_at = clock_timestamp() + interval '2 minutes',
+           finalization_partial = $3, finalization_inventory = $4,
+           updated_at = clock_timestamp()
+         WHERE id = $1 RETURNING finalizing_at, finalization_deadline_at`,
+        [raid.id, nextVersion, partial, input.inventory],
+      )
+      const timing = finalized.rows[0]!
+      await client.query(
+        `INSERT INTO raid_route_finalization_cutoffs
+          (raid_id, lease_id, generation, max_sequence, cutoff_at)
+         SELECT raid_id, id, generation, max_accepted_sequence, $2
+         FROM raid_navigator_leases WHERE raid_id = $1`,
+        [raid.id, timing.finalizing_at],
+      )
+      const response: FinishRaidResponse = {
+        raid: await this.project(client, actorUserId, raid.id),
+        finalization: await this.finalizationProjection(client, raid.id),
+      }
+      await this.storeReceipt(client, {
+        actorUserId,
+        operationId,
+        raidId: raid.id,
+        command: 'finish',
+        requestFingerprint,
+        expectedVersion: input.expectedVersion,
+        fromState: raid.state,
+        mutatesState: true,
+        response,
+      })
+      return response
+    })
+  }
+
+  async settleFinalization(
+    actorUserId: string,
+    raidId: string,
+    expectedVersion: number,
+    operationId: string,
+  ): Promise<SettleRaidResponse> {
+    const input = { expectedVersion }
+    const requestFingerprint = fingerprint('settle-finalization', raidId, input)
+    return transaction(this.pool, async (client) => {
+      await this.lockOperation(client, actorUserId, operationId)
+      const replay = await this.replay<SettleRaidResponse>(
+        client,
+        actorUserId,
+        operationId,
+        requestFingerprint,
+      )
+      if (replay) return replay
+      const raid = await this.lockRaid(client, actorUserId, raidId)
+      this.requireOrganizer(raid, actorUserId)
+      this.requireVersion(raid, expectedVersion)
+      if (raid.state !== 'finalizing' || !raid.finalization_deadline_at || !raid.finalizing_at) {
+        throw this.invalidTransition(raid)
+      }
+      const pending = await this.pendingCounts(client, raid.id)
+      const beforeDeadline = raid.finalization_deadline_at.getTime() > raid.server_now.getTime()
+      if (beforeDeadline && pending.claims + pending.fallbacks + pending.media > 0) {
+        throw new RaidError('FINALIZATION_PENDING', 409, 'Ещё принимаются подтверждения', {
+          pendingCounts: pending,
+          deadlineAt: raid.finalization_deadline_at.toISOString(),
+        })
+      }
+      const terminalizedTail = await this.expireFinalizationTail(client, raid.id)
+      if (terminalizedTail > 0 && !raid.finalization_partial) {
+        await client.query('UPDATE raids SET finalization_partial = true WHERE id = $1', [raid.id])
+        raid.finalization_partial = true
+      }
+      const completedAt = (
+        await client.query<{ completed_at: Date }>('SELECT clock_timestamp() AS completed_at')
+      ).rows[0]!.completed_at
+      const result = await this.buildImmutableResult(client, raid, completedAt, actorUserId)
+      const sharePng = await renderRaidShareCard(result)
+      await this.storeImmutableResult(client, result, sharePng)
+      await client.query(
+        `UPDATE raids SET state = 'completed', version = $2, completed_at = $3,
+           updated_at = $3 WHERE id = $1`,
+        [raid.id, raid.version + 1, completedAt],
+      )
+      const response: SettleRaidResponse = {
+        raid: await this.project(client, actorUserId, raid.id),
+        result,
+      }
+      await this.storeReceipt(client, {
+        actorUserId,
+        operationId,
+        raidId: raid.id,
+        command: 'settle-finalization',
+        requestFingerprint,
+        expectedVersion,
+        fromState: raid.state,
+        mutatesState: true,
+        response,
+      })
+      return response
+    })
+  }
+
+  async leaveRaid(
+    actorUserId: string,
+    raidId: string,
+    expectedVersion: number,
+    operationId: string,
+  ): Promise<{ raid: RaidProjection }> {
+    const input = { expectedVersion }
+    const requestFingerprint = fingerprint('leave', raidId, input)
+    return transaction(this.pool, async (client) => {
+      await this.lockOperation(client, actorUserId, operationId)
+      const replay = await this.replay<{ raid: RaidProjection }>(
+        client,
+        actorUserId,
+        operationId,
+        requestFingerprint,
+      )
+      if (replay) return replay
+      const raid = await this.lockRaid(client, actorUserId, raidId)
+      this.requireVersion(raid, expectedVersion)
+      if (
+        raid.membership_role === 'owner' ||
+        raid.participant_state !== 'active' ||
+        (raid.state !== 'active' && raid.state !== 'paused')
+      ) {
+        throw this.forbiddenCommand()
+      }
+      if (raid.navigator_user_id === actorUserId) {
+        throw new RaidError('NAVIGATOR_MUST_HANDOFF', 409, 'Сначала передай роль навигатора')
+      }
+      await client.query(
+        `UPDATE raid_participants SET state = 'left', left_at = now(), updated_at = now()
+         WHERE raid_id = $1 AND user_id = $2`,
+        [raid.id, actorUserId],
+      )
+      await client.query('UPDATE raids SET version = $2, updated_at = now() WHERE id = $1', [
+        raid.id,
+        raid.version + 1,
+      ])
+      const response = { raid: await this.project(client, actorUserId, raid.id) }
+      await this.storeReceipt(client, {
+        actorUserId,
+        operationId,
+        raidId: raid.id,
+        command: 'leave',
+        requestFingerprint,
+        expectedVersion,
+        fromState: raid.state,
+        mutatesState: true,
+        response,
+      })
+      return response
+    })
+  }
+
+  async getResult(actorUserId: string, raidId: string): Promise<RaidResult> {
+    const result = await this.pool.query<{
+      result_json: RaidResult
+      duration_seconds: number | null
+      distance_meters: number | null
+      unique_points: number | null
+      photos: number | null
+    }>(
+      `SELECT rr.result_json, rp.duration_seconds, rp.distance_meters,
+         rp.unique_points, rp.photos
+       FROM raid_results rr
+       JOIN kabanda_memberships m
+         ON m.kabanda_id = rr.kabanda_id AND m.user_id = $2 AND m.removed_at IS NULL
+       LEFT JOIN raid_result_participants rp
+         ON rp.raid_id = rr.raid_id AND rp.user_id = $2
+       WHERE rr.raid_id = $1`,
+      [raidId, actorUserId],
+    )
+    const row = result.rows[0]
+    if (!row) throw this.notFound()
+    return {
+      ...row.result_json,
+      personal: this.metrics(row),
+    }
+  }
+
+  async listHistory(
+    actorUserId: string,
+    kabandaId: string,
+    limit: number,
+    cursor?: string,
+  ): Promise<{
+    raids: Array<{
+      raidId: string
+      title: string
+      completedAt: string
+      partial: boolean
+      team: RaidMetrics
+      personal: RaidMetrics
+    }>
+    nextCursor: string | null
+  }> {
+    await this.requireKabandaMembership(actorUserId, kabandaId)
+    const parsedCursor = this.historyCursor(cursor)
+    const result = await this.pool.query<{
+      raid_id: string
+      title: string
+      completed_at: Date
+      partial: boolean
+      team_duration_seconds: number
+      team_distance_meters: number
+      team_unique_points: number
+      team_photos: number
+      duration_seconds: number | null
+      distance_meters: number | null
+      unique_points: number | null
+      photos: number | null
+    }>(
+      `SELECT rr.raid_id, r.title, rr.completed_at, rr.partial,
+         rr.team_duration_seconds, rr.team_distance_meters,
+         rr.team_unique_points, rr.team_photos,
+         rp.duration_seconds, rp.distance_meters, rp.unique_points, rp.photos
+       FROM raid_results rr JOIN raids r ON r.id = rr.raid_id
+       LEFT JOIN raid_result_participants rp
+         ON rp.raid_id = rr.raid_id AND rp.user_id = $2
+       WHERE rr.kabanda_id = $1
+         AND ($3::timestamptz IS NULL OR (rr.completed_at, rr.raid_id) < ($3, $4::uuid))
+       ORDER BY rr.completed_at DESC, rr.raid_id DESC LIMIT $5`,
+      [kabandaId, actorUserId, parsedCursor?.completedAt ?? null, parsedCursor?.raidId ?? null, limit + 1],
+    )
+    const rows = result.rows.slice(0, limit)
+    return {
+      raids: rows.map((row) => ({
+        raidId: row.raid_id,
+        title: row.title,
+        completedAt: row.completed_at.toISOString(),
+        partial: row.partial,
+        team: {
+          durationSeconds: Number(row.team_duration_seconds),
+          distanceMeters: this.roundDistance(row.team_distance_meters),
+          uniquePoints: Number(row.team_unique_points),
+          photos: Number(row.team_photos),
+        },
+        personal: this.metrics(row),
+      })),
+      nextCursor:
+        result.rows.length > limit && rows.length
+          ? Buffer.from(
+              JSON.stringify({
+                completedAt: rows[rows.length - 1]!.completed_at.toISOString(),
+                raidId: rows[rows.length - 1]!.raid_id,
+              }),
+            ).toString('base64url')
+          : null,
+    }
+  }
+
+  async getProgress(
+    actorUserId: string,
+    kabandaId: string,
+  ): Promise<{
+    progress: {
+      team: RaidMetrics & { completedRaids: number }
+      personal: RaidMetrics & { completedRaids: number }
+    }
+  }> {
+    await this.requireKabandaMembership(actorUserId, kabandaId)
+    const result = await this.pool.query<{
+      completed_raids: string
+      team_duration_seconds: string
+      team_distance_meters: number
+      team_photos: string
+      team_unique_points: string
+      personal_completed_raids: string
+      personal_duration_seconds: string
+      personal_distance_meters: number
+      personal_photos: string
+      personal_unique_points: string
+    }>(
+      `SELECT
+         count(DISTINCT rr.raid_id)::text AS completed_raids,
+         coalesce(sum(rr.team_duration_seconds), 0)::text AS team_duration_seconds,
+         coalesce(sum(rr.team_distance_meters), 0) AS team_distance_meters,
+         coalesce(sum(rr.team_photos), 0)::text AS team_photos,
+         (SELECT count(DISTINCT rtp.source_point_id)::text FROM raid_result_points rtp
+          JOIN raid_results tr ON tr.raid_id = rtp.raid_id WHERE tr.kabanda_id = $1)
+           AS team_unique_points,
+         count(rp.raid_id)::text AS personal_completed_raids,
+         coalesce(sum(rp.duration_seconds), 0)::text AS personal_duration_seconds,
+         coalesce(sum(rp.distance_meters), 0) AS personal_distance_meters,
+         coalesce(sum(rp.photos), 0)::text AS personal_photos,
+         (SELECT count(DISTINCT rpp.source_point_id)::text FROM raid_result_points rpp
+          JOIN raid_results pr ON pr.raid_id = rpp.raid_id
+          WHERE pr.kabanda_id = $1 AND rpp.user_id = $2) AS personal_unique_points
+       FROM raid_results rr
+       LEFT JOIN raid_result_participants rp
+         ON rp.raid_id = rr.raid_id AND rp.user_id = $2
+       WHERE rr.kabanda_id = $1`,
+      [kabandaId, actorUserId],
+    )
+    const row = result.rows[0]!
+    return {
+      progress: {
+        team: {
+          completedRaids: Number(row.completed_raids),
+          durationSeconds: Number(row.team_duration_seconds),
+          distanceMeters: this.roundDistance(row.team_distance_meters),
+          uniquePoints: Number(row.team_unique_points),
+          photos: Number(row.team_photos),
+        },
+        personal: {
+          completedRaids: Number(row.personal_completed_raids),
+          durationSeconds: Number(row.personal_duration_seconds),
+          distanceMeters: this.roundDistance(row.personal_distance_meters),
+          uniquePoints: Number(row.personal_unique_points),
+          photos: Number(row.personal_photos),
+        },
+      },
+    }
+  }
+
+  async getShareCard(actorUserId: string, raidId: string): Promise<Buffer> {
+    const result = await this.pool.query<{ share_png: Buffer }>(
+      `SELECT rr.share_png FROM raid_results rr
+       JOIN kabanda_memberships m
+         ON m.kabanda_id = rr.kabanda_id AND m.user_id = $2 AND m.removed_at IS NULL
+       WHERE rr.raid_id = $1`,
+      [raidId, actorUserId],
+    )
+    if (!result.rows[0]) throw this.notFound()
+    return result.rows[0].share_png
+  }
+
   async getRaid(actorUserId: string, raidId: string): Promise<RaidProjection> {
     const client = await this.pool.connect()
     try {
-      await this.visibleRaid(client, actorUserId, raidId)
+      await this.visibleRaidProjection(client, actorUserId, raidId)
       return this.project(client, actorUserId, raidId)
     } finally {
       client.release()
@@ -1591,7 +2168,7 @@ export class DatabaseRaidService implements RaidService {
     client: PoolClient,
     actorUserId: string,
     raid: RaidRow,
-    action: RaidAction,
+    action: RaidCommandAction,
     input: RaidCommandInput,
     nextVersion: number,
   ): Promise<void> {
@@ -1865,10 +2442,10 @@ export class DatabaseRaidService implements RaidService {
   private async closeCurrentLease(
     client: PoolClient,
     raidId: string,
-    reason: 'pause' | 'cancel' | 'handoff' | 'recover',
+    reason: 'pause' | 'cancel' | 'handoff' | 'recover' | 'finish',
   ): Promise<void> {
     await client.query(
-      `UPDATE raid_navigator_leases SET ended_at = now(), ended_reason = $2,
+      `UPDATE raid_navigator_leases SET ended_at = clock_timestamp(), ended_reason = $2,
          cutover_sequence = max_accepted_sequence
        WHERE raid_id = $1 AND ended_at IS NULL`,
       [raidId, reason],
@@ -1893,7 +2470,7 @@ export class DatabaseRaidService implements RaidService {
     closedVersion: number,
   ): Promise<void> {
     await client.query(
-      `UPDATE raid_activity_windows SET closed_at = now(), closed_version = $2
+      `UPDATE raid_activity_windows SET closed_at = clock_timestamp(), closed_version = $2
        WHERE raid_id = $1 AND closed_at IS NULL`,
       [raidId, closedVersion],
     )
@@ -1976,10 +2553,361 @@ export class DatabaseRaidService implements RaidService {
       : null
   }
 
+  private async pendingCounts(client: PoolClient, raidId: string): Promise<RaidPendingCounts> {
+    const result = await client.query<{
+      claims: string
+      fallbacks: string
+      media: string
+    }>(
+      `SELECT
+         (SELECT count(*)::text FROM raid_checkin_claims
+          WHERE raid_id = $1 AND status = 'pending' AND expires_at > clock_timestamp()) AS claims,
+         (SELECT count(*)::text FROM raid_checkin_fallbacks
+          WHERE raid_id = $1 AND status = 'pending_verifier'
+            AND expires_at > clock_timestamp()) AS fallbacks,
+         (SELECT count(*)::text FROM raid_media WHERE raid_id = $1 AND (
+            state = 'processing' OR
+            (state = 'pending_upload' AND upload_expires_at > clock_timestamp())
+          )) AS media`,
+      [raidId],
+    )
+    const row = result.rows[0]!
+    return {
+      claims: Number(row.claims),
+      fallbacks: Number(row.fallbacks),
+      media: Number(row.media),
+    }
+  }
+
+  private async finalizationProjection(
+    client: PoolClient,
+    raidId: string,
+  ): Promise<RaidFinalizationProjection> {
+    const result = await client.query<{
+      finalization_deadline_at: Date
+      finalization_partial: boolean
+      deadline_elapsed: boolean
+    }>(
+      `SELECT finalization_deadline_at, finalization_partial,
+         finalization_deadline_at <= clock_timestamp() AS deadline_elapsed FROM raids
+       WHERE id = $1 AND state = 'finalizing'`,
+      [raidId],
+    )
+    const row = result.rows[0]
+    if (!row?.finalization_deadline_at) throw new Error('Finalizing raid has no deadline')
+    const pendingCounts = await this.pendingCounts(client, raidId)
+    return {
+      status: 'collecting',
+      partial: row.finalization_partial,
+      pendingCounts,
+      deadlineAt: row.finalization_deadline_at.toISOString(),
+      canSettle:
+        row.deadline_elapsed ||
+        pendingCounts.claims + pendingCounts.fallbacks + pendingCounts.media === 0,
+    }
+  }
+
+  private async expireFinalizationTail(client: PoolClient, raidId: string): Promise<number> {
+    const claims = await client.query(
+      `UPDATE raid_checkin_claims SET status = 'expired_finalization', responded_at = now()
+       WHERE raid_id = $1 AND status = 'pending'`,
+      [raidId],
+    )
+    const fallbacks = await client.query(
+      `UPDATE raid_checkin_fallbacks SET status = 'expired_finalization', responded_at = now()
+       WHERE raid_id = $1 AND status = 'pending_verifier'`,
+      [raidId],
+    )
+    const media = await client.query(
+      `UPDATE raid_media SET state = 'expired_finalization', content_bytes = NULL,
+         processing_started_at = NULL, processing_token = NULL
+       WHERE raid_id = $1 AND state IN ('pending_upload', 'processing')`,
+      [raidId],
+    )
+    return (claims.rowCount ?? 0) + (fallbacks.rowCount ?? 0) + (media.rowCount ?? 0)
+  }
+
+  private async buildImmutableResult(
+    client: PoolClient,
+    raid: RaidRow,
+    completedAt: Date,
+    actorUserId: string,
+  ): Promise<RaidResult> {
+    if (!raid.started_at || !raid.finalizing_at) throw new Error('Raid timing is incomplete')
+    const teamResult = await client.query<{
+      duration_seconds: number
+      distance_meters: number
+      unique_points: number
+      photos: number
+    }>(
+      `WITH ordered AS (
+         SELECT s.lease_id, s.sequence, s.captured_at, s.received_at, s.geom, s.accuracy_m,
+           lag(s.sequence) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_sequence,
+           lag(s.captured_at) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_at,
+           lag(s.received_at) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_received_at,
+           lag(s.geom) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_geom,
+           lag(s.accuracy_m) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_accuracy
+         FROM raid_route_samples s
+         JOIN raid_route_finalization_cutoffs c
+           ON c.raid_id = s.raid_id AND c.lease_id = s.lease_id
+            AND s.sequence <= c.max_sequence
+         WHERE s.raid_id = $1
+       ), segments AS (
+         SELECT *, ST_Distance(geom, previous_geom) AS meters,
+           extract(epoch FROM (captured_at - previous_at)) AS seconds
+         FROM ordered WHERE previous_geom IS NOT NULL
+       )
+       SELECT
+         (SELECT floor(coalesce(sum(extract(epoch FROM (closed_at - opened_at))), 0))
+          FROM raid_activity_windows WHERE raid_id = $1) AS duration_seconds,
+         (SELECT coalesce(sum(meters), 0) FROM segments
+          WHERE accuracy_m <= 50 AND previous_accuracy <= 50
+            AND sequence = previous_sequence + 1
+            AND seconds > 0 AND seconds <= 120 AND meters <= 2000
+            AND meters / seconds <= 50
+            AND EXISTS (SELECT 1 FROM raid_activity_windows w
+              WHERE w.raid_id = $1 AND previous_received_at >= w.opened_at
+                AND received_at <= w.closed_at)) AS distance_meters,
+         (SELECT count(DISTINCT point_snapshot_id) FROM raid_point_credits
+          WHERE raid_id = $1) AS unique_points,
+         (SELECT count(*) FROM raid_media
+          WHERE raid_id = $1 AND state = 'ready' AND ready_at <= $2) AS photos`,
+      [raid.id, completedAt],
+    )
+    const participantResult = await client.query<{
+      user_id: string
+      display_name: string
+      duration_seconds: number
+      distance_meters: number
+      unique_points: number
+      photos: number
+    }>(
+      `WITH ordered AS (
+         SELECT s.lease_id, s.sequence, s.captured_at, s.received_at, s.geom, s.accuracy_m,
+           lag(s.sequence) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_sequence,
+           lag(s.captured_at) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_at,
+           lag(s.received_at) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_received_at,
+           lag(s.geom) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_geom,
+           lag(s.accuracy_m) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_accuracy
+         FROM raid_route_samples s
+         JOIN raid_route_finalization_cutoffs c
+           ON c.raid_id = s.raid_id AND c.lease_id = s.lease_id
+            AND s.sequence <= c.max_sequence
+         WHERE s.raid_id = $1
+       ), segments AS (
+         SELECT *, ST_Distance(geom, previous_geom) AS meters,
+           extract(epoch FROM (captured_at - previous_at)) AS seconds
+         FROM ordered WHERE previous_geom IS NOT NULL
+       ), valid_segments AS (
+         SELECT * FROM segments WHERE accuracy_m <= 50 AND previous_accuracy <= 50
+           AND sequence = previous_sequence + 1
+           AND seconds > 0 AND seconds <= 120 AND meters <= 2000
+           AND meters / seconds <= 50
+           AND EXISTS (SELECT 1 FROM raid_activity_windows w
+             WHERE w.raid_id = $1 AND previous_received_at >= w.opened_at
+               AND received_at <= w.closed_at)
+       )
+       SELECT p.user_id,
+         coalesce(u.display_name, split_part(u.email::text, '@', 1)) AS display_name,
+         (SELECT floor(coalesce(sum(greatest(0, extract(epoch FROM (
+            least(w.closed_at, coalesce(p.left_at, $2), coalesce(km.removed_at, $2)) -
+            greatest(w.opened_at, p.active_from, km.joined_at)
+          )))), 0)) FROM raid_activity_windows w
+          WHERE w.raid_id = p.raid_id AND w.closed_at > greatest(p.active_from, km.joined_at)
+            AND w.opened_at < least(coalesce(p.left_at, $2), coalesce(km.removed_at, $2)))
+          AS duration_seconds,
+         (SELECT coalesce(sum(s.meters), 0) FROM valid_segments s
+          WHERE s.previous_received_at >= greatest(p.active_from, km.joined_at)
+            AND s.received_at <= least(coalesce(p.left_at, $2), coalesce(km.removed_at, $2)))
+          AS distance_meters,
+         (SELECT count(DISTINCT c.point_snapshot_id) FROM raid_point_credits c
+          WHERE c.raid_id = p.raid_id AND c.user_id = p.user_id
+            AND c.created_at BETWEEN greatest(p.active_from, km.joined_at)
+              AND least(coalesce(p.left_at, $2), coalesce(km.removed_at, $2))) AS unique_points,
+         (SELECT count(*) FROM raid_media m WHERE m.raid_id = p.raid_id
+          AND m.uploader_user_id = p.user_id AND m.state = 'ready'
+          AND m.ready_at BETWEEN greatest(p.active_from, km.joined_at)
+            AND least(coalesce(p.left_at, $2), coalesce(km.removed_at, $2))) AS photos
+       FROM raid_participants p
+       JOIN raids r ON r.id = p.raid_id
+       JOIN kabanda_memberships km
+         ON km.kabanda_id = r.kabanda_id AND km.user_id = p.user_id
+       JOIN users u ON u.id = p.user_id
+       WHERE p.raid_id = $1 AND p.active_from IS NOT NULL
+       ORDER BY p.active_from, p.user_id`,
+      [raid.id, completedAt],
+    )
+    const team = this.metrics(teamResult.rows[0]!)
+    const participants = participantResult.rows.map((row) => ({
+      userId: row.user_id,
+      displayName: row.display_name,
+      metrics: this.metrics(row),
+    }))
+    const personal = participants.find((participant) => participant.userId === actorUserId)?.metrics ?? {
+      durationSeconds: 0,
+      distanceMeters: 0,
+      uniquePoints: 0,
+      photos: 0,
+    }
+    return {
+      schemaVersion: 1,
+      raid: {
+        id: raid.id,
+        kabandaId: raid.kabanda_id,
+        title: raid.title,
+        startedAt: raid.started_at.toISOString(),
+        completedAt: completedAt.toISOString(),
+        partial: raid.finalization_partial,
+      },
+      team,
+      personal,
+      participants,
+    }
+  }
+
+  private async storeImmutableResult(
+    client: PoolClient,
+    result: RaidResult,
+    sharePng: Buffer,
+  ): Promise<void> {
+    await client.query(
+      `INSERT INTO raid_results
+        (raid_id, kabanda_id, schema_version, partial, started_at, completed_at,
+         team_duration_seconds, team_distance_meters, team_unique_points, team_photos,
+         result_json, share_png, share_sha256)
+       VALUES ($1, $2, 1, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+      [
+        result.raid.id,
+        result.raid.kabandaId,
+        result.raid.partial,
+        result.raid.startedAt,
+        result.raid.completedAt,
+        result.team.durationSeconds,
+        result.team.distanceMeters,
+        result.team.uniquePoints,
+        result.team.photos,
+        result,
+        sharePng,
+        createHash('sha256').update(sharePng).digest('hex'),
+      ],
+    )
+    for (const participant of result.participants) {
+      await client.query(
+        `INSERT INTO raid_result_participants
+          (raid_id, user_id, display_name, duration_seconds, distance_meters,
+           unique_points, photos)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        [
+          result.raid.id,
+          participant.userId,
+          participant.displayName,
+          participant.metrics.durationSeconds,
+          participant.metrics.distanceMeters,
+          participant.metrics.uniquePoints,
+          participant.metrics.photos,
+        ],
+      )
+    }
+    await client.query(
+      `INSERT INTO raid_result_points (raid_id, user_id, source_point_id)
+       SELECT DISTINCT c.raid_id, c.user_id, s.source_point_id
+       FROM raid_point_credits c
+       JOIN raid_point_snapshots s ON s.id = c.point_snapshot_id
+       JOIN raid_participants p ON p.raid_id = c.raid_id AND p.user_id = c.user_id
+       JOIN raids r ON r.id = c.raid_id
+       JOIN kabanda_memberships km
+         ON km.kabanda_id = r.kabanda_id AND km.user_id = c.user_id
+       WHERE c.raid_id = $1 AND p.active_from IS NOT NULL
+         AND c.created_at BETWEEN greatest(p.active_from, km.joined_at)
+           AND least(coalesce(p.left_at, $2), coalesce(km.removed_at, $2))`,
+      [result.raid.id, result.raid.completedAt],
+    )
+  }
+
+  private metrics(row: {
+    duration_seconds?: number | string | null
+    distance_meters?: number | string | null
+    unique_points?: number | string | null
+    photos?: number | string | null
+  }): RaidMetrics {
+    return {
+      durationSeconds: Number(row.duration_seconds ?? 0),
+      distanceMeters: this.roundDistance(Number(row.distance_meters ?? 0)),
+      uniquePoints: Number(row.unique_points ?? 0),
+      photos: Number(row.photos ?? 0),
+    }
+  }
+
+  private roundDistance(value: number): number {
+    return Math.round(Number(value) * 10) / 10
+  }
+
+  private async requireKabandaMembership(actorUserId: string, kabandaId: string): Promise<void> {
+    const result = await this.pool.query(
+      `SELECT 1 FROM kabanda_memberships m JOIN kabandas k ON k.id = m.kabanda_id
+       WHERE m.kabanda_id = $1 AND m.user_id = $2 AND m.removed_at IS NULL
+         AND k.archived_at IS NULL`,
+      [kabandaId, actorUserId],
+    )
+    if (!result.rowCount) throw this.notFound()
+  }
+
+  private historyCursor(cursor?: string): { completedAt: string; raidId: string } | null {
+    if (!cursor) return null
+    try {
+      const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as {
+        completedAt: string
+        raidId: string
+      }
+      if (
+        Number.isNaN(new Date(parsed.completedAt).getTime()) ||
+        !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+          parsed.raidId,
+        )
+      ) {
+        throw new Error('invalid')
+      }
+      return parsed
+    } catch {
+      throw new RaidError('HISTORY_CURSOR_INVALID', 400, 'Некорректный cursor')
+    }
+  }
+
+  private requireVersion(raid: RaidRow, expectedVersion: number): void {
+    if (raid.version !== expectedVersion) {
+      throw new RaidError('RAID_VERSION_CONFLICT', 409, 'Рейд уже изменился', {
+        currentVersion: raid.version,
+        currentState: raid.state,
+      })
+    }
+  }
+
+  private invalidTransition(raid: RaidRow): RaidError {
+    return new RaidError('RAID_TRANSITION_INVALID', 409, 'Команда недоступна в текущем состоянии', {
+      currentVersion: raid.version,
+      currentState: raid.state,
+    })
+  }
+
   private requireActiveParticipant(raid: RaidRow): void {
     if (raid.state !== 'active' || raid.participant_state !== 'active') {
       throw new RaidError('CHECKIN_UNAVAILABLE', 409, 'Отметка доступна только в активном рейде')
     }
+  }
+
+  private requireFinalizationCommitParticipant(raid: RaidRow): void {
+    if (raid.participant_state !== 'active') {
+      throw new RaidError('CHECKIN_UNAVAILABLE', 409, 'Операция участника недоступна')
+    }
+    if (raid.state === 'active') return
+    if (
+      raid.state === 'finalizing' &&
+      raid.finalization_deadline_at &&
+      raid.finalization_deadline_at.getTime() > raid.server_now.getTime()
+    ) {
+      return
+    }
+    throw new RaidError('FINALIZATION_CLOSED', 409, 'Окно завершения уже закрыто')
   }
 
   private async requireRaidParticipants(
@@ -2040,7 +2968,8 @@ export class DatabaseRaidService implements RaidService {
       `INSERT INTO raid_checkin_claims (raid_id, attempt_id, user_id)
        SELECT $1, $2, x.user_id FROM unnest($3::uuid[]) x(user_id)
        ON CONFLICT (attempt_id, user_id) DO NOTHING
-       RETURNING id, attempt_id, user_id, status, expires_at`,
+       RETURNING id, attempt_id, user_id, status, expires_at,
+         expires_at <= clock_timestamp() AS expired`,
       [raidId, attemptId, userIds],
     )
     return result.rows.map((row) => this.claimProjection(row))
@@ -2052,15 +2981,17 @@ export class DatabaseRaidService implements RaidService {
     user_id: string
     status: string
     expires_at: Date
+    expired: boolean
   }): ClaimProjection {
     return {
       id: row.id,
       attemptId: row.attempt_id,
       userId: row.user_id,
-      status:
-        row.status === 'pending' && row.expires_at.getTime() <= Date.now()
-          ? 'expired'
-          : (row.status as ClaimProjection['status']),
+      status: resolveExpiringStatus(
+        row.status,
+        'pending',
+        row.expired,
+      ) as ClaimProjection['status'],
       expiresAt: row.expires_at.toISOString(),
     }
   }
@@ -2073,16 +3004,18 @@ export class DatabaseRaidService implements RaidService {
     status: string
     reason: string
     expires_at: Date
+    expired: boolean
   }): FallbackProjection {
     return {
       id: row.id,
       attemptId: row.attempt_id,
       mediaId: row.media_id,
       verifierUserId: row.verifier_user_id,
-      status:
-        row.status === 'pending_verifier' && row.expires_at.getTime() <= Date.now()
-          ? 'expired'
-          : (row.status as FallbackProjection['status']),
+      status: resolveExpiringStatus(
+        row.status,
+        'pending_verifier',
+        row.expired,
+      ) as FallbackProjection['status'],
       reason: row.reason,
       expiresAt: row.expires_at.toISOString(),
     }
@@ -2142,7 +3075,9 @@ export class DatabaseRaidService implements RaidService {
   private async lockRaid(client: PoolClient, actorUserId: string, raidId: string): Promise<RaidRow> {
     const result = await client.query<RaidRow>(
       `SELECT r.id, r.kabanda_id, r.organizer_user_id, r.navigator_user_id,
-         r.title, r.description, r.scheduled_at, r.state, r.version,
+         r.title, r.description, r.scheduled_at, r.started_at, r.finalizing_at,
+         r.finalization_deadline_at, r.finalization_partial, clock_timestamp() AS server_now,
+         r.state, r.version,
          m.role AS membership_role, p.state AS participant_state
        FROM raids r
        JOIN kabandas k ON k.id = r.kabanda_id AND k.archived_at IS NULL
@@ -2183,6 +3118,35 @@ export class DatabaseRaidService implements RaidService {
     }
   }
 
+  private async visibleRaidProjection(
+    client: PoolClient,
+    actorUserId: string,
+    raidId: string,
+  ): Promise<void> {
+    const result = await client.query<{
+      state: RaidState
+      role: 'owner' | 'member'
+      participant_state: RaidParticipantState | null
+    }>(
+      `SELECT r.state, m.role, p.state AS participant_state FROM raids r
+       JOIN kabandas k ON k.id = r.kabanda_id AND k.archived_at IS NULL
+       JOIN kabanda_memberships m
+         ON m.kabanda_id = r.kabanda_id AND m.user_id = $2 AND m.removed_at IS NULL
+       LEFT JOIN raid_participants p ON p.raid_id = r.id AND p.user_id = $2
+       WHERE r.id = $1`,
+      [raidId, actorUserId],
+    )
+    const access = result.rows[0]
+    if (
+      !access ||
+      (access.state !== 'completed' &&
+        access.role !== 'owner' &&
+        (!access.participant_state || !visibleParticipantStates.includes(access.participant_state)))
+    ) {
+      throw this.notFound()
+    }
+  }
+
   private async project(
     client: PoolClient,
     actorUserId: string,
@@ -2190,7 +3154,9 @@ export class DatabaseRaidService implements RaidService {
   ): Promise<RaidProjection> {
     const raidResult = await client.query<RaidRow>(
       `SELECT r.id, r.kabanda_id, r.organizer_user_id, r.navigator_user_id,
-         r.title, r.description, r.scheduled_at, r.state, r.version,
+         r.title, r.description, r.scheduled_at, r.started_at, r.finalizing_at,
+         r.finalization_deadline_at, r.finalization_partial, clock_timestamp() AS server_now,
+         r.state, r.version,
          m.role AS membership_role, p.state AS participant_state
        FROM raids r
        JOIN kabanda_memberships m
@@ -2227,6 +3193,10 @@ export class DatabaseRaidService implements RaidService {
     )
     const routeStatus = await this.routeStatus(client, raid)
     const navigatorLease = await this.navigatorLeaseProjection(client, raid, actorUserId)
+    const finalization =
+      raid.state === 'finalizing'
+        ? await this.finalizationProjection(client, raid.id)
+        : null
     return {
       id: raid.id,
       kabandaId: raid.kabanda_id,
@@ -2240,6 +3210,7 @@ export class DatabaseRaidService implements RaidService {
       navigatorReady,
       navigatorBlockers: readiness?.blocker_codes ?? [],
       navigatorWarnings: readiness?.warning_codes ?? [],
+      finalization,
       routeStatus,
       navigatorLease,
       participants: participants.rows.map((participant) => ({
@@ -2253,6 +3224,7 @@ export class DatabaseRaidService implements RaidService {
         role: raid.membership_role,
         participantState: raid.participant_state,
         navigatorReady,
+        finalizationCanSettle: finalization?.canSettle ?? false,
       }),
     }
   }
@@ -2288,7 +3260,13 @@ export class DatabaseRaidService implements RaidService {
       expectedVersion: number | null
       fromState: RaidState | null
       mutatesState: boolean
-      response: RaidCommandResponse | RaidReadinessResponse | RaidLeaseResponse
+      response:
+        | RaidCommandResponse
+        | RaidReadinessResponse
+        | RaidLeaseResponse
+        | FinishRaidResponse
+        | SettleRaidResponse
+        | { raid: RaidProjection }
     },
   ): Promise<void> {
     await client.query(

--- a/apps/api/src/raids.ts
+++ b/apps/api/src/raids.ts
@@ -2641,10 +2641,9 @@ export class DatabaseRaidService implements RaidService {
       photos: number
     }>(
       `WITH ordered AS (
-         SELECT s.lease_id, s.sequence, s.captured_at, s.received_at, s.geom, s.accuracy_m,
+         SELECT s.lease_id, s.sequence, s.captured_at, s.geom, s.accuracy_m,
            lag(s.sequence) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_sequence,
            lag(s.captured_at) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_at,
-           lag(s.received_at) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_received_at,
            lag(s.geom) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_geom,
            lag(s.accuracy_m) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_accuracy
          FROM raid_route_samples s
@@ -2666,8 +2665,8 @@ export class DatabaseRaidService implements RaidService {
             AND seconds > 0 AND seconds <= 120 AND meters <= 2000
             AND meters / seconds <= 50
             AND EXISTS (SELECT 1 FROM raid_activity_windows w
-              WHERE w.raid_id = $1 AND previous_received_at >= w.opened_at
-                AND received_at <= w.closed_at)) AS distance_meters,
+              WHERE w.raid_id = $1 AND previous_at >= w.opened_at
+                AND captured_at <= w.closed_at)) AS distance_meters,
          (SELECT count(DISTINCT point_snapshot_id) FROM raid_point_credits
           WHERE raid_id = $1) AS unique_points,
          (SELECT count(*) FROM raid_media
@@ -2683,10 +2682,9 @@ export class DatabaseRaidService implements RaidService {
       photos: number
     }>(
       `WITH ordered AS (
-         SELECT s.lease_id, s.sequence, s.captured_at, s.received_at, s.geom, s.accuracy_m,
+         SELECT s.lease_id, s.sequence, s.captured_at, s.geom, s.accuracy_m,
            lag(s.sequence) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_sequence,
            lag(s.captured_at) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_at,
-           lag(s.received_at) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_received_at,
            lag(s.geom) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_geom,
            lag(s.accuracy_m) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_accuracy
          FROM raid_route_samples s
@@ -2704,8 +2702,8 @@ export class DatabaseRaidService implements RaidService {
            AND seconds > 0 AND seconds <= 120 AND meters <= 2000
            AND meters / seconds <= 50
            AND EXISTS (SELECT 1 FROM raid_activity_windows w
-             WHERE w.raid_id = $1 AND previous_received_at >= w.opened_at
-               AND received_at <= w.closed_at)
+             WHERE w.raid_id = $1 AND previous_at >= w.opened_at
+               AND captured_at <= w.closed_at)
        )
        SELECT p.user_id,
          coalesce(u.display_name, split_part(u.email::text, '@', 1)) AS display_name,
@@ -2715,10 +2713,10 @@ export class DatabaseRaidService implements RaidService {
           )))), 0)) FROM raid_activity_windows w
           WHERE w.raid_id = p.raid_id AND w.closed_at > p.active_from
             AND w.opened_at < coalesce(p.left_at, $2))
-          AS duration_seconds,
+         AS duration_seconds,
          (SELECT coalesce(sum(s.meters), 0) FROM valid_segments s
-          WHERE s.previous_received_at >= p.active_from
-            AND s.received_at <= coalesce(p.left_at, $2))
+          WHERE s.previous_at >= p.active_from
+            AND s.captured_at <= coalesce(p.left_at, $2))
           AS distance_meters,
          (SELECT count(DISTINCT c.point_snapshot_id) FROM raid_point_credits c
           WHERE c.raid_id = p.raid_id AND c.user_id = p.user_id

--- a/apps/api/src/raids.ts
+++ b/apps/api/src/raids.ts
@@ -2710,28 +2710,23 @@ export class DatabaseRaidService implements RaidService {
        SELECT p.user_id,
          coalesce(u.display_name, split_part(u.email::text, '@', 1)) AS display_name,
          (SELECT floor(coalesce(sum(greatest(0, extract(epoch FROM (
-            least(w.closed_at, coalesce(p.left_at, $2), coalesce(km.removed_at, $2)) -
-            greatest(w.opened_at, p.active_from, km.joined_at)
+            least(w.closed_at, coalesce(p.left_at, $2)) -
+            greatest(w.opened_at, p.active_from)
           )))), 0)) FROM raid_activity_windows w
-          WHERE w.raid_id = p.raid_id AND w.closed_at > greatest(p.active_from, km.joined_at)
-            AND w.opened_at < least(coalesce(p.left_at, $2), coalesce(km.removed_at, $2)))
+          WHERE w.raid_id = p.raid_id AND w.closed_at > p.active_from
+            AND w.opened_at < coalesce(p.left_at, $2))
           AS duration_seconds,
          (SELECT coalesce(sum(s.meters), 0) FROM valid_segments s
-          WHERE s.previous_received_at >= greatest(p.active_from, km.joined_at)
-            AND s.received_at <= least(coalesce(p.left_at, $2), coalesce(km.removed_at, $2)))
+          WHERE s.previous_received_at >= p.active_from
+            AND s.received_at <= coalesce(p.left_at, $2))
           AS distance_meters,
          (SELECT count(DISTINCT c.point_snapshot_id) FROM raid_point_credits c
           WHERE c.raid_id = p.raid_id AND c.user_id = p.user_id
-            AND c.created_at BETWEEN greatest(p.active_from, km.joined_at)
-              AND least(coalesce(p.left_at, $2), coalesce(km.removed_at, $2))) AS unique_points,
+            AND c.created_at BETWEEN p.active_from AND coalesce(p.left_at, $2)) AS unique_points,
          (SELECT count(*) FROM raid_media m WHERE m.raid_id = p.raid_id
           AND m.uploader_user_id = p.user_id AND m.state = 'ready'
-          AND m.ready_at BETWEEN greatest(p.active_from, km.joined_at)
-            AND least(coalesce(p.left_at, $2), coalesce(km.removed_at, $2))) AS photos
+          AND m.ready_at BETWEEN p.active_from AND coalesce(p.left_at, $2)) AS photos
        FROM raid_participants p
-       JOIN raids r ON r.id = p.raid_id
-       JOIN kabanda_memberships km
-         ON km.kabanda_id = r.kabanda_id AND km.user_id = p.user_id
        JOIN users u ON u.id = p.user_id
        WHERE p.raid_id = $1 AND p.active_from IS NOT NULL
        ORDER BY p.active_from, p.user_id`,
@@ -2814,12 +2809,8 @@ export class DatabaseRaidService implements RaidService {
        FROM raid_point_credits c
        JOIN raid_point_snapshots s ON s.id = c.point_snapshot_id
        JOIN raid_participants p ON p.raid_id = c.raid_id AND p.user_id = c.user_id
-       JOIN raids r ON r.id = c.raid_id
-       JOIN kabanda_memberships km
-         ON km.kabanda_id = r.kabanda_id AND km.user_id = c.user_id
        WHERE c.raid_id = $1 AND p.active_from IS NOT NULL
-         AND c.created_at BETWEEN greatest(p.active_from, km.joined_at)
-           AND least(coalesce(p.left_at, $2), coalesce(km.removed_at, $2))`,
+         AND c.created_at BETWEEN p.active_from AND coalesce(p.left_at, $2)`,
       [result.raid.id, result.raid.completedAt],
     )
   }

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -8,7 +8,14 @@ import {
 import { buildApp } from '../src/app.js'
 import { loadConfig } from '../src/config.js'
 import type { KabandaService } from '../src/kabandas.js'
-import { deriveMediaUploadCapability, type RaidService } from '../src/raids.js'
+import {
+  deriveMediaUploadCapability,
+  escapeShareCardXml,
+  renderRaidShareCard,
+  resolveExpiringStatus,
+  type RaidResult,
+  type RaidService,
+} from '../src/raids.js'
 
 const user: User = {
   id: '7484a9f8-11dd-45bd-9740-44b52413fa6b',
@@ -18,6 +25,16 @@ const user: User = {
 }
 
 const testOrigin = 'http://localhost:5173'
+
+it('projects claim and fallback expiry only from the SQL-derived flag', () => {
+  expect(resolveExpiringStatus('pending', 'pending', false)).toBe('pending')
+  expect(resolveExpiringStatus('pending', 'pending', true)).toBe('expired')
+  expect(resolveExpiringStatus('pending_verifier', 'pending_verifier', false)).toBe(
+    'pending_verifier',
+  )
+  expect(resolveExpiringStatus('pending_verifier', 'pending_verifier', true)).toBe('expired')
+  expect(resolveExpiringStatus('expired_finalization', 'pending', false)).toBe('expired')
+})
 
 function createAuth(overrides: Partial<AuthService> = {}): AuthService {
   return {
@@ -70,6 +87,13 @@ function createRaids(overrides: Partial<RaidService> = {}): RaidService {
     listMedia: vi.fn().mockResolvedValue({ media: [], nextCursor: null }),
     readMedia: vi.fn(),
     tombstoneMedia: vi.fn(),
+    finishRaid: vi.fn(),
+    settleFinalization: vi.fn(),
+    leaveRaid: vi.fn(),
+    getResult: vi.fn(),
+    listHistory: vi.fn().mockResolvedValue({ raids: [], nextCursor: null }),
+    getProgress: vi.fn(),
+    getShareCard: vi.fn(),
     ...overrides,
   }
 }
@@ -129,6 +153,46 @@ describe('API foundation', () => {
         MEDIA_CAPABILITY_SECRET: 'production-media-capability-secret-at-least-32-bytes',
       }),
     ).not.toThrow()
+  })
+
+  it('renders one deterministic metadata-free private PNG result card', async () => {
+    const result: RaidResult = {
+      schemaVersion: 1,
+      raid: {
+        id: '81297402-898c-48d6-bc78-c74b6b38205c',
+        kabandaId: '2e56a447-23dc-4507-af50-5b8c2430ac81',
+        title: 'Рейд <script>& "кабан"',
+        startedAt: '2026-08-28T10:00:00.000Z',
+        completedAt: '2026-08-28T11:00:00.000Z',
+        partial: false,
+      },
+      team: { durationSeconds: 3600, distanceMeters: 12_345.6, uniquePoints: 7, photos: 3 },
+      personal: { durationSeconds: 1800, distanceMeters: 6000, uniquePoints: 4, photos: 1 },
+      participants: [
+        {
+          userId: user.id,
+          displayName: 'Павел',
+          metrics: { durationSeconds: 1800, distanceMeters: 6000, uniquePoints: 4, photos: 1 },
+        },
+      ],
+    }
+    expect(escapeShareCardXml(result.raid.title)).toBe(
+      'Рейд &lt;script&gt;&amp; &quot;кабан&quot;',
+    )
+    const first = await renderRaidShareCard(result)
+    const second = await renderRaidShareCard(result)
+    expect(first.equals(second)).toBe(true)
+    expect(first.length).toBeLessThan(1024 * 1024)
+    expect(first.subarray(0, 8).toString('hex')).toBe('89504e470d0a1a0a')
+    const chunkTypes: string[] = []
+    for (let offset = 8; offset + 12 <= first.length; ) {
+      const length = first.readUInt32BE(offset)
+      chunkTypes.push(first.subarray(offset + 4, offset + 8).toString('ascii'))
+      offset += length + 12
+    }
+    expect(chunkTypes).not.toEqual(
+      expect.arrayContaining(['eXIf', 'iTXt', 'tEXt', 'zTXt', 'iCCP']),
+    )
   })
 
   it('reports liveness', async () => {
@@ -620,5 +684,56 @@ describe('API foundation', () => {
       'a'.repeat(64),
       bytes,
     )
+  })
+
+  it('registers exact finish, settle and leave command DTOs', async () => {
+    const finishRaid = vi.fn().mockResolvedValue({ raid: {}, finalization: {} })
+    const settleFinalization = vi.fn().mockResolvedValue({ raid: {}, result: {} })
+    const leaveRaid = vi.fn().mockResolvedValue({ raid: {} })
+    const app = await createTestApp(
+      createAuth({ getUser: vi.fn().mockResolvedValue(user) }),
+      createKabandas(),
+      createRaids({ finishRaid, settleFinalization, leaveRaid }),
+    )
+    const raidId = '81297402-898c-48d6-bc78-c74b6b38205c'
+    const commonHeaders = {
+      origin: testOrigin,
+      cookie: 'kabanda_session=session',
+      'idempotency-key': 'finalization-operation',
+    }
+    const finish = await app.inject({
+      method: 'POST',
+      url: `/api/raids/${raidId}/commands/finish`,
+      headers: commonHeaders,
+      payload: {
+        expectedVersion: 8,
+        inventory: { routePending: 0, checkInsPending: 0, mediaPending: 0, needsAction: 1 },
+        confirmPartial: true,
+      },
+    })
+    expect(finish.statusCode).toBe(200)
+    expect(finishRaid).toHaveBeenCalledWith(
+      user.id,
+      raidId,
+      {
+        expectedVersion: 8,
+        inventory: { routePending: 0, checkInsPending: 0, mediaPending: 0, needsAction: 1 },
+        confirmPartial: true,
+      },
+      'finalization-operation',
+    )
+    for (const [path, handler] of [
+      ['finalization/settle', settleFinalization],
+      ['participants/me/leave', leaveRaid],
+    ] as const) {
+      const response = await app.inject({
+        method: 'POST',
+        url: `/api/raids/${raidId}/${path}`,
+        headers: { ...commonHeaders, 'idempotency-key': `operation-${path}` },
+        payload: { expectedVersion: 9 },
+      })
+      expect(response.statusCode).toBe(200)
+      expect(handler).toHaveBeenCalledWith(user.id, raidId, 9, `operation-${path}`)
+    }
   })
 })

--- a/apps/api/test/kabandas.postgres.test.ts
+++ b/apps/api/test/kabandas.postgres.test.ts
@@ -1815,7 +1815,8 @@ describePostgres('Kabandas and points PostgreSQL invariants', () => {
     )
     await pool!.query(
       `UPDATE raid_participants SET active_from = '2026-08-28T10:00:00Z',
-         left_at = CASE WHEN user_id = $2 THEN '2026-08-28T10:30:00Z' ELSE NULL END
+         left_at = CASE WHEN user_id = $2
+           THEN '2026-08-28T10:30:00Z'::timestamptz ELSE NULL::timestamptz END
        WHERE raid_id = $1`,
       [acquired.raid.id, memberId],
     )

--- a/apps/api/test/kabandas.postgres.test.ts
+++ b/apps/api/test/kabandas.postgres.test.ts
@@ -1825,13 +1825,13 @@ describePostgres('Kabandas and points PostgreSQL invariants', () => {
          captured_at = CASE sequence
            WHEN 1 THEN '2026-08-28T10:10:10Z'::timestamptz
            WHEN 2 THEN '2026-08-28T10:10:20Z'::timestamptz
-           WHEN 4 THEN '2026-08-28T10:10:30Z'::timestamptz
-           ELSE '2026-08-28T10:10:40Z'::timestamptz END,
-         received_at = CASE sequence
-           WHEN 1 THEN '2026-08-28T10:10:10Z'::timestamptz
-           WHEN 2 THEN '2026-08-28T10:10:20Z'::timestamptz
            WHEN 4 THEN '2026-08-28T10:29:50Z'::timestamptz
-           ELSE '2026-08-28T10:30:10Z'::timestamptz END
+           ELSE '2026-08-28T10:30:10Z'::timestamptz END,
+         received_at = CASE sequence
+           WHEN 1 THEN '2026-08-28T10:45:10Z'::timestamptz
+           WHEN 2 THEN '2026-08-28T10:45:20Z'::timestamptz
+           WHEN 4 THEN '2026-08-28T10:45:30Z'::timestamptz
+           ELSE '2026-08-28T10:45:40Z'::timestamptz END
        WHERE raid_id = $1`,
       [acquired.raid.id],
     )
@@ -1867,7 +1867,12 @@ describePostgres('Kabandas and points PostgreSQL invariants', () => {
     })
     expect(
       settled.result.participants.find((participant) => participant.userId === memberId)?.metrics,
-    ).toMatchObject({ durationSeconds: 1800, uniquePoints: 1, photos: 0 })
+    ).toMatchObject({
+      durationSeconds: 1800,
+      distanceMeters: Math.round(expectedDistance * 10) / 10,
+      uniquePoints: 1,
+      photos: 0,
+    })
     await expect(
       raidService!.settleFinalization(
         ownerId,

--- a/apps/api/test/kabandas.postgres.test.ts
+++ b/apps/api/test/kabandas.postgres.test.ts
@@ -9,8 +9,9 @@ const databaseUrl = process.env.DATABASE_URL
 const describePostgres = databaseUrl ? describe : describe.skip
 const pool = databaseUrl ? new Pool({ connectionString: databaseUrl }) : null
 const service = pool ? new DatabaseKabandaService(pool) : null
+const mediaCapabilitySecret = 'test-media-capability-secret-at-least-32-bytes'
 const raidService = pool
-  ? new DatabaseRaidService(pool, 'test-media-capability-secret-at-least-32-bytes')
+  ? new DatabaseRaidService(pool, mediaCapabilitySecret)
   : null
 
 const bounds = { minLat: 56.8, minLon: 53.1, maxLat: 56.9, maxLon: 53.3 }
@@ -1404,9 +1405,10 @@ describePostgres('Kabandas and points PostgreSQL invariants', () => {
       ),
     ).rejects.toMatchObject({ code: 'MEDIA_IS_FALLBACK_EVIDENCE' })
     await pool!.query(
-      `UPDATE raid_media SET state = 'processing', processing_started_at = now()
+      `UPDATE raid_media SET state = 'processing', processing_started_at = clock_timestamp(),
+         processing_token = $2
        WHERE id = $1`,
-      [uploaded.media.id],
+      [uploaded.media.id, randomUUID()],
     )
     await expect(
       raidService!.respondFallback(
@@ -1418,7 +1420,8 @@ describePostgres('Kabandas and points PostgreSQL invariants', () => {
       ),
     ).rejects.toMatchObject({ code: 'FALLBACK_MEDIA_UNAVAILABLE' })
     await pool!.query(
-      `UPDATE raid_media SET state = 'ready', processing_started_at = NULL WHERE id = $1`,
+      `UPDATE raid_media SET state = 'ready', processing_started_at = NULL,
+         processing_token = NULL WHERE id = $1`,
       [uploaded.media.id],
     )
     await pool!.query("UPDATE raid_media SET purpose = 'gallery' WHERE id = $1", [
@@ -1524,5 +1527,602 @@ describePostgres('Kabandas and points PostgreSQL invariants', () => {
       'checkin-media-confirm-claim',
     )
     expect(confirmed.credit).toMatchObject({ userId: memberId, source: 'claim' })
+  })
+
+  it('fences stale media processors with a server-timed UUID claim token', async () => {
+    const { ownerId, kabanda } = await ownerAndKabanda('media-fence')
+    const { acquired } = await activeOwnerRaid(ownerId, kabanda.id, 'media-fence')
+
+    for (const mode of ['commit', 'reset'] as const) {
+      const source = await sharp({
+        create: {
+          width: 12,
+          height: 12,
+          channels: 3,
+          background: mode === 'commit' ? '#245d3b' : '#7a3e18',
+        },
+      })
+        .png()
+        .toBuffer()
+      const sourceSha256 = createHash('sha256').update(source).digest('hex')
+      const intent = await raidService!.createMediaIntent(
+        ownerId,
+        acquired.raid.id,
+        {
+          sourceSha256,
+          sizeBytes: source.length,
+          contentType: 'image/png',
+          purpose: 'gallery',
+        },
+        `media-fence-intent-${mode}`,
+      )
+      await pool!.query(
+        `UPDATE raid_media SET state = 'processing',
+           processing_started_at = clock_timestamp() - interval '3 minutes',
+           processing_token = $2
+         WHERE id = $1`,
+        [intent.intentId, randomUUID()],
+      )
+
+      let enteredProcessor!: () => void
+      const processorEntered = new Promise<void>((resolve) => {
+        enteredProcessor = resolve
+      })
+      let releaseProcessor!: () => void
+      const processorReleased = new Promise<void>((resolve) => {
+        releaseProcessor = resolve
+      })
+      const delayedService = new DatabaseRaidService(
+        pool!,
+        mediaCapabilitySecret,
+        async () => {
+          enteredProcessor()
+          await processorReleased
+          if (mode === 'reset') throw new Error('synthetic processor failure')
+          return {
+            data: source,
+            info: { width: 12, height: 12, size: source.length },
+          }
+        },
+      )
+      const upload = delayedService.uploadMedia(
+        ownerId,
+        acquired.raid.id,
+        intent.intentId,
+        intent.uploadCapability,
+        sourceSha256,
+        source,
+      )
+      await processorEntered
+      const claimed = await pool!.query<{ processing_token: string }>(
+        'SELECT processing_token FROM raid_media WHERE id = $1',
+        [intent.intentId],
+      )
+      const firstToken = claimed.rows[0]!.processing_token
+      const replacementToken = randomUUID()
+      await pool!.query(
+        `UPDATE raid_media SET processing_token = $2,
+           processing_started_at = clock_timestamp()
+         WHERE id = $1 AND processing_token = $3`,
+        [intent.intentId, replacementToken, firstToken],
+      )
+      releaseProcessor()
+
+      await expect(upload).rejects.toMatchObject({
+        code: 'MEDIA_PROCESSING_SUPERSEDED',
+        statusCode: 409,
+      })
+      const stored = await pool!.query<{
+        state: string
+        processing_token: string
+        content_bytes: Buffer | null
+      }>(
+        `SELECT state, processing_token, content_bytes FROM raid_media WHERE id = $1`,
+        [intent.intentId],
+      )
+      expect(stored.rows[0]).toMatchObject({
+        state: 'processing',
+        processing_token: replacementToken,
+        content_bytes: null,
+      })
+    }
+  })
+
+  it('freezes one canonical result, participant cutoffs, history and private PNG', async () => {
+    const { ownerId, kabanda } = await ownerAndKabanda('results')
+    const { acquired, clientInstanceId, leaseId } = await activeOwnerRaid(
+      ownerId,
+      kabanda.id,
+      'results',
+    )
+    const memberId = await user('results-member@example.com')
+    await pool!.query(
+      `INSERT INTO kabanda_memberships (kabanda_id, user_id, role) VALUES ($1, $2, 'member')`,
+      [kabanda.id, memberId],
+    )
+    await pool!.query(
+      `INSERT INTO raid_participants (raid_id, user_id, state, accepted_at, active_from)
+       VALUES ($1, $2, 'active', now(), now())`,
+      [acquired.raid.id, memberId],
+    )
+    await raidService!.submitRouteBatch(
+      ownerId,
+      acquired.raid.id,
+      {
+        schemaVersion: 1,
+        leaseId,
+        clientInstanceId,
+        samples: [
+          {
+            operationId: 'result-route-sample-one',
+            sequence: 1,
+            capturedAt: new Date().toISOString(),
+            latitude: 56.86,
+            longitude: 53.21,
+            accuracyM: 8,
+          },
+          {
+            operationId: 'result-route-sample-two',
+            sequence: 2,
+            capturedAt: new Date(Date.now() + 1000).toISOString(),
+            latitude: 56.8602,
+            longitude: 53.211,
+            accuracyM: 8,
+          },
+          {
+            operationId: 'result-route-sample-four',
+            sequence: 4,
+            capturedAt: new Date(Date.now() + 2000).toISOString(),
+            latitude: 56.8604,
+            longitude: 53.212,
+            accuracyM: 8,
+          },
+          {
+            operationId: 'result-route-sample-five',
+            sequence: 5,
+            capturedAt: new Date(Date.now() + 3000).toISOString(),
+            latitude: 56.8605,
+            longitude: 53.2122,
+            accuracyM: 8,
+          },
+        ],
+      },
+      'result-route-batch',
+    )
+    const snapshot = (
+      await pool!.query<{ id: string }>(
+        'SELECT id FROM raid_point_snapshots WHERE raid_id = $1 LIMIT 1',
+        [acquired.raid.id],
+      )
+    ).rows[0]!
+    await raidService!.createCheckin(
+      ownerId,
+      acquired.raid.id,
+      {
+        pointSnapshotId: snapshot.id,
+        evidence: {
+          latitude: 56.86,
+          longitude: 53.21,
+          capturedAt: new Date().toISOString(),
+          accuracyMeters: 8,
+        },
+        presentParticipantIds: [memberId],
+        organizerAttestation: true,
+      },
+      'result-checkin',
+    )
+    const mediaId = randomUUID()
+    await pool!.query(
+      `INSERT INTO raid_media
+        (id, raid_id, uploader_user_id, purpose, source_sha256, declared_size_bytes,
+         declared_content_type, upload_capability_hash, upload_expires_at, state,
+         content_bytes, content_type, size_bytes, width, height, content_sha256, ready_at)
+       VALUES ($1, $2, $3, 'gallery', $4, 4, 'image/jpeg', $5, now() + interval '1 minute',
+         'ready', decode('ffd8ffd9', 'hex'), 'image/jpeg', 4, 1, 1, $6, now())`,
+      [mediaId, acquired.raid.id, ownerId, 'a'.repeat(64), 'b'.repeat(64), 'c'.repeat(64)],
+    )
+    await expect(
+      raidService!.leaveRaid(
+        ownerId,
+        acquired.raid.id,
+        acquired.raid.version,
+        'result-owner-cannot-leave',
+      ),
+    ).rejects.toMatchObject({ code: 'RAID_COMMAND_FORBIDDEN' })
+    const left = await raidService!.leaveRaid(
+      memberId,
+      acquired.raid.id,
+      acquired.raid.version,
+      'result-member-leave',
+    )
+    expect(left.raid.participants.find((participant) => participant.id === memberId)?.state).toBe(
+      'left',
+    )
+    await expect(raidService!.getRaid(memberId, acquired.raid.id)).rejects.toMatchObject({
+      code: 'RAID_NOT_FOUND',
+    })
+    const current = await raidService!.getRaid(ownerId, acquired.raid.id)
+    const finish = await raidService!.finishRaid(
+      ownerId,
+      acquired.raid.id,
+      {
+        expectedVersion: current.version,
+        inventory: { routePending: 0, checkInsPending: 0, mediaPending: 0, needsAction: 0 },
+        confirmPartial: false,
+      },
+      'result-finish',
+    )
+    expect(finish.finalization).toMatchObject({ status: 'collecting', partial: false })
+    const finalizationSeconds = Number(
+      (
+        await pool!.query(
+          `SELECT extract(epoch FROM (finalization_deadline_at - finalizing_at)) AS seconds
+           FROM raids WHERE id = $1`,
+          [acquired.raid.id],
+        )
+      ).rows[0]!.seconds,
+    )
+    expect(finalizationSeconds).toBeGreaterThanOrEqual(119.9)
+    expect(finalizationSeconds).toBeLessThanOrEqual(120.1)
+    expect(
+      Number(
+        (
+          await pool!.query(
+            'SELECT count(*) FROM raid_route_finalization_cutoffs WHERE raid_id = $1',
+            [acquired.raid.id],
+          )
+        ).rows[0]!.count,
+      ),
+    ).toBeGreaterThan(0)
+    await expect(
+      raidService!.submitRouteBatch(
+        ownerId,
+        acquired.raid.id,
+        {
+          schemaVersion: 1,
+          leaseId,
+          clientInstanceId,
+          samples: [
+            {
+              operationId: 'result-route-after-cutoff',
+              sequence: 6,
+              capturedAt: new Date().toISOString(),
+              latitude: 56.8603,
+              longitude: 53.2112,
+              accuracyM: 8,
+            },
+          ],
+        },
+        'result-route-after-finish',
+      ),
+    ).rejects.toMatchObject({ code: 'NAVIGATOR_LEASE_SUPERSEDED' })
+
+    await pool!.query(
+      `UPDATE raids SET started_at = '2026-08-28T10:00:00Z',
+         finalizing_at = '2026-08-28T11:00:00Z' WHERE id = $1`,
+      [acquired.raid.id],
+    )
+    await pool!.query(
+      `UPDATE raid_activity_windows SET opened_at = '2026-08-28T10:00:00Z',
+         closed_at = '2026-08-28T10:30:00Z' WHERE raid_id = $1`,
+      [acquired.raid.id],
+    )
+    await pool!.query(
+      `INSERT INTO raid_activity_windows
+        (raid_id, opened_at, closed_at, opened_version, closed_version)
+       VALUES ($1, '2026-08-28T10:30:00Z', '2026-08-28T11:00:00Z', 100, 100)`,
+      [acquired.raid.id],
+    )
+    await pool!.query(
+      `UPDATE raid_participants SET active_from = '2026-08-28T10:00:00Z',
+         left_at = CASE WHEN user_id = $2 THEN '2026-08-28T10:30:00Z' ELSE NULL END
+       WHERE raid_id = $1`,
+      [acquired.raid.id, memberId],
+    )
+    await pool!.query(
+      `UPDATE raid_route_samples SET
+         captured_at = CASE sequence
+           WHEN 1 THEN '2026-08-28T10:10:10Z'::timestamptz
+           WHEN 2 THEN '2026-08-28T10:10:20Z'::timestamptz
+           WHEN 4 THEN '2026-08-28T10:10:30Z'::timestamptz
+           ELSE '2026-08-28T10:10:40Z'::timestamptz END,
+         received_at = CASE sequence
+           WHEN 1 THEN '2026-08-28T10:10:10Z'::timestamptz
+           WHEN 2 THEN '2026-08-28T10:10:20Z'::timestamptz
+           WHEN 4 THEN '2026-08-28T10:29:50Z'::timestamptz
+           ELSE '2026-08-28T10:30:10Z'::timestamptz END
+       WHERE raid_id = $1`,
+      [acquired.raid.id],
+    )
+    await pool!.query(
+      `UPDATE raid_point_credits SET created_at = '2026-08-28T10:20:00Z' WHERE raid_id = $1`,
+      [acquired.raid.id],
+    )
+    await pool!.query(
+      `UPDATE raid_media SET ready_at = '2026-08-28T10:20:00Z' WHERE id = $1`,
+      [mediaId],
+    )
+    const expectedDistance = Number(
+      (
+        await pool!.query(
+          `SELECT ST_Distance(a.geom, b.geom) AS meters FROM raid_route_samples a
+           JOIN raid_route_samples b ON b.lease_id = a.lease_id AND b.sequence = 2
+           WHERE a.lease_id = $1 AND a.sequence = 1`,
+          [leaseId],
+        )
+      ).rows[0]!.meters,
+    )
+    const settled = await raidService!.settleFinalization(
+      ownerId,
+      acquired.raid.id,
+      finish.raid.version,
+      'result-settle',
+    )
+    expect(settled.result.team).toEqual({
+      durationSeconds: 3600,
+      distanceMeters: Math.round(expectedDistance * 10) / 10,
+      uniquePoints: 1,
+      photos: 1,
+    })
+    expect(
+      settled.result.participants.find((participant) => participant.userId === memberId)?.metrics,
+    ).toMatchObject({ durationSeconds: 1800, uniquePoints: 1, photos: 0 })
+    await expect(
+      raidService!.settleFinalization(
+        ownerId,
+        acquired.raid.id,
+        finish.raid.version,
+        'result-settle',
+      ),
+    ).resolves.toEqual(settled)
+
+    await pool!.query("UPDATE users SET display_name = 'Новое имя' WHERE id = $1", [ownerId])
+    await pool!.query(
+      `UPDATE raid_activity_windows SET opened_at = opened_at + interval '1 minute'
+       WHERE raid_id = $1`,
+      [acquired.raid.id],
+    )
+    await raidService!.tombstoneMedia(
+      ownerId,
+      acquired.raid.id,
+      mediaId,
+      'result-photo-tombstone',
+    )
+    const immutable = await raidService!.getResult(ownerId, acquired.raid.id)
+    expect(immutable).toEqual(settled.result)
+    expect(immutable.team.photos).toBe(1)
+    await expect(
+      pool!.query('UPDATE raid_results SET team_photos = 99 WHERE raid_id = $1', [
+        acquired.raid.id,
+      ]),
+    ).rejects.toMatchObject({ code: '55000' })
+    expect(immutable.participants.some((participant) => participant.displayName === 'Новое имя')).toBe(
+      false,
+    )
+    await expect(raidService!.getRaid(memberId, acquired.raid.id)).resolves.toMatchObject({
+      id: acquired.raid.id,
+      state: 'completed',
+    })
+    const laterMemberId = await user('results-later-member@example.com')
+    await pool!.query(
+      `INSERT INTO kabanda_memberships (kabanda_id, user_id, role) VALUES ($1, $2, 'member')`,
+      [kabanda.id, laterMemberId],
+    )
+    await expect(raidService!.getRaid(laterMemberId, acquired.raid.id)).resolves.toMatchObject({
+      id: acquired.raid.id,
+      state: 'completed',
+    })
+    expect((await raidService!.listHistory(laterMemberId, kabanda.id, 20)).raids[0]!.personal).toEqual({
+      durationSeconds: 0,
+      distanceMeters: 0,
+      uniquePoints: 0,
+      photos: 0,
+    })
+    const history = await raidService!.listHistory(ownerId, kabanda.id, 20)
+    expect(history.raids[0]).toMatchObject({ raidId: acquired.raid.id, team: settled.result.team })
+    const progress = await raidService!.getProgress(ownerId, kabanda.id)
+    expect(progress.progress.team).toMatchObject({ completedRaids: 1, uniquePoints: 1, photos: 1 })
+    const png = await raidService!.getShareCard(ownerId, acquired.raid.id)
+    expect(png.subarray(0, 8).toString('hex')).toBe('89504e470d0a1a0a')
+
+    const outsider = await ownerAndKabanda('results-outsider')
+    await expect(raidService!.getResult(outsider.ownerId, acquired.raid.id)).rejects.toMatchObject({
+      code: 'RAID_NOT_FOUND',
+    })
+  })
+
+  it('serializes settle against finalizing claim and media commits', async () => {
+    const { ownerId, kabanda } = await ownerAndKabanda('finalizing-race')
+    const { acquired } = await activeOwnerRaid(ownerId, kabanda.id, 'finalizing-race')
+    const memberId = await user('finalizing-race-member@example.com')
+    await pool!.query(
+      `INSERT INTO kabanda_memberships (kabanda_id, user_id, role) VALUES ($1, $2, 'member')`,
+      [kabanda.id, memberId],
+    )
+    await pool!.query(
+      `INSERT INTO raid_participants (raid_id, user_id, state, accepted_at, active_from)
+       VALUES ($1, $2, 'active', now(), now())`,
+      [acquired.raid.id, memberId],
+    )
+    const snapshot = (
+      await pool!.query<{ id: string }>(
+        'SELECT id FROM raid_point_snapshots WHERE raid_id = $1 LIMIT 1',
+        [acquired.raid.id],
+      )
+    ).rows[0]!
+    const checkin = await raidService!.createCheckin(
+      ownerId,
+      acquired.raid.id,
+      {
+        pointSnapshotId: snapshot.id,
+        evidence: {
+          latitude: 56.86,
+          longitude: 53.21,
+          capturedAt: new Date().toISOString(),
+          accuracyMeters: 8,
+        },
+        presentParticipantIds: [memberId],
+        organizerAttestation: false,
+      },
+      'finalizing-race-checkin',
+    )
+    const claimId = checkin.claims[0]!.id
+    const source = await sharp({
+      create: { width: 20, height: 20, channels: 3, background: '#315d42' },
+    })
+      .png()
+      .toBuffer()
+    const sourceSha = createHash('sha256').update(source).digest('hex')
+    const intent = await raidService!.createMediaIntent(
+      ownerId,
+      acquired.raid.id,
+      {
+        sourceSha256: sourceSha,
+        sizeBytes: source.length,
+        contentType: 'image/png',
+        purpose: 'gallery',
+      },
+      'finalizing-race-media',
+    )
+    const expiredIntent = await raidService!.createMediaIntent(
+      ownerId,
+      acquired.raid.id,
+      {
+        sourceSha256: 'd'.repeat(64),
+        sizeBytes: 100,
+        contentType: 'image/jpeg',
+        purpose: 'gallery',
+      },
+      'finalizing-race-expired-media',
+    )
+    await pool!.query('UPDATE raid_media SET upload_expires_at = now() - interval \'1 second\' WHERE id = $1', [
+      expiredIntent.intentId,
+    ])
+    const finish = await raidService!.finishRaid(
+      ownerId,
+      acquired.raid.id,
+      {
+        expectedVersion: acquired.raid.version,
+        inventory: { routePending: 0, checkInsPending: 0, mediaPending: 0, needsAction: 0 },
+        confirmPartial: false,
+      },
+      'finalizing-race-finish',
+    )
+    expect(finish.finalization.partial).toBe(false)
+    const raced = await Promise.allSettled([
+      raidService!.respondClaim(
+        memberId,
+        acquired.raid.id,
+        claimId,
+        'confirm',
+        'finalizing-race-confirm-claim',
+      ),
+      raidService!.uploadMedia(
+        ownerId,
+        acquired.raid.id,
+        intent.intentId,
+        intent.uploadCapability,
+        sourceSha,
+        source,
+      ),
+      raidService!.settleFinalization(
+        ownerId,
+        acquired.raid.id,
+        finish.raid.version,
+        'finalizing-race-settle-first',
+      ),
+    ])
+    expect(raced[0]!.status).toBe('fulfilled')
+    expect(raced[1]!.status).toBe('fulfilled')
+    if (raced[2]!.status === 'rejected') {
+      expect(raced[2]!.reason).toMatchObject({ code: 'FINALIZATION_PENDING' })
+    }
+    const afterRace = await raidService!.getRaid(ownerId, acquired.raid.id)
+    const settled =
+      afterRace.state === 'completed'
+        ? { result: await raidService!.getResult(ownerId, acquired.raid.id) }
+        : await raidService!.settleFinalization(
+            ownerId,
+            acquired.raid.id,
+            afterRace.version,
+            'finalizing-race-settle-second',
+          )
+    expect(settled.result).toMatchObject({
+      raid: { partial: true },
+      team: { uniquePoints: 1, photos: 1 },
+    })
+    expect(
+      settled.result.participants.find((participant) => participant.userId === memberId)?.metrics,
+    ).toMatchObject({ uniquePoints: 1 })
+    expect(
+      (
+        await pool!.query<{ state: string }>('SELECT state FROM raid_media WHERE id = $1', [
+          expiredIntent.intentId,
+        ])
+      ).rows[0]!.state,
+    ).toBe('expired_finalization')
+  })
+
+  it('serializes finish against the last route batch and freezes that generation', async () => {
+    const { ownerId, kabanda } = await ownerAndKabanda('finish-route-race')
+    const { acquired, clientInstanceId, leaseId } = await activeOwnerRaid(
+      ownerId,
+      kabanda.id,
+      'finish-route-race',
+    )
+    const raced = await Promise.allSettled([
+      raidService!.finishRaid(
+        ownerId,
+        acquired.raid.id,
+        {
+          expectedVersion: acquired.raid.version,
+          inventory: { routePending: 0, checkInsPending: 0, mediaPending: 0, needsAction: 0 },
+          confirmPartial: false,
+        },
+        'finish-route-race-finish',
+      ),
+      raidService!.submitRouteBatch(
+        ownerId,
+        acquired.raid.id,
+        {
+          schemaVersion: 1,
+          leaseId,
+          clientInstanceId,
+          samples: [
+            {
+              operationId: 'finish-route-race-sample',
+              sequence: 1,
+              capturedAt: new Date().toISOString(),
+              latitude: 56.86,
+              longitude: 53.21,
+              accuracyM: 8,
+            },
+          ],
+        },
+        'finish-route-race-batch',
+      ),
+    ])
+    expect(raced[0]!.status).toBe('fulfilled')
+    if (raced[1]!.status === 'rejected') {
+      expect(raced[1]!.reason).toMatchObject({ code: 'NAVIGATOR_LEASE_SUPERSEDED' })
+    }
+    const storedSamples = Number(
+      (
+        await pool!.query(
+          'SELECT count(*) FROM raid_route_samples WHERE raid_id = $1 AND lease_id = $2',
+          [acquired.raid.id, leaseId],
+        )
+      ).rows[0]!.count,
+    )
+    const cutoff = Number(
+      (
+        await pool!.query(
+          `SELECT max_sequence FROM raid_route_finalization_cutoffs
+           WHERE raid_id = $1 AND lease_id = $2`,
+          [acquired.raid.id, leaseId],
+        )
+      ).rows[0]!.max_sequence,
+    )
+    expect(cutoff).toBe(storedSamples)
   })
 })

--- a/apps/pwa/src/features/checkins/CheckInPanel.tsx
+++ b/apps/pwa/src/features/checkins/CheckInPanel.tsx
@@ -53,11 +53,13 @@ export function CheckInPanel({
   raid,
   staleProjection,
   onCanonicalRefresh,
+  serverTailOnly = false,
 }: {
   identityId: string
   raid: RaidProjection
   staleProjection: boolean
   onCanonicalRefresh: () => Promise<unknown>
+  serverTailOnly?: boolean
 }) {
   const [nearby, setNearby] = useState<NearbyPoint[]>([])
   const [selectedPointId, setSelectedPointId] = useState('')
@@ -304,7 +306,7 @@ export function CheckInPanel({
       : [...current, participantId])
   }
 
-  const primaryKind = selectCheckInPrimary({
+  const selectedPrimaryKind = selectCheckInPrimary({
     hasPendingClaim: Boolean(pendingClaim),
     hasPendingFallback: Boolean(pendingFallback),
     hasManualAttempt: Boolean(manualResponse),
@@ -316,6 +318,9 @@ export function CheckInPanel({
     viewerIsNavigator,
     hasSelectedPoint: Boolean(selectedPointId),
   })
+  const primaryKind = serverTailOnly && selectedPrimaryKind !== 'claim' && selectedPrimaryKind !== 'verify_fallback'
+    ? null
+    : selectedPrimaryKind
   const primary = primaryKind === 'claim' && pendingClaim
     ? { label: 'Подтвердить, что я был здесь', action: () => claimAction(pendingClaim, 'confirm') }
     : primaryKind === 'verify_fallback' && pendingFallback
@@ -335,7 +340,7 @@ export function CheckInPanel({
         <div><p className="kb-kicker">Точка рейда</p><h2>{manualResponse ? 'Нужна ручная проверка' : 'Кто сейчас здесь?'}</h2></div>
         {local?.unsynced ? <span className="checkin-pending">Локально: {local.unsynced}</span> : null}
       </div>
-      <p className="kb-muted">Для каждой попытки берём отдельную координату. Маршрут навигатора не используется как evidence.</p>
+      <p className="kb-muted">{serverTailOnly ? 'В finalizing доступны только уже созданные server-side подтверждения.' : 'Для каждой попытки берём отдельную координату. Маршрут навигатора не используется как evidence.'}</p>
 
       {pendingClaim && <div className="kb-notice"><strong>Вас отметил участник рейда.</strong><p>Подтвердите только своё присутствие или отклоните claim.</p></div>}
       {pendingFallback && <div className="kb-notice"><strong>Вас выбрали verifier.</strong><p>Подтверждение будет отдельным от автора попытки.</p></div>}

--- a/apps/pwa/src/features/checkins/replay.ts
+++ b/apps/pwa/src/features/checkins/replay.ts
@@ -98,3 +98,48 @@ export async function replayOneCheckInOrMedia(input: {
       : { kind: 'retryable' }
   }
 }
+
+export async function replayOneIssuedMedia(input: {
+  identityId: string
+  raidId: string
+  holderTabId: string
+  online: boolean
+}): Promise<CheckInReplayResult> {
+  if (!input.online) return { kind: 'idle' }
+  const fence = await acquireCheckInSenderLease(input.identityId, input.raidId, input.holderTabId)
+  if (!fence) return { kind: 'idle' }
+  const media = await claimNextMediaDraft(fence, Date.now(), true)
+  if (!media) return { kind: 'idle' }
+  try {
+    const intent = await createMediaIntent(media.raidId, media.operationId, {
+      sourceSha256: media.sourceSha256,
+      sizeBytes: media.sizeBytes,
+      contentType: media.contentType,
+      caption: media.caption,
+      purpose: media.purpose,
+      ...(media.attemptId ? { attemptId: media.attemptId } : {}),
+    })
+    if (!(await rememberMediaIntent(fence, media.operationId, intent.intentId))) return { kind: 'fence_lost' }
+    const response = await uploadMediaContent(
+      media.raidId,
+      intent.intentId,
+      intent.uploadCapability,
+      media.sourceSha256,
+      media.blob,
+    )
+    const settled = await settleMediaDraft(fence, media.operationId, response)
+    return settled
+      ? { kind: 'media', operationId: media.operationId, mediaId: response.media.id }
+      : { kind: 'fence_lost' }
+  } catch (error) {
+    if (error instanceof ApiError && error.code === 'MEDIA_INTENT_EXPIRED') {
+      const marked = await retryMediaDraft(fence, media.operationId, error.code, true)
+      return marked ? { kind: 'terminal', code: error.code } : { kind: 'fence_lost' }
+    }
+    const terminal = isTerminal(error)
+    const marked = await retryMediaDraft(fence, media.operationId, errorCode(error), terminal)
+    return !marked ? { kind: 'fence_lost' } : terminal
+      ? { kind: 'terminal', code: errorCode(error) }
+      : { kind: 'retryable' }
+  }
+}

--- a/apps/pwa/src/features/checkins/store.test.ts
+++ b/apps/pwa/src/features/checkins/store.test.ts
@@ -126,6 +126,53 @@ describe('identity-bound check-in outbox', () => {
     })
   })
 
+  it('claims only an already-issued media intent during finalizing drain', async () => {
+    const now = Date.parse('2026-08-28T08:00:00.000Z')
+    const local = await persistMediaDraft({
+      identityId: 'user-a', kabandaId: 'kabanda-a', raidId: 'raid-a',
+      blob: new Blob(['local'], { type: 'image/jpeg' }), sourceSha256: 'local', sizeBytes: 5,
+      contentType: 'image/jpeg', caption: null, purpose: 'gallery', attemptId: null,
+    }, now)
+    const issued = await persistMediaDraft({
+      identityId: 'user-a', kabandaId: 'kabanda-a', raidId: 'raid-a',
+      blob: new Blob(['issued'], { type: 'image/jpeg' }), sourceSha256: 'issued', sizeBytes: 6,
+      contentType: 'image/jpeg', caption: null, purpose: 'gallery', attemptId: null,
+    }, now + 1)
+    await offlineDb.mediaDrafts.update(issued!.operationId, { intentId: 'intent-a' })
+    const fence = await acquireCheckInSenderLease('user-a', 'raid-a', 'tab-a', now + 2)
+    expect((await claimNextMediaDraft(fence!, now + 3, true))?.operationId).toBe(issued?.operationId)
+    expect((await offlineDb.mediaDrafts.get(local!.operationId))?.status).toBe('local')
+  })
+
+  it('keeps only an issued media upload replayable in finalizing', async () => {
+    const now = Date.parse('2026-08-28T08:00:00.000Z')
+    const checkIn = await enqueueCheckIn('user-a', 'kabanda-a', 'raid-a', {
+      pointSnapshotId: 'point-a', evidence, presentParticipantIds: ['user-a'], organizerAttestation: false,
+    }, now)
+    const local = await persistMediaDraft({
+      identityId: 'user-a', kabandaId: 'kabanda-a', raidId: 'raid-a',
+      blob: new Blob(['local'], { type: 'image/jpeg' }), sourceSha256: 'local', sizeBytes: 5,
+      contentType: 'image/jpeg', caption: null, purpose: 'gallery', attemptId: null,
+    }, now)
+    const issued = await persistMediaDraft({
+      identityId: 'user-a', kabandaId: 'kabanda-a', raidId: 'raid-a',
+      blob: new Blob(['issued'], { type: 'image/jpeg' }), sourceSha256: 'issued', sizeBytes: 6,
+      contentType: 'image/jpeg', caption: null, purpose: 'gallery', attemptId: null,
+    }, now + 1)
+    await offlineDb.mediaDrafts.update(issued!.operationId, { intentId: 'intent-a' })
+    await offlineDb.raidProjections.put({
+      key: JSON.stringify(['user-a', 'raid-a']), identityId: 'user-a', raidId: 'raid-a',
+      kabandaId: 'kabanda-a', state: 'finalizing', savedAt: new Date(now + 2).toISOString(), projection: {},
+    })
+
+    expect(await reconcileAndCountUnsyncedCheckInWork(now + 3)).toBe(1)
+    expect(await offlineDb.checkInOutbox.get(checkIn!.operationId)).toMatchObject({ status: 'rejected' })
+    expect(await offlineDb.mediaDrafts.get(local!.operationId)).toMatchObject({ status: 'rejected' })
+    expect(await offlineDb.mediaDrafts.get(issued!.operationId)).toMatchObject({
+      status: 'local', intentId: 'intent-a', sourceSha256: 'issued',
+    })
+  })
+
   it('terminalizes replay work after the canonical raid leaves active without deleting evidence', async () => {
     const now = Date.parse('2026-08-28T08:00:00.000Z')
     const checkIn = await enqueueCheckIn('user-a', 'kabanda-a', 'raid-a', {

--- a/apps/pwa/src/features/checkins/store.ts
+++ b/apps/pwa/src/features/checkins/store.ts
@@ -259,6 +259,7 @@ export async function replaceExpiredMediaIntent(
 export async function claimNextMediaDraft(
   fence: CheckInSenderFence,
   now = Date.now(),
+  issuedOnly = false,
 ): Promise<MediaDraftRecord | null> {
   return offlineDb.transaction(
     'rw',
@@ -275,6 +276,7 @@ export async function claimNextMediaDraft(
       const candidate = rows
         .filter((row) => row.status === 'local' || row.status === 'intent' || row.status === 'retryable' ||
           (row.status === 'uploading' && row.claimUntil !== null && Date.parse(row.claimUntil) <= now))
+        .filter((row) => !issuedOnly || row.intentId !== null)
         .filter((row) => !row.nextAttemptAt || Date.parse(row.nextAttemptAt) <= now)
         .sort((a, b) => a.createdAt.localeCompare(b.createdAt))[0]
       if (!candidate) return null
@@ -469,7 +471,11 @@ export async function reconcileAndCountUnsyncedCheckInWork(now = Date.now()): Pr
           updatedAt: timestamp,
         }))
       const terminalMedia = media
-        .filter((row) => replayableMediaStatuses.has(row.status) && stateByRaid.has(row.raidId) && stateByRaid.get(row.raidId) !== 'active')
+        .filter((row) => {
+          if (!replayableMediaStatuses.has(row.status) || !stateByRaid.has(row.raidId)) return false
+          const state = stateByRaid.get(row.raidId)
+          return state !== 'active' && !(state === 'finalizing' && row.intentId !== null)
+        })
         .map((row) => ({
           ...row,
           status: 'rejected' as const,

--- a/apps/pwa/src/features/kabandas/KabandasPage.tsx
+++ b/apps/pwa/src/features/kabandas/KabandasPage.tsx
@@ -17,6 +17,7 @@ import {
 import { readPointProjection, savePointProjection } from './cache'
 import { choosePointPresentation, detectWebgl } from './map-state'
 import { RaidHomeCard } from '../raids/RaidHomeCard'
+import { RaidHistory } from '../results/RaidHistory'
 import type {
   KabandaMember,
   KabandaPoint,
@@ -275,6 +276,7 @@ function KabandaWorkspace({ user, kabanda, onLeft }: { user: User; kabanda: Kaba
       {message && <p className="kb-notice" role="status">{message}</p>}
 
       <RaidHomeCard identityId={user.id} kabanda={kabanda} />
+      <RaidHistory identityId={user.id} kabandaId={kabanda.id} />
 
       <div className="kb-grid">
         <section className="kb-card kb-points">

--- a/apps/pwa/src/features/offline/db.ts
+++ b/apps/pwa/src/features/offline/db.ts
@@ -12,6 +12,9 @@ import type {
   CheckInOutboxRecord,
   MediaDraftRecord,
   CheckInSenderLeaseRecord,
+  RaidResultRecord,
+  RaidHistoryRecord,
+  KabandaProgressRecord,
 } from './types'
 
 class KabandaOfflineDatabase extends Dexie {
@@ -27,6 +30,9 @@ class KabandaOfflineDatabase extends Dexie {
   checkInOutbox!: EntityTable<CheckInOutboxRecord, 'operationId'>
   mediaDrafts!: EntityTable<MediaDraftRecord, 'operationId'>
   checkInSenderLeases!: EntityTable<CheckInSenderLeaseRecord, 'key'>
+  raidResults!: EntityTable<RaidResultRecord, 'key'>
+  raidHistory!: EntityTable<RaidHistoryRecord, 'key'>
+  kabandaProgress!: EntityTable<KabandaProgressRecord, 'key'>
 
   constructor() {
     super('kabanda-offline')
@@ -100,6 +106,33 @@ class KabandaOfflineDatabase extends Dexie {
         'operationId, clientDraftId, identityId, raidId, purpose, attemptId, status, createdAt, claimUntil, [identityId+raidId+status+createdAt]',
       checkInSenderLeases:
         'key, identityId, raidId, holderTabId, expiresAt',
+    })
+    this.version(7).stores({
+      identities: 'userId, activatedAt',
+      identityContext: 'key, userId, changedAt',
+      outbox:
+        'id, identityId, kind, aggregateId, status, createdAt, [identityId+status+createdAt]',
+      pointCollections:
+        'key, identityId, kabandaId, collectionId, savedAt, [identityId+kabandaId+collectionId]',
+      raidProjections:
+        'key, identityId, raidId, kabandaId, state, savedAt, [identityId+raidId], [identityId+kabandaId+savedAt], [identityId+savedAt]',
+      routeOutbox:
+        'id, identityId, raidId, navigatorLeaseId, status, batchId, sequence, [identityId+raidId+navigatorLeaseId+status+sequence]',
+      recorderSessions:
+        'key, identityId, raidId, navigatorLeaseId, updatedAt, [identityId+raidId+updatedAt]',
+      recorderClients:
+        'key, identityId, raidId, updatedAt, [identityId+raidId]',
+      recorderWriterLeases:
+        'key, identityId, raidId, navigatorLeaseId, holderTabId, expiresAt',
+      checkInOutbox:
+        'operationId, identityId, raidId, status, createdAt, claimUntil, [identityId+raidId+status+createdAt]',
+      mediaDrafts:
+        'operationId, clientDraftId, identityId, raidId, purpose, attemptId, status, createdAt, claimUntil, [identityId+raidId+status+createdAt]',
+      checkInSenderLeases:
+        'key, identityId, raidId, holderTabId, expiresAt',
+      raidResults: 'key, identityId, raidId, kabandaId, savedAt, [identityId+raidId]',
+      raidHistory: 'key, identityId, kabandaId, savedAt, [identityId+kabandaId]',
+      kabandaProgress: 'key, identityId, kabandaId, savedAt, [identityId+kabandaId]',
     })
   }
 }

--- a/apps/pwa/src/features/offline/types.ts
+++ b/apps/pwa/src/features/offline/types.ts
@@ -43,6 +43,31 @@ export interface RaidProjectionRecord {
   projection: unknown
 }
 
+export interface RaidResultRecord {
+  key: string
+  identityId: string
+  raidId: string
+  kabandaId: string
+  savedAt: string
+  result: unknown
+}
+
+export interface RaidHistoryRecord {
+  key: string
+  identityId: string
+  kabandaId: string
+  savedAt: string
+  history: unknown
+}
+
+export interface KabandaProgressRecord {
+  key: string
+  identityId: string
+  kabandaId: string
+  savedAt: string
+  progress: unknown
+}
+
 export type RouteOutboxStatus =
   | 'pending'
   | 'sending'

--- a/apps/pwa/src/features/raids/PwaUpdateGate.tsx
+++ b/apps/pwa/src/features/raids/PwaUpdateGate.tsx
@@ -4,12 +4,19 @@ import { useRegisterSW } from 'virtual:pwa-register/react'
 import { reconcileAndCountUnsyncedCheckInWork } from '../checkins/store'
 import { shouldDeferServiceWorkerUpdate } from './recording/state'
 import { useRecordingRuntime } from './recording/runtime'
+import { reconcileAndCountUnsyncedRouteWork } from './recording/store'
 
 export function PwaUpdateGate() {
   const { phase, unsyncedCheckInWork } = useRecordingRuntime()
   const [durableUnsyncedWork, setDurableUnsyncedWork] = useState(0)
   useEffect(() => {
-    const subscription = liveQuery(reconcileAndCountUnsyncedCheckInWork).subscribe({
+    const subscription = liveQuery(async () => {
+      const [checkIns, route] = await Promise.all([
+        reconcileAndCountUnsyncedCheckInWork(),
+        reconcileAndCountUnsyncedRouteWork(),
+      ])
+      return checkIns + route
+    }).subscribe({
       next: setDurableUnsyncedWork,
       error: () => setDurableUnsyncedWork(1),
     })

--- a/apps/pwa/src/features/raids/RaidApp.tsx
+++ b/apps/pwa/src/features/raids/RaidApp.tsx
@@ -55,6 +55,9 @@ import type {
   ReadinessStatus,
 } from './types'
 import { ActiveRaidPanel } from './recording/ActiveRaidPanel'
+import { FinalizationPanel } from '../results/FinalizationPanel'
+import { ResultPanel } from '../results/ResultPanel'
+import { leaveRaid } from '../results/api'
 import './raids.css'
 
 type RaidIdentity = { id: string }
@@ -332,7 +335,10 @@ function RaidDetailPage({
     return { logical, key }
   }
 
-  const applyCommand = async (command: RaidAllowedAction, extra?: { navigatorUserId: string }) => {
+  const applyCommand = async (
+    command: Exclude<RaidAllowedAction, 'finish' | 'leave' | 'settle-finalization'>,
+    extra?: { navigatorUserId: string },
+  ) => {
     if (resource.stale || operation || !navigator.onLine) return
     const { logical, key } = keyFor(extra ? `${command}:${extra.navigatorUserId}` : command)
     setOperation(command)
@@ -357,6 +363,23 @@ function RaidDetailPage({
       } else {
         setMessage('Команда не подтверждена сервером. Повтор сохранит тот же ключ действия.')
       }
+    } finally {
+      setOperation(null)
+    }
+  }
+
+  const leaveCurrentRaid = async () => {
+    if (resource.stale || operation || !navigator.onLine || !allowed.has('leave')) return
+    if (!window.confirm('Выйти из активного рейда? Новый вклад после выхода не начисляется.')) return
+    const { logical, key } = keyFor('leave')
+    setOperation('leave')
+    setMessage(null)
+    try {
+      const next = await leaveRaid(raid.id, raid.version, key)
+      operationKeys.current.delete(logical)
+      await resource.applyRaid(next)
+    } catch (error) {
+      setMessage(error instanceof ApiError ? error.message : 'Выход не подтверждён. Повтор использует тот же ключ.')
     } finally {
       setOperation(null)
     }
@@ -476,7 +499,7 @@ function RaidDetailPage({
         </section>
       )}
 
-      {(viewerIsNavigator || raid.navigatorUserId) && (
+      {(raid.state === 'draft' || raid.state === 'planned' || raid.state === 'lobby') && (viewerIsNavigator || raid.navigatorUserId) && (
         <section className="kb-card raid-readiness">
           <div className="kb-section-head"><div><p className="kb-kicker">Перед стартом</p><h2>Готов ли телефон?</h2></div><span className={`readiness-pill readiness-pill--${readinessStatus}`}>{readinessStatus}</span></div>
           <p className="kb-muted">Проверяем только измеримое. КАБАНДА не обещает запись при выключенном экране.</p>
@@ -487,7 +510,7 @@ function RaidDetailPage({
         </section>
       )}
 
-      {(raid.state === 'active' || raid.state === 'paused' || raid.state === 'finalizing') && (
+      {(raid.state === 'active' || raid.state === 'paused') && (
         <ActiveRaidPanel
           identityId={user.id}
           raid={raid}
@@ -499,6 +522,18 @@ function RaidDetailPage({
           onApplyRaid={resource.applyRaid}
         />
       )}
+
+      {raid.state === 'finalizing' && (
+        <FinalizationPanel
+          identityId={user.id}
+          raid={raid}
+          staleProjection={resource.stale}
+          onCanonicalRefresh={resource.refresh}
+          onApplyRaid={resource.applyRaid}
+        />
+      )}
+
+      {raid.state === 'completed' && <ResultPanel identityId={user.id} raid={raid} staleOnly={resource.stale} />}
 
       {allowed.has('handoff-navigator') && !resource.stale && handoffCandidates.length > 0 && (
         <section className="kb-card raid-handoff">
@@ -535,6 +570,7 @@ function RaidDetailPage({
         <button className="kb-primary raid-primary raid-sticky" type="button" disabled={Boolean(operation) || (primary.kind === 'command' && primary.command === 'start' && !navigator.onLine)} onClick={handlePrimary}>{operation ? 'Подтверждаем…' : primary.label}</button>
       )}
       {allowed.has('cancel') && !resource.stale && <button className="raid-cancel" type="button" disabled={operation === 'cancel'} onClick={() => window.confirm('Отменить рейд для всей команды?') && applyCommand('cancel')}>Отменить рейд</button>}
+      {allowed.has('leave') && !resource.stale && <button className="raid-cancel" type="button" disabled={operation === 'leave' || !navigator.onLine} onClick={leaveCurrentRaid}>{operation === 'leave' ? 'Выходим…' : 'Выйти из рейда'}</button>}
     </RaidShell>
   )
 }

--- a/apps/pwa/src/features/raids/raids.css
+++ b/apps/pwa/src/features/raids/raids.css
@@ -489,6 +489,44 @@
   background: #f4f4f2;
 }
 
+.result-finish-review,
+.result-finalizing,
+.result-shell,
+.result-history { display: grid; gap: 1rem; }
+
+.result-inventory,
+.result-progress,
+.result-metrics { display: grid; gap: 1px; margin: 0; overflow: hidden; border: 1px solid var(--kb-line); border-radius: 14px; background: var(--kb-line); }
+.result-inventory { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.result-inventory div,
+.result-progress > div { display: grid; gap: .25rem; padding: .8rem; background: #fff; }
+.result-inventory dt,
+.result-progress span { color: var(--kb-muted); font-size: .72rem; }
+.result-inventory dd { margin: 0; font-size: 1.3rem; font-weight: 760; }
+.result-partial-confirm { display: flex; gap: .75rem; align-items: flex-start; padding: .85rem; border-radius: 14px; background: #fff4ef; }
+.result-partial-confirm input { width: 1.2rem; height: 1.2rem; }
+.result-partial-confirm span { display: grid; gap: .2rem; }
+.result-partial-confirm small { color: var(--kb-muted); }
+.result-hero { padding: 1.4rem; border-radius: 20px; background: linear-gradient(145deg, #23272e, #3a3030); color: #fff; }
+.result-hero h2 { margin: .3rem 0; font-size: clamp(1.8rem, 8vw, 3rem); }
+.result-hero p { margin: 0; color: #d8d8d5; }
+.result-hero span { display: inline-flex; margin-top: .8rem; padding: .35rem .6rem; border-radius: 999px; background: rgb(255 255 255 / 12%); font-size: .78rem; }
+.result-metrics > div { display: grid; grid-template-columns: 1.2fr 1fr 1fr; gap: .5rem; align-items: center; padding: .75rem; background: #fff; }
+.result-metrics__head { color: var(--kb-muted); font-size: .72rem; }
+.result-metrics strong { text-align: right; }
+.result-participants { display: grid; gap: .6rem; margin: 0; padding: 0; list-style: none; }
+.result-participants li { display: flex; justify-content: space-between; gap: 1rem; }
+.result-participants span { color: var(--kb-muted); font-size: .8rem; text-align: right; }
+.result-share { display: grid; gap: .8rem; }
+.result-share img { width: 100%; border-radius: 14px; }
+.result-next { display: block; width: 100%; text-align: center; }
+.result-progress { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.result-progress small { color: var(--kb-muted); }
+.result-history__list { display: grid; gap: .65rem; }
+.result-history__list a { display: grid; gap: .45rem; padding: .9rem; border: 1px solid var(--kb-line); border-radius: 14px; color: inherit; text-decoration: none; }
+.result-history__list a > span { display: grid; gap: .1rem; }
+.result-history__list a > span:last-child { color: var(--kb-muted); font-size: .82rem; }
+
 @media (max-width: 620px) {
   .raid-shell > .kb-brand { margin-bottom: 25px; }
   .raid-hero { align-items: flex-start; flex-direction: column; }
@@ -509,4 +547,6 @@
   .raid-assign label { grid-column: auto; }
   .raid-participants li { align-items: flex-start; }
   .participant-state { max-width: 78px; }
+  .result-inventory { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .result-progress { grid-template-columns: 1fr; }
 }

--- a/apps/pwa/src/features/raids/recording/ActiveRaidPanel.tsx
+++ b/apps/pwa/src/features/raids/recording/ActiveRaidPanel.tsx
@@ -3,6 +3,7 @@ import type { RaidProjection } from '../types'
 import { routeStatusLabel, selectActivePrimaryAction, wakeLockLabel } from './state'
 import { useRouteRecorder } from './useRouteRecorder'
 import { CheckInPanel } from '../../checkins/CheckInPanel'
+import { FinishRaidPanel } from '../../results/FinishRaidPanel'
 
 export function ActiveRaidPanel({
   identityId,
@@ -67,6 +68,15 @@ export function ActiveRaidPanel({
         </button>
       )}
     </section>
+    {(raid.state === 'active' || raid.state === 'paused') && (
+      <FinishRaidPanel
+        identityId={identityId}
+        raid={raid}
+        flushRoute={recorder.flush}
+        onApplyRaid={onApplyRaid}
+        onCanonicalRefresh={onCanonicalRefresh}
+      />
+    )}
     </>
   )
 }

--- a/apps/pwa/src/features/raids/recording/store.test.ts
+++ b/apps/pwa/src/features/raids/recording/store.test.ts
@@ -11,6 +11,7 @@ import {
   completeRouteLeaseAttempt,
   markRouteBatchRetryable,
   persistRouteSample,
+  reconcileAndCountUnsyncedRouteWork,
   settleRouteBatch,
   WRITER_LEASE_TTL_MS,
 } from './store'
@@ -122,5 +123,26 @@ describe('fenced route storage', () => {
     }
     expect(await settleRouteBatch(context, fence!, batch!.batchId, complete, now + 1_300)).toBe(true)
     expect((await offlineDb.routeOutbox.where('batchId').equals(batch!.batchId).toArray()).every(({ status }) => status === 'accepted')).toBe(true)
+  })
+
+  it('retains but terminalizes route evidence at the canonical finalization cutoff', async () => {
+    const now = Date.parse('2026-08-28T08:00:00.000Z')
+    await getOrCreateRecorderSession(context, now)
+    const fence = await acquireWriterLease(context, 'tab-a', now)
+    const persisted = await persistRouteSample(context, fence!, sample(1), now + 1_000)
+    expect(await reconcileAndCountUnsyncedRouteWork(now + 1_001)).toBe(1)
+    await offlineDb.raidProjections.put({
+      key: JSON.stringify(['user-a', 'raid-a']), identityId: 'user-a', raidId: 'raid-a',
+      kabandaId: 'kabanda-a', state: 'finalizing', savedAt: new Date(now + 2_000).toISOString(), projection: {},
+    })
+
+    expect(await reconcileAndCountUnsyncedRouteWork(now + 2_001)).toBe(1)
+    expect(await offlineDb.routeOutbox.get(persisted!.id)).toMatchObject({
+      status: 'rejected',
+      latitude: sample(1).latitude,
+      lastErrorCode: 'RAID_FINALIZATION_CUTOFF_LOCAL_RECONCILIATION',
+    })
+    await offlineDb.raidProjections.update(JSON.stringify(['user-a', 'raid-a']), { state: 'completed' })
+    expect(await reconcileAndCountUnsyncedRouteWork(now + 3_000)).toBe(0)
   })
 })

--- a/apps/pwa/src/features/raids/recording/store.ts
+++ b/apps/pwa/src/features/raids/recording/store.ts
@@ -556,3 +556,51 @@ export async function getRecorderLocalStats(
     lastPersistedSampleAt: session.lastPersistedSampleAt,
   }
 }
+
+const replayableRouteStatuses = new Set<RouteOutboxRecord['status']>([
+  'pending',
+  'sending',
+  'retryable',
+])
+
+/**
+ * Reconciles route work against the active identity's canonical raid cache.
+ * Finalization closes route ingestion, so those rows become retained terminal
+ * diagnostics instead of being replayed forever or blocking an SW update.
+ */
+export async function reconcileAndCountUnsyncedRouteWork(now = Date.now()): Promise<number> {
+  return offlineDb.transaction(
+    'rw',
+    offlineDb.identityContext,
+    offlineDb.raidProjections,
+    offlineDb.routeOutbox,
+    async () => {
+      const identityId = (await offlineDb.identityContext.get('active'))?.userId
+      if (!identityId) return 0
+      const [projections, rows] = await Promise.all([
+        offlineDb.raidProjections.where('identityId').equals(identityId).toArray(),
+        offlineDb.routeOutbox.where('identityId').equals(identityId).toArray(),
+      ])
+      const stateByRaid = new Map(projections.map((projection) => [projection.raidId, projection.state]))
+      const closedStates = new Set(['finalizing', 'completed', 'cancelled'])
+      const timestamp = new Date(now).toISOString()
+      const terminal = rows
+        .filter((row) => replayableRouteStatuses.has(row.status) && closedStates.has(stateByRaid.get(row.raidId) ?? ''))
+        .map((row) => ({
+          ...row,
+          status: 'rejected' as const,
+          claimUntil: null,
+          nextAttemptAt: null,
+          lastErrorCode: stateByRaid.get(row.raidId) === 'finalizing'
+            ? 'RAID_FINALIZATION_CUTOFF_LOCAL_RECONCILIATION'
+            : 'RAID_CLOSED_LOCAL_RECONCILIATION',
+        }))
+      if (terminal.length) await offlineDb.routeOutbox.bulkPut(terminal)
+      const terminalIds = new Set(terminal.map(({ id }) => id))
+      const replayable = rows.filter((row) => replayableRouteStatuses.has(row.status) && !terminalIds.has(row.id)).length
+      // Reloading while the server is collecting known tails can strand the
+      // finalization runner even after the route cutoff has been reconciled.
+      return replayable + (projections.some(({ state }) => state === 'finalizing') ? 1 : 0)
+    },
+  )
+}

--- a/apps/pwa/src/features/raids/recording/types.ts
+++ b/apps/pwa/src/features/raids/recording/types.ts
@@ -69,7 +69,7 @@ export interface RouteRecorderView {
   routeStatus: RouteStatusProjection
   message: string | null
   recover: () => void
-  flush: () => void
+  flush: () => Promise<void>
 }
 
 export type StoredRecorderSession = RecorderSessionRecord

--- a/apps/pwa/src/features/raids/recording/useRouteRecorder.ts
+++ b/apps/pwa/src/features/raids/recording/useRouteRecorder.ts
@@ -66,7 +66,7 @@ export function useRouteRecorder(input: {
   const [message, setMessage] = useState<string | null>(null)
   const [recoverNonce, setRecoverNonce] = useState(0)
   const leaseRequestInFlight = useRef(false)
-  const flushRef = useRef<() => void>(() => undefined)
+  const flushRef = useRef<() => Promise<void>>(async () => undefined)
   const previousContext = useRef<RecorderContext | null>(null)
   const { setPhase: setRuntimePhase } = useRecordingRuntime()
   const tabId = useRef(getTabId()).current
@@ -172,7 +172,7 @@ export function useRouteRecorder(input: {
     if (!eligible || !context) {
       setPhase(raid.state === 'paused' ? 'paused' : 'ineligible')
       setStats(emptyStats)
-      flushRef.current = () => undefined
+      flushRef.current = async () => undefined
       return
     }
 
@@ -286,7 +286,7 @@ export function useRouteRecorder(input: {
         replaying = false
       }
     }
-    flushRef.current = () => void flush()
+    flushRef.current = flush
 
     const startPageRecorder = async () => {
       if (cancelled || starting || document.visibilityState !== 'visible') return
@@ -428,7 +428,7 @@ export function useRouteRecorder(input: {
 
     return () => {
       cancelled = true
-      flushRef.current = () => undefined
+      flushRef.current = async () => undefined
       document.removeEventListener('visibilitychange', handleVisibility)
       window.removeEventListener('online', handleResume)
       window.removeEventListener('focus', handleResume)

--- a/apps/pwa/src/features/raids/state.test.ts
+++ b/apps/pwa/src/features/raids/state.test.ts
@@ -29,6 +29,7 @@ const raid: RaidProjection = {
     missingSequenceCount: 0,
   },
   navigatorLease: null,
+  finalization: null,
   participants: [],
   allowedActions: [],
 }

--- a/apps/pwa/src/features/raids/state.ts
+++ b/apps/pwa/src/features/raids/state.ts
@@ -11,7 +11,7 @@ import type {
 
 export type RaidPrimaryAction =
   | { kind: 'navigate'; label: string }
-  | { kind: 'command'; command: RaidAllowedAction; label: string }
+  | { kind: 'command'; command: Exclude<RaidAllowedAction, 'finish' | 'leave' | 'settle-finalization'>; label: string }
   | { kind: 'readiness'; label: string }
   | { kind: 'refresh'; label: string }
 

--- a/apps/pwa/src/features/raids/types.ts
+++ b/apps/pwa/src/features/raids/types.ts
@@ -25,6 +25,9 @@ export type RaidAllowedAction =
   | 'resume'
   | 'cancel'
   | 'handoff-navigator'
+  | 'finish'
+  | 'leave'
+  | 'settle-finalization'
   | 'accept'
   | 'decline'
   | 'ready'
@@ -76,8 +79,17 @@ export interface RaidProjection {
   navigatorWarnings: string[]
   routeStatus: RouteStatusProjection
   navigatorLease: NavigatorLeaseProjection | null
+  finalization: RaidFinalizationProjection | null
   participants: RaidParticipant[]
   allowedActions: RaidAllowedAction[]
+}
+
+export interface RaidFinalizationProjection {
+  status: 'collecting'
+  partial: boolean
+  pendingCounts: { claims: number; fallbacks: number; media: number }
+  deadlineAt: string
+  canSettle: boolean
 }
 
 export interface RouteBatchSample {

--- a/apps/pwa/src/features/results/FinalizationPanel.tsx
+++ b/apps/pwa/src/features/results/FinalizationPanel.tsx
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ApiError } from '../../lib/http'
+import { CheckInPanel } from '../checkins/CheckInPanel'
+import type { RaidProjection } from '../raids/types'
+import { settleFinalization } from './api'
+import { saveRaidResult } from './cache'
+import { drainFinalizingServerTail } from './local'
+import {
+  readResultOperationAttempt,
+  resultOperationStorageKey,
+  saveResultOperationAttempt,
+  selectResultOperationAttempt,
+  type ResultOperationAttempt,
+} from './operation'
+
+export function FinalizationPanel({
+  identityId,
+  raid,
+  staleProjection,
+  onCanonicalRefresh,
+  onApplyRaid,
+}: {
+  identityId: string
+  raid: RaidProjection
+  staleProjection: boolean
+  onCanonicalRefresh: () => Promise<unknown>
+  onApplyRaid: (raid: RaidProjection) => Promise<unknown>
+}) {
+  const [busy, setBusy] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+  const attempt = useRef<ResultOperationAttempt<{ expectedVersion: number }> | null>(null)
+  const drainInFlight = useRef(false)
+  const drainTimer = useRef<number | null>(null)
+  const drainRef = useRef<() => void>(() => undefined)
+  const drainGeneration = useRef(0)
+  const storageKey = resultOperationStorageKey('settle', identityId, raid.id)
+  const finalization = raid.finalization
+  const deadlineAt = finalization?.deadlineAt ?? null
+
+  const drain = useCallback(async () => {
+    if (
+      drainInFlight.current ||
+      staleProjection ||
+      !navigator.onLine ||
+      document.visibilityState !== 'visible'
+    ) return
+    const generation = drainGeneration.current
+    drainInFlight.current = true
+    try {
+      const result = await drainFinalizingServerTail({ identityId, raidId: raid.id, online: true })
+      await onCanonicalRefresh()
+      const beforeDeadline = deadlineAt && Date.parse(deadlineAt) > Date.now()
+      if (result.mayHaveMore && beforeDeadline && drainGeneration.current === generation) {
+        if (drainTimer.current !== null) window.clearTimeout(drainTimer.current)
+        drainTimer.current = window.setTimeout(() => drainRef.current(), 500)
+      }
+    } finally {
+      drainInFlight.current = false
+    }
+  }, [deadlineAt, identityId, onCanonicalRefresh, raid.id, staleProjection])
+
+  useEffect(() => {
+    drainGeneration.current += 1
+    attempt.current = readResultOperationAttempt(storageKey)
+    drainRef.current = () => void drain().catch(() => undefined)
+    drainRef.current()
+    const resume = () => drainRef.current()
+    window.addEventListener('online', resume)
+    window.addEventListener('focus', resume)
+    document.addEventListener('visibilitychange', resume)
+    return () => {
+      drainGeneration.current += 1
+      window.removeEventListener('online', resume)
+      window.removeEventListener('focus', resume)
+      document.removeEventListener('visibilitychange', resume)
+      if (drainTimer.current !== null) window.clearTimeout(drainTimer.current)
+    }
+  }, [drain, storageKey])
+
+  const settle = async () => {
+    if (busy || staleProjection || !navigator.onLine || !raid.allowedActions.includes('settle-finalization')) return
+    setBusy(true)
+    setMessage(null)
+    const payload = { expectedVersion: raid.version }
+    const selected = selectResultOperationAttempt(attempt.current, JSON.stringify([raid.id, payload]), payload)
+    attempt.current = selected
+    saveResultOperationAttempt(storageKey, selected)
+    try {
+      const response = await settleFinalization(raid.id, selected.payload.expectedVersion, selected.key)
+      await saveRaidResult(identityId, response.result)
+      await onApplyRaid(response.raid)
+    } catch (error) {
+      setMessage(error instanceof ApiError ? error.message : 'Итог ещё не подтверждён. Повтор использует тот же ключ.')
+      await onCanonicalRefresh()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <>
+      <section className="kb-card result-finalizing">
+        <p className="kb-kicker">Каноническая финализация</p>
+        <h2>Сервер собирает итог</h2>
+        <p className="kb-muted">Новый маршрут, check-in и media intent уже не создаются. Принимаются только известные серверу хвосты.</p>
+        {finalization ? (
+          <>
+            <dl className="result-inventory">
+              <div><dt>Claims</dt><dd>{finalization.pendingCounts.claims}</dd></div>
+              <div><dt>Fallbacks</dt><dd>{finalization.pendingCounts.fallbacks}</dd></div>
+              <div><dt>Media</dt><dd>{finalization.pendingCounts.media}</dd></div>
+            </dl>
+            <p className="kb-muted">Deadline: {new Date(finalization.deadlineAt).toLocaleString('ru-RU')}{finalization.partial ? ' · итог будет partial' : ''}</p>
+          </>
+        ) : <p className="kb-muted">Обновляем finalization projection…</p>}
+        {message && <p className="kb-notice" role="status">{message}</p>}
+        {raid.allowedActions.includes('settle-finalization') && !staleProjection && (
+          <button className="kb-primary raid-primary" type="button" disabled={busy || !navigator.onLine} onClick={settle}>{busy ? 'Фиксируем…' : 'Зафиксировать итог'}</button>
+        )}
+        {!raid.allowedActions.includes('settle-finalization') && <button className="kb-link-button" type="button" disabled={staleProjection || !navigator.onLine} onClick={() => drainRef.current()}>Проверить статус</button>}
+      </section>
+      <CheckInPanel
+        identityId={identityId}
+        raid={raid}
+        staleProjection={staleProjection}
+        onCanonicalRefresh={onCanonicalRefresh}
+        serverTailOnly
+      />
+    </>
+  )
+}

--- a/apps/pwa/src/features/results/FinishRaidPanel.tsx
+++ b/apps/pwa/src/features/results/FinishRaidPanel.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useRef, useState } from 'react'
+import { ApiError } from '../../lib/http'
+import type { RaidProjection } from '../raids/types'
+import { finishRaid } from './api'
+import { drainForegroundRaidWork, getFinishLocalReview } from './local'
+import {
+  readResultOperationAttempt,
+  resultOperationStorageKey,
+  saveResultOperationAttempt,
+  selectResultOperationAttempt,
+  type ResultOperationAttempt,
+} from './operation'
+import {
+  finishNeedsPartialConfirmation,
+  pendingInventoryCount,
+  replayableInventoryCount,
+  selectFinishPrimary,
+} from './state'
+import type { FinishLocalReview } from './types'
+
+export function FinishRaidPanel({
+  identityId,
+  raid,
+  flushRoute,
+  onApplyRaid,
+  onCanonicalRefresh,
+}: {
+  identityId: string
+  raid: RaidProjection
+  flushRoute: () => Promise<void> | void
+  onApplyRaid: (raid: RaidProjection) => Promise<unknown>
+  onCanonicalRefresh: () => Promise<unknown>
+}) {
+  const [review, setReview] = useState<FinishLocalReview | null>(null)
+  const [partialConfirmed, setPartialConfirmed] = useState(false)
+  const [drainAttempted, setDrainAttempted] = useState(false)
+  const [busy, setBusy] = useState<'drain' | 'finish' | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+  const attempt = useRef<ResultOperationAttempt<{
+    expectedVersion: number
+    inventory: FinishLocalReview['inventory']
+    confirmPartial: boolean
+  }> | null>(null)
+  const storageKey = resultOperationStorageKey('finish', identityId, raid.id)
+
+  useEffect(() => {
+    attempt.current = readResultOperationAttempt(storageKey)
+    if (attempt.current) {
+      setPartialConfirmed(attempt.current.payload.confirmPartial)
+      setDrainAttempted(true)
+    }
+    void getFinishLocalReview(identityId, raid.id).then(setReview)
+  }, [identityId, raid.id, storageKey])
+
+  if (!raid.allowedActions.includes('finish')) return null
+  const pending = review ? replayableInventoryCount(review) : 0
+  const effectivePartialConfirmed = partialConfirmed && (pending === 0 || drainAttempted)
+  const primary = review ? selectFinishPrimary(review, effectivePartialConfirmed, navigator.onLine) : null
+  const unresolved = review ? finishNeedsPartialConfirmation(review) : false
+
+  const drain = async () => {
+    if (busy || !navigator.onLine) return
+    setBusy('drain')
+    setMessage(null)
+    try {
+      const next = await drainForegroundRaidWork({
+        identityId, raidId: raid.id, flushRoute, online: true,
+      })
+      setReview(next)
+      setDrainAttempted(true)
+      if (next && pendingInventoryCount(next) > 0) {
+        setMessage('Не всё получило receipt. Можно повторить отправку или явно завершить с неполным итогом.')
+      }
+    } catch {
+      setMessage('Foreground drain не завершился. Локальные данные сохранены; повторите или подтвердите partial.')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const finish = async () => {
+    if (!review || busy || !navigator.onLine || (unresolved && !effectivePartialConfirmed)) return
+    setBusy('finish')
+    setMessage(null)
+    const payload = { expectedVersion: raid.version, inventory: review.inventory, confirmPartial: effectivePartialConfirmed }
+    const fingerprint = JSON.stringify([raid.id, payload])
+    const selected = selectResultOperationAttempt(attempt.current, fingerprint, payload)
+    attempt.current = selected
+    saveResultOperationAttempt(storageKey, selected)
+    try {
+      const response = await finishRaid(
+        raid.id,
+        selected.payload.expectedVersion,
+        selected.payload.inventory,
+        selected.payload.confirmPartial,
+        selected.key,
+      )
+      // Keep the exact payload/key through remounts until ResultPanel observes
+      // the canonical completed result. A finish receipt may still be a stale
+      // finalizing projection after a lost response.
+      await onApplyRaid(response.raid)
+      await onCanonicalRefresh()
+    } catch (error) {
+      setMessage(error instanceof ApiError ? error.message : 'Завершение не подтверждено. Повтор использует тот же idempotency key.')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  return (
+    <section className="kb-card result-finish-review">
+      <div className="kb-section-head"><div><p className="kb-kicker">Перед финишем</p><h2>Что ещё ждёт receipt</h2></div></div>
+      {!review ? <p className="kb-muted" aria-busy="true">Проверяем локальную очередь…</p> : (
+        <>
+          <dl className="result-inventory">
+            <div><dt>Маршрут</dt><dd>{review.inventory.routePending}</dd></div>
+            <div><dt>Чекины</dt><dd>{review.inventory.checkInsPending}</dd></div>
+            <div><dt>Фото</dt><dd>{review.inventory.mediaPending}</dd></div>
+            <div><dt>Нужно действие</dt><dd>{review.inventory.needsAction}</dd></div>
+          </dl>
+          {unresolved && (pending === 0 || drainAttempted) && (
+            <label className="result-partial-confirm">
+              <input type="checkbox" checked={partialConfirmed} onChange={(event) => setPartialConfirmed(event.target.checked)} />
+              <span><strong>Подтверждаю неполный итог</strong><small>Непринятые сервером данные не попадут в канонические метрики.</small></span>
+            </label>
+          )}
+        </>
+      )}
+      {message && <p className="kb-notice" role="status">{message}</p>}
+      {primary === 'drain' && <button className="kb-link-button" type="button" disabled={Boolean(busy)} onClick={drain}>{busy === 'drain' ? 'Досылаем…' : 'Дослать сохранённое'}</button>}
+      {primary === 'finish' && <button className="kb-link-button" type="button" disabled={Boolean(busy)} onClick={finish}>{busy === 'finish' ? 'Завершаем…' : unresolved ? 'Завершить с неполным итогом' : 'Завершить рейд'}</button>}
+    </section>
+  )
+}

--- a/apps/pwa/src/features/results/RaidHistory.tsx
+++ b/apps/pwa/src/features/results/RaidHistory.tsx
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useState } from 'react'
+import { appPath } from '../../lib/paths'
+import { getKabandaProgress, listRaidHistory } from './api'
+import {
+  readKabandaProgress,
+  readRaidHistory,
+  saveKabandaProgress,
+  saveRaidHistory,
+  newestFirst,
+} from './cache'
+import { formatDistance } from './state'
+import type { KabandaProgress, RaidHistoryItem } from './types'
+
+export function RaidHistory({ identityId, kabandaId }: { identityId: string; kabandaId: string }) {
+  const [raids, setRaids] = useState<RaidHistoryItem[]>([])
+  const [progress, setProgress] = useState<KabandaProgress | null>(null)
+  const [staleAt, setStaleAt] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const refresh = useCallback(async () => {
+    const [historyResult, progressResult] = await Promise.allSettled([
+      listRaidHistory(kabandaId, 12),
+      getKabandaProgress(kabandaId),
+    ])
+    let stale: string | null = null
+    if (historyResult.status === 'fulfilled') {
+      setRaids(newestFirst(historyResult.value).raids)
+      await saveRaidHistory(identityId, kabandaId, historyResult.value)
+    } else {
+      const cached = await readRaidHistory(identityId, kabandaId)
+      if (cached) { setRaids(cached.page.raids); stale = cached.savedAt }
+    }
+    if (progressResult.status === 'fulfilled') {
+      setProgress(progressResult.value)
+      await saveKabandaProgress(identityId, kabandaId, progressResult.value)
+    } else {
+      const cached = await readKabandaProgress(identityId, kabandaId)
+      if (cached) { setProgress(cached.progress); stale = stale ?? cached.savedAt }
+    }
+    setStaleAt(stale)
+    setLoading(false)
+  }, [identityId, kabandaId])
+
+  useEffect(() => {
+    void refresh()
+    const resume = () => {
+      if (document.visibilityState === 'visible' && navigator.onLine) void refresh()
+    }
+    window.addEventListener('online', resume)
+    window.addEventListener('focus', resume)
+    document.addEventListener('visibilitychange', resume)
+    return () => {
+      window.removeEventListener('online', resume)
+      window.removeEventListener('focus', resume)
+      document.removeEventListener('visibilitychange', resume)
+    }
+  }, [refresh])
+
+  return (
+    <section className="kb-card result-history">
+      <div className="kb-section-head"><div><p className="kb-kicker">Канонические данные</p><h2>История рейдов</h2></div></div>
+      {staleAt && <p className="kb-stale">Сохранённая копия от {new Date(staleAt).toLocaleString('ru-RU')} — только для этого аккаунта.</p>}
+      {progress && <div className="result-progress"><div><span>Лично</span><strong>{progress.personal.completedRaids} рейдов</strong><small>{formatDistance(progress.personal.distanceMeters)} · {progress.personal.uniquePoints} точек</small></div><div><span>Команда</span><strong>{progress.team.completedRaids} рейдов</strong><small>{formatDistance(progress.team.distanceMeters)} · {progress.team.uniquePoints} точек</small></div></div>}
+      {loading && <p className="kb-muted" aria-busy="true">Загружаем последние результаты…</p>}
+      {!loading && raids.length === 0 && <p className="kb-muted">Завершённых рейдов пока нет.</p>}
+      <div className="result-history__list">{raids.slice(0, 12).map((raid) => (
+        <a key={raid.raidId} href={`${appPath('app')}?raid=${encodeURIComponent(raid.raidId)}`}>
+          <span><small>{new Date(raid.completedAt).toLocaleDateString('ru-RU')}{raid.partial ? ' · partial' : ''}</small><strong>{raid.title}</strong></span>
+          <span>{formatDistance(raid.team.distanceMeters)} · {raid.team.uniquePoints} точек · {raid.team.photos} фото</span>
+        </a>
+      ))}</div>
+    </section>
+  )
+}

--- a/apps/pwa/src/features/results/ResultPanel.tsx
+++ b/apps/pwa/src/features/results/ResultPanel.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from 'react'
+import { ApiError } from '../../lib/http'
+import { appPath } from '../../lib/paths'
+import type { RaidProjection } from '../raids/types'
+import { getRaidResult, getShareCard } from './api'
+import { readRaidResult, saveRaidResult } from './cache'
+import { clearResultOperationAttempt, resultOperationStorageKey } from './operation'
+import { shareResultCard } from './share'
+import { metricRows } from './state'
+import type { RaidResult } from './types'
+
+export function ResultPanel({
+  identityId,
+  raid,
+  staleOnly,
+}: {
+  identityId: string
+  raid: RaidProjection
+  staleOnly: boolean
+}) {
+  const [result, setResult] = useState<RaidResult | null>(null)
+  const [staleAt, setStaleAt] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [card, setCard] = useState<{ blob: Blob; url: string } | null>(null)
+  const [shareMessage, setShareMessage] = useState<string | null>(null)
+  const viewerIsOwner = raid.organizerUserId === identityId
+
+  useEffect(() => {
+    let active = true
+    const load = async () => {
+      if (!staleOnly) {
+        try {
+          const canonical = await getRaidResult(raid.id)
+          if (!active) return
+          setResult(canonical)
+          setStaleAt(null)
+          setError(null)
+          await saveRaidResult(identityId, canonical)
+          const finishKey = resultOperationStorageKey('finish', identityId, raid.id)
+          const finishAttempt = readSessionKey(finishKey)
+          if (finishAttempt) clearResultOperationAttempt(finishKey, finishAttempt)
+          const settleKey = resultOperationStorageKey('settle', identityId, raid.id)
+          const settleAttempt = readSessionKey(settleKey)
+          if (settleAttempt) clearResultOperationAttempt(settleKey, settleAttempt)
+          return
+        } catch (reason) {
+          if (reason instanceof ApiError && reason.status < 500) {
+            if (active) setError(reason.message)
+            return
+          }
+        }
+      }
+      const cached = await readRaidResult(identityId, raid.id)
+      if (!active) return
+      if (cached) {
+        setResult(cached.result)
+        setStaleAt(cached.savedAt)
+      } else setError('Канонический итог ещё не сохранён на этом устройстве.')
+    }
+    void load()
+    return () => { active = false }
+  }, [identityId, raid.id, staleOnly])
+
+  useEffect(() => {
+    if (!result || staleOnly || !navigator.onLine) return
+    let active = true
+    let url: string | null = null
+    getShareCard(raid.id).then((blob) => {
+      if (!active) return
+      url = URL.createObjectURL(blob)
+      setCard({ blob, url })
+    }).catch(() => undefined)
+    return () => {
+      active = false
+      if (url) URL.revokeObjectURL(url)
+    }
+  }, [raid.id, result, staleOnly])
+
+  if (!result) return <section className="kb-card" aria-busy={!error}><h2>Собираем канонический итог…</h2>{error && <p className="kb-error">{error}</p>}</section>
+  const rows = metricRows(result.personal, result.team)
+  const share = async () => {
+    if (!card) return
+    try {
+      const outcome = await shareResultCard(card.blob, result.raid.title, `kabanda-${result.raid.id}.png`)
+      setShareMessage(outcome === 'shared' ? 'Карточка передана системному меню.' : 'Карточка скачана на устройство.')
+    } catch {
+      setShareMessage('Не удалось поделиться. Карточку можно скачать повторным нажатием.')
+    }
+  }
+  return (
+    <section className="result-shell">
+      <article className="result-hero">
+        <p className="kb-kicker">Канонический итог</p>
+        <h2>{result.raid.title}</h2>
+        <p>{new Date(result.raid.completedAt).toLocaleString('ru-RU')}</p>
+        {result.raid.partial && <span>Partial · непринятые операции не включены</span>}
+      </article>
+      {staleAt && <p className="kb-stale">Сохранённая identity-bound копия от {new Date(staleAt).toLocaleString('ru-RU')}.</p>}
+      <div className="result-metrics" role="table" aria-label="Личные и командные метрики">
+        <div className="result-metrics__head" role="row"><span>Метрика</span><strong>Лично</strong><strong>Команда</strong></div>
+        {rows.map((row) => <div key={row.id} role="row"><span>{row.label}</span><strong>{row.personal}</strong><strong>{row.team}</strong></div>)}
+      </div>
+      <section className="kb-card"><p className="kb-kicker">Участники</p><ul className="result-participants">{result.participants.map((participant) => <li key={participant.userId}><strong>{participant.displayName}</strong><span>{participant.metrics.uniquePoints} точек · {participant.metrics.photos} фото</span></li>)}</ul></section>
+      {card && <section className="kb-card result-share"><img src={card.url} alt="Приватная карточка результата без маршрута и внутренних ID" /><button className="kb-link-button" type="button" onClick={share}>Поделиться карточкой</button>{shareMessage && <p className="kb-muted" role="status">{shareMessage}</p>}</section>}
+      {viewerIsOwner ? <a className="kb-primary raid-primary result-next" href={`${appPath('app')}?createRaid=${encodeURIComponent(result.raid.kabandaId)}`}>Запланировать следующий рейд</a> : <a className="kb-link-button result-next" href={`${appPath('app')}?kabanda=${encodeURIComponent(result.raid.kabandaId)}`}>Вернуться к истории</a>}
+    </section>
+  )
+}
+
+function readSessionKey(storageKey: string): string | null {
+  try {
+    const value = JSON.parse(sessionStorage.getItem(storageKey) ?? 'null') as { key?: unknown } | null
+    return typeof value?.key === 'string' ? value.key : null
+  } catch {
+    return null
+  }
+}

--- a/apps/pwa/src/features/results/api.test.ts
+++ b/apps/pwa/src/features/results/api.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { finishRaid } from './api'
+
+describe('finish API contract', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('sends bounded needsAction inside the immutable inventory', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ raid: {}, finalization: {} }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    await finishRaid('raid-a', 8, {
+      routePending: 0,
+      checkInsPending: 0,
+      mediaPending: 0,
+      needsAction: 2,
+    }, true, 'finish-key')
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/raids/raid-a/commands/finish', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({ 'Idempotency-Key': 'finish-key' }),
+      body: JSON.stringify({
+        expectedVersion: 8,
+        inventory: { routePending: 0, checkInsPending: 0, mediaPending: 0, needsAction: 2 },
+        confirmPartial: true,
+      }),
+    }))
+  })
+})

--- a/apps/pwa/src/features/results/api.ts
+++ b/apps/pwa/src/features/results/api.ts
@@ -1,0 +1,93 @@
+import { ApiError, requestJson } from '../../lib/http'
+import type { RaidProjection } from '../raids/types'
+import type {
+  FinishInventory,
+  FinishRaidResponse,
+  KabandaProgress,
+  RaidHistoryPage,
+  RaidResult,
+  SettleRaidResponse,
+} from './types'
+
+const raidBase = (raidId: string) => `/api/raids/${encodeURIComponent(raidId)}`
+
+export function finishRaid(
+  raidId: string,
+  expectedVersion: number,
+  inventory: FinishInventory,
+  confirmPartial: boolean,
+  idempotencyKey: string,
+): Promise<FinishRaidResponse> {
+  return requestJson(`${raidBase(raidId)}/commands/finish`, {
+    method: 'POST',
+    headers: { 'Idempotency-Key': idempotencyKey },
+    body: JSON.stringify({ expectedVersion, inventory, confirmPartial }),
+  })
+}
+
+export function settleFinalization(
+  raidId: string,
+  expectedVersion: number,
+  idempotencyKey: string,
+): Promise<SettleRaidResponse> {
+  return requestJson(`${raidBase(raidId)}/finalization/settle`, {
+    method: 'POST',
+    headers: { 'Idempotency-Key': idempotencyKey },
+    body: JSON.stringify({ expectedVersion }),
+  })
+}
+
+export async function leaveRaid(
+  raidId: string,
+  expectedVersion: number,
+  idempotencyKey: string,
+): Promise<RaidProjection> {
+  const response = await requestJson<{ raid: RaidProjection }>(
+    `${raidBase(raidId)}/participants/me/leave`,
+    {
+      method: 'POST',
+      headers: { 'Idempotency-Key': idempotencyKey },
+      body: JSON.stringify({ expectedVersion }),
+    },
+  )
+  return response.raid
+}
+
+export async function getRaidResult(raidId: string): Promise<RaidResult> {
+  return (await requestJson<{ result: RaidResult }>(`${raidBase(raidId)}/result`)).result
+}
+
+export function listRaidHistory(
+  kabandaId: string,
+  limit = 12,
+  cursor?: string,
+): Promise<RaidHistoryPage> {
+  const query = new URLSearchParams({ limit: String(Math.min(Math.max(limit, 1), 20)) })
+  if (cursor) query.set('cursor', cursor)
+  return requestJson(`/api/kabandas/${encodeURIComponent(kabandaId)}/raids/history?${query}`)
+}
+
+export async function getKabandaProgress(kabandaId: string): Promise<KabandaProgress> {
+  return (await requestJson<{ progress: KabandaProgress }>(
+    `/api/kabandas/${encodeURIComponent(kabandaId)}/progress`,
+  )).progress
+}
+
+export async function getShareCard(raidId: string): Promise<Blob> {
+  const response = await fetch(`${raidBase(raidId)}/share-card`, {
+    credentials: 'same-origin',
+    cache: 'no-store',
+  })
+  if (!response.ok) {
+    let error: { code?: string; message?: string } = {}
+    try {
+      error = (await response.json()).error ?? {}
+    } catch {
+      // The private image endpoint may return an empty error body.
+    }
+    throw new ApiError(error.code ?? 'SHARE_CARD_FAILED', error.message ?? 'Карточка недоступна', response.status)
+  }
+  const blob = await response.blob()
+  if (blob.type !== 'image/png') throw new ApiError('SHARE_CARD_INVALID', 'Сервер вернул неверный формат карточки', 502)
+  return blob
+}

--- a/apps/pwa/src/features/results/cache.test.ts
+++ b/apps/pwa/src/features/results/cache.test.ts
@@ -1,0 +1,50 @@
+import 'fake-indexeddb/auto'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { activateIdentity } from '../offline/ledger'
+import { offlineDb } from '../offline/db'
+import { newestFirst, readRaidResult, saveRaidResult } from './cache'
+import type { RaidHistoryPage, RaidResult } from './types'
+
+const metrics = { durationSeconds: 60, distanceMeters: 1000, uniquePoints: 1, photos: 1 }
+const result: RaidResult = {
+  schemaVersion: 1,
+  raid: {
+    id: 'raid-a', kabandaId: 'kabanda-a', title: 'Рейд', startedAt: '2026-08-28T08:00:00.000Z',
+    completedAt: '2026-08-28T09:00:00.000Z', partial: false,
+  },
+  team: metrics,
+  personal: metrics,
+  participants: [],
+}
+
+describe('identity-bound result cache', () => {
+  beforeEach(async () => {
+    await offlineDb.delete()
+    await offlineDb.open()
+    await activateIdentity('user-a')
+  })
+  afterEach(async () => { await offlineDb.delete() })
+
+  it('does not expose user A result after account switch', async () => {
+    await saveRaidResult('user-a', result)
+    expect((await readRaidResult('user-a', 'raid-a'))?.result).toEqual(result)
+    await activateIdentity('user-b')
+    expect(await readRaidResult('user-a', 'raid-a')).toBeNull()
+    expect(await readRaidResult('user-b', 'raid-a')).toBeNull()
+  })
+
+  it('bounds history and orders it newest first', () => {
+    const page: RaidHistoryPage = {
+      raids: Array.from({ length: 24 }, (_, index) => ({
+        raidId: `raid-${index}`, title: `Рейд ${index}`,
+        completedAt: new Date(Date.UTC(2026, 7, index + 1)).toISOString(), partial: false,
+        team: metrics, personal: metrics,
+      })),
+      nextCursor: 'next',
+    }
+    const bounded = newestFirst(page)
+    expect(bounded.raids).toHaveLength(20)
+    expect(bounded.raids[0]?.raidId).toBe('raid-23')
+    expect(bounded.raids.at(-1)?.raidId).toBe('raid-4')
+  })
+})

--- a/apps/pwa/src/features/results/cache.ts
+++ b/apps/pwa/src/features/results/cache.ts
@@ -1,0 +1,111 @@
+import { offlineDb } from '../offline/db'
+import { getActiveIdentityId } from '../offline/ledger'
+import type { KabandaProgress, RaidHistoryPage, RaidMetrics, RaidResult } from './types'
+
+const key = (identityId: string, resourceId: string) => JSON.stringify([identityId, resourceId])
+
+function validMetrics(value: unknown): value is RaidMetrics {
+  if (!value || typeof value !== 'object') return false
+  const metrics = value as Partial<RaidMetrics>
+  return ['durationSeconds', 'distanceMeters', 'uniquePoints', 'photos'].every((field) => {
+    const metric = metrics[field as keyof RaidMetrics]
+    return typeof metric === 'number' && Number.isFinite(metric) && metric >= 0
+  })
+}
+
+function validResult(value: unknown): value is RaidResult {
+  if (!value || typeof value !== 'object') return false
+  const result = value as Partial<RaidResult>
+  return result.schemaVersion === 1 && Boolean(result.raid) &&
+    typeof result.raid?.id === 'string' && typeof result.raid?.kabandaId === 'string' &&
+    typeof result.raid?.title === 'string' && Number.isFinite(Date.parse(result.raid?.completedAt ?? '')) &&
+    validMetrics(result.team) && validMetrics(result.personal) && Array.isArray(result.participants) &&
+    result.participants.every((participant) =>
+      participant && typeof participant.userId === 'string' &&
+      typeof participant.displayName === 'string' && validMetrics(participant.metrics),
+    )
+}
+
+function newestFirst(page: RaidHistoryPage): RaidHistoryPage {
+  return {
+    raids: [...page.raids]
+      .filter((raid) =>
+        typeof raid.raidId === 'string' &&
+        typeof raid.title === 'string' &&
+        Number.isFinite(Date.parse(raid.completedAt)) &&
+        validMetrics(raid.team) &&
+        validMetrics(raid.personal),
+      )
+      .sort((a, b) => Date.parse(b.completedAt) - Date.parse(a.completedAt))
+      .slice(0, 20),
+    nextCursor: typeof page.nextCursor === 'string' ? page.nextCursor : null,
+  }
+}
+
+function validProgress(value: unknown): value is KabandaProgress {
+  if (!value || typeof value !== 'object') return false
+  const progress = value as Partial<KabandaProgress>
+  return validMetrics(progress.team) && validMetrics(progress.personal) &&
+    typeof progress.team?.completedRaids === 'number' && progress.team.completedRaids >= 0 &&
+    typeof progress.personal?.completedRaids === 'number' && progress.personal.completedRaids >= 0
+}
+
+async function identityMatches(identityId: string): Promise<boolean> {
+  return (await getActiveIdentityId()) === identityId
+}
+
+export async function saveRaidResult(identityId: string, result: RaidResult): Promise<void> {
+  if (!(await identityMatches(identityId)) || !validResult(result)) return
+  await offlineDb.raidResults.put({
+    key: key(identityId, result.raid.id), identityId, raidId: result.raid.id,
+    kabandaId: result.raid.kabandaId, savedAt: new Date().toISOString(), result,
+  })
+}
+
+export async function readRaidResult(identityId: string, raidId: string) {
+  if (!(await identityMatches(identityId))) return null
+  const record = await offlineDb.raidResults.get(key(identityId, raidId))
+  if (!record || record.identityId !== identityId || !validResult(record.result)) return null
+  return { result: record.result, savedAt: record.savedAt }
+}
+
+export async function saveRaidHistory(
+  identityId: string,
+  kabandaId: string,
+  page: RaidHistoryPage,
+): Promise<void> {
+  if (!(await identityMatches(identityId))) return
+  await offlineDb.raidHistory.put({
+    key: key(identityId, kabandaId), identityId, kabandaId,
+    savedAt: new Date().toISOString(), history: newestFirst(page),
+  })
+}
+
+export async function readRaidHistory(identityId: string, kabandaId: string) {
+  if (!(await identityMatches(identityId))) return null
+  const record = await offlineDb.raidHistory.get(key(identityId, kabandaId))
+  if (!record || record.identityId !== identityId || !record.history || typeof record.history !== 'object') return null
+  const page = newestFirst(record.history as RaidHistoryPage)
+  return { page, savedAt: record.savedAt }
+}
+
+export async function saveKabandaProgress(
+  identityId: string,
+  kabandaId: string,
+  progress: KabandaProgress,
+): Promise<void> {
+  if (!(await identityMatches(identityId)) || !validProgress(progress)) return
+  await offlineDb.kabandaProgress.put({
+    key: key(identityId, kabandaId), identityId, kabandaId,
+    savedAt: new Date().toISOString(), progress,
+  })
+}
+
+export async function readKabandaProgress(identityId: string, kabandaId: string) {
+  if (!(await identityMatches(identityId))) return null
+  const record = await offlineDb.kabandaProgress.get(key(identityId, kabandaId))
+  if (!record || record.identityId !== identityId || !validProgress(record.progress)) return null
+  return { progress: record.progress, savedAt: record.savedAt }
+}
+
+export { newestFirst }

--- a/apps/pwa/src/features/results/local.test.ts
+++ b/apps/pwa/src/features/results/local.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../checkins/replay', () => ({
+  replayOneCheckInOrMedia: vi.fn(),
+  replayOneIssuedMedia: vi.fn(),
+}))
+
+import { replayOneIssuedMedia } from '../checkins/replay'
+import { drainFinalizingServerTail } from './local'
+
+describe('finalizing foreground drain', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('continues in bounded chunks instead of treating ten media as idle', async () => {
+    vi.stubGlobal('sessionStorage', {
+      getItem: () => 'tab-a',
+      setItem: () => undefined,
+    })
+    const replay = vi.mocked(replayOneIssuedMedia)
+    for (let index = 0; index < 11; index += 1) {
+      replay.mockResolvedValueOnce({ kind: 'media', operationId: `operation-${index}`, mediaId: `media-${index}` })
+    }
+    replay.mockResolvedValueOnce({ kind: 'idle' })
+
+    await expect(drainFinalizingServerTail({
+      identityId: 'user-a', raidId: 'raid-a', online: true, maxOperations: 10,
+    })).resolves.toEqual({ processed: 10, mayHaveMore: true })
+    await expect(drainFinalizingServerTail({
+      identityId: 'user-a', raidId: 'raid-a', online: true, maxOperations: 10,
+    })).resolves.toEqual({ processed: 1, mayHaveMore: false })
+    expect(replay).toHaveBeenCalledTimes(12)
+  })
+})

--- a/apps/pwa/src/features/results/local.ts
+++ b/apps/pwa/src/features/results/local.ts
@@ -1,0 +1,96 @@
+import { replayOneCheckInOrMedia, replayOneIssuedMedia } from '../checkins/replay'
+import { offlineDb } from '../offline/db'
+import { getActiveIdentityId } from '../offline/ledger'
+import type { FinishLocalReview } from './types'
+
+const routePending = new Set(['pending', 'sending', 'retryable'])
+const checkInPending = new Set(['pending', 'sending', 'retryable'])
+const mediaPending = new Set(['local', 'intent', 'uploading', 'retryable'])
+const MAX_FINISH_INVENTORY_COUNT = 10_000
+
+function boundedCount(count: number): number {
+  return Math.min(Math.max(count, 0), MAX_FINISH_INVENTORY_COUNT)
+}
+
+export async function getFinishLocalReview(
+  identityId: string,
+  raidId: string,
+): Promise<FinishLocalReview | null> {
+  if ((await getActiveIdentityId()) !== identityId) return null
+  const [route, checkIns, media] = await Promise.all([
+    offlineDb.routeOutbox.where('identityId').equals(identityId).filter((row) => row.raidId === raidId).toArray(),
+    offlineDb.checkInOutbox.where('identityId').equals(identityId).filter((row) => row.raidId === raidId).toArray(),
+    offlineDb.mediaDrafts.where('identityId').equals(identityId).filter((row) => row.raidId === raidId).toArray(),
+  ])
+  return {
+    inventory: {
+      routePending: boundedCount(route.filter(({ status }) => routePending.has(status)).length),
+      checkInsPending: boundedCount(checkIns.filter(({ status }) => checkInPending.has(status)).length),
+      mediaPending: boundedCount(media.filter(({ status }) => mediaPending.has(status)).length),
+      needsAction: boundedCount(
+        checkIns.filter(({ status }) => status === 'needs_action').length +
+        media.filter(({ status }) => status === 'rejected').length,
+      ),
+    },
+  }
+}
+
+function senderTabId(): string {
+  const key = 'kabanda:checkin-sender-tab:v1'
+  try {
+    const existing = sessionStorage.getItem(key)
+    if (existing) return existing
+    const created = crypto.randomUUID()
+    sessionStorage.setItem(key, created)
+    return created
+  } catch {
+    return crypto.randomUUID()
+  }
+}
+
+export async function drainForegroundRaidWork(input: {
+  identityId: string
+  raidId: string
+  flushRoute: () => Promise<void> | void
+  online: boolean
+  maxOperations?: number
+}): Promise<FinishLocalReview | null> {
+  if (!input.online) return getFinishLocalReview(input.identityId, input.raidId)
+  await input.flushRoute()
+  const holderTabId = senderTabId()
+  for (let index = 0; index < (input.maxOperations ?? 20); index += 1) {
+    const result = await replayOneCheckInOrMedia({
+      identityId: input.identityId,
+      raidId: input.raidId,
+      holderTabId,
+      online: true,
+    })
+    if (result.kind === 'idle' || result.kind === 'retryable' || result.kind === 'fence_lost') break
+    if (result.kind === 'terminal') continue
+  }
+  return getFinishLocalReview(input.identityId, input.raidId)
+}
+
+export async function drainFinalizingServerTail(input: {
+  identityId: string
+  raidId: string
+  online: boolean
+  maxOperations?: number
+}): Promise<{ processed: number; mayHaveMore: boolean }> {
+  if (!input.online) return { processed: 0, mayHaveMore: false }
+  const holderTabId = senderTabId()
+  let processed = 0
+  for (let index = 0; index < (input.maxOperations ?? 10); index += 1) {
+    const result = await replayOneIssuedMedia({
+      identityId: input.identityId,
+      raidId: input.raidId,
+      holderTabId,
+      online: true,
+    })
+    if (result.kind === 'idle' || result.kind === 'retryable' || result.kind === 'fence_lost') {
+      return { processed, mayHaveMore: false }
+    }
+    processed += 1
+  }
+  return { processed, mayHaveMore: true }
+}

--- a/apps/pwa/src/features/results/operation.test.ts
+++ b/apps/pwa/src/features/results/operation.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearResultOperationAttempt,
+  readResultOperationAttempt,
+  resultOperationStorageKey,
+  saveResultOperationAttempt,
+  selectResultOperationAttempt,
+} from './operation'
+
+describe('result command attempt', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('keeps the exact key and payload for a lost-response retry', () => {
+    const payload = { expectedVersion: 8, confirmPartial: true }
+    const first = selectResultOperationAttempt(null, 'same', payload, () => 'stable-key')
+    expect(selectResultOperationAttempt(first, 'same', { expectedVersion: 9, confirmPartial: false }, () => 'new-key')).toBe(first)
+    expect(selectResultOperationAttempt(first, 'changed', payload, () => 'new-key').key).toBe('new-key')
+  })
+
+  it('survives remount until a canonical result clears the exact key', () => {
+    const values = new Map<string, string>()
+    vi.stubGlobal('sessionStorage', {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+      removeItem: (key: string) => values.delete(key),
+    })
+    const attempt = selectResultOperationAttempt(null, 'finish-v8', { expectedVersion: 8 }, () => 'finish-key')
+    saveResultOperationAttempt('finish:raid-a', attempt)
+    expect(readResultOperationAttempt('finish:raid-a')).toEqual(attempt)
+    clearResultOperationAttempt('finish:raid-a', 'another-key')
+    expect(readResultOperationAttempt('finish:raid-a')).toEqual(attempt)
+    clearResultOperationAttempt('finish:raid-a', 'finish-key')
+    expect(readResultOperationAttempt('finish:raid-a')).toBeNull()
+  })
+
+  it('binds pending finish and settle attempts to the current identity', () => {
+    expect(resultOperationStorageKey('finish', 'user-a', 'raid-a')).not.toBe(
+      resultOperationStorageKey('finish', 'user-b', 'raid-a'),
+    )
+    expect(resultOperationStorageKey('finish', 'user-a', 'raid-a')).not.toBe(
+      resultOperationStorageKey('settle', 'user-a', 'raid-a'),
+    )
+  })
+})

--- a/apps/pwa/src/features/results/operation.ts
+++ b/apps/pwa/src/features/results/operation.ts
@@ -1,0 +1,52 @@
+export interface ResultOperationAttempt<T> {
+  fingerprint: string
+  key: string
+  payload: T
+}
+
+export function resultOperationStorageKey(
+  kind: 'finish' | 'settle',
+  identityId: string,
+  raidId: string,
+): string {
+  return `kabanda:${kind}:${encodeURIComponent(identityId)}:${encodeURIComponent(raidId)}`
+}
+
+export function selectResultOperationAttempt<T>(
+  current: ResultOperationAttempt<T> | null,
+  fingerprint: string,
+  payload: T,
+  createKey: () => string = () => crypto.randomUUID(),
+): ResultOperationAttempt<T> {
+  return current?.fingerprint === fingerprint
+    ? current
+    : { fingerprint, key: createKey(), payload }
+}
+
+export function readResultOperationAttempt<T>(storageKey: string): ResultOperationAttempt<T> | null {
+  try {
+    const value = JSON.parse(sessionStorage.getItem(storageKey) ?? 'null') as Partial<ResultOperationAttempt<T>> | null
+    return value && typeof value.fingerprint === 'string' && typeof value.key === 'string' && 'payload' in value
+      ? value as ResultOperationAttempt<T>
+      : null
+  } catch {
+    return null
+  }
+}
+
+export function saveResultOperationAttempt<T>(storageKey: string, attempt: ResultOperationAttempt<T>): void {
+  try {
+    sessionStorage.setItem(storageKey, JSON.stringify(attempt))
+  } catch {
+    // The in-memory caller still keeps the exact attempt stable for this mount.
+  }
+}
+
+export function clearResultOperationAttempt(storageKey: string, key: string): void {
+  try {
+    const current = readResultOperationAttempt(storageKey)
+    if (current?.key === key) sessionStorage.removeItem(storageKey)
+  } catch {
+    // A canonical response is already sufficient; storage cleanup is best effort.
+  }
+}

--- a/apps/pwa/src/features/results/share.ts
+++ b/apps/pwa/src/features/results/share.ts
@@ -1,0 +1,32 @@
+export type ShareCardOutcome = 'shared' | 'downloaded'
+
+function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = filename
+  anchor.rel = 'noopener'
+  document.body.append(anchor)
+  anchor.click()
+  anchor.remove()
+  window.setTimeout(() => URL.revokeObjectURL(url), 0)
+}
+
+export async function shareResultCard(
+  blob: Blob,
+  title: string,
+  filename = 'kabanda-result.png',
+): Promise<ShareCardOutcome> {
+  const file = typeof File === 'function' ? new File([blob], filename, { type: 'image/png' }) : null
+  const data: ShareData = {
+    title,
+    text: 'Канонический итог рейда КАБАНДЫ',
+    ...(file ? { files: [file] } : {}),
+  }
+  if (file && typeof navigator.share === 'function' && typeof navigator.canShare === 'function' && navigator.canShare(data)) {
+    await navigator.share(data)
+    return 'shared'
+  }
+  downloadBlob(blob, filename)
+  return 'downloaded'
+}

--- a/apps/pwa/src/features/results/state.test.ts
+++ b/apps/pwa/src/features/results/state.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { finishNeedsPartialConfirmation, metricRows, pendingInventoryCount, selectFinishPrimary } from './state'
+
+describe('result and finish state', () => {
+  it('drains before finish and requires explicit partial confirmation for unresolved work', () => {
+    const pending = {
+      inventory: { routePending: 2, checkInsPending: 1, mediaPending: 1, needsAction: 0 },
+    }
+    expect(selectFinishPrimary(pending, false, true)).toBe('drain')
+    expect(selectFinishPrimary(pending, true, true)).toBe('finish')
+    expect(finishNeedsPartialConfirmation(pending)).toBe(true)
+    const needsAction = { inventory: { routePending: 0, checkInsPending: 0, mediaPending: 0, needsAction: 1 } }
+    expect(selectFinishPrimary(needsAction, false, true)).toBeNull()
+    expect(selectFinishPrimary(needsAction, true, true)).toBe('finish')
+    expect(finishNeedsPartialConfirmation(needsAction)).toBe(true)
+    expect(pendingInventoryCount(needsAction)).toBe(1)
+    expect(selectFinishPrimary({ inventory: { routePending: 0, checkInsPending: 0, mediaPending: 0, needsAction: 0 } }, false, false)).toBeNull()
+  })
+
+  it('renders four personal/team metrics without consulting local distance', () => {
+    const personal = { durationSeconds: 600, distanceMeters: 1200, uniquePoints: 2, photos: 3 }
+    const team = { durationSeconds: 3600, distanceMeters: 8800, uniquePoints: 6, photos: 14 }
+    const rows = metricRows(personal, team)
+    expect(rows.map(({ id }) => id)).toEqual(['distance', 'duration', 'points', 'photos'])
+    expect(rows[0]).toMatchObject({ personal: '1,2 км', team: '8,8 км' })
+  })
+})

--- a/apps/pwa/src/features/results/state.ts
+++ b/apps/pwa/src/features/results/state.ts
@@ -1,0 +1,48 @@
+import type { FinishLocalReview, RaidMetrics } from './types'
+
+export type FinishPrimary = 'drain' | 'finish' | null
+
+export function pendingInventoryCount(review: FinishLocalReview): number {
+  return replayableInventoryCount(review) + review.inventory.needsAction
+}
+
+export function replayableInventoryCount(review: FinishLocalReview): number {
+  return review.inventory.routePending + review.inventory.checkInsPending + review.inventory.mediaPending
+}
+
+export function selectFinishPrimary(
+  review: FinishLocalReview,
+  partialConfirmed: boolean,
+  online: boolean,
+): FinishPrimary {
+  if (!online) return null
+  if (replayableInventoryCount(review) > 0) return partialConfirmed ? 'finish' : 'drain'
+  if (review.inventory.needsAction > 0 && !partialConfirmed) return null
+  return 'finish'
+}
+
+export function finishNeedsPartialConfirmation(review: FinishLocalReview): boolean {
+  return pendingInventoryCount(review) > 0
+}
+
+export function formatDistance(meters: number): string {
+  return meters >= 1_000
+    ? `${(meters / 1_000).toLocaleString('ru-RU', { maximumFractionDigits: 1 })} км`
+    : `${Math.round(meters)} м`
+}
+
+export function formatDuration(seconds: number): string {
+  const minutes = Math.floor(seconds / 60)
+  const hours = Math.floor(minutes / 60)
+  const remainder = minutes % 60
+  return hours ? `${hours}:${String(remainder).padStart(2, '0')}` : `${minutes} мин`
+}
+
+export function metricRows(personal: RaidMetrics, team: RaidMetrics) {
+  return [
+    { id: 'distance', label: 'Расстояние', personal: formatDistance(personal.distanceMeters), team: formatDistance(team.distanceMeters) },
+    { id: 'duration', label: 'В пути', personal: formatDuration(personal.durationSeconds), team: formatDuration(team.durationSeconds) },
+    { id: 'points', label: 'Точки', personal: String(personal.uniquePoints), team: String(team.uniquePoints) },
+    { id: 'photos', label: 'Фото', personal: String(personal.photos), team: String(team.photos) },
+  ]
+}

--- a/apps/pwa/src/features/results/types.ts
+++ b/apps/pwa/src/features/results/types.ts
@@ -1,0 +1,71 @@
+import type { RaidFinalizationProjection, RaidProjection } from '../raids/types'
+
+export interface RaidMetrics {
+  durationSeconds: number
+  distanceMeters: number
+  uniquePoints: number
+  photos: number
+}
+
+export interface RaidResult {
+  schemaVersion: 1
+  raid: {
+    id: string
+    kabandaId: string
+    title: string
+    startedAt: string
+    completedAt: string
+    partial: boolean
+  }
+  team: RaidMetrics
+  personal: RaidMetrics
+  participants: Array<{
+    userId: string
+    displayName: string
+    metrics: RaidMetrics
+  }>
+}
+
+export interface RaidHistoryItem {
+  raidId: string
+  title: string
+  completedAt: string
+  partial: boolean
+  team: RaidMetrics
+  personal: RaidMetrics
+}
+
+export interface RaidHistoryPage {
+  raids: RaidHistoryItem[]
+  nextCursor: string | null
+}
+
+export interface ProgressMetrics extends RaidMetrics {
+  completedRaids: number
+}
+
+export interface KabandaProgress {
+  team: ProgressMetrics
+  personal: ProgressMetrics
+}
+
+export interface FinishInventory {
+  routePending: number
+  checkInsPending: number
+  mediaPending: number
+  needsAction: number
+}
+
+export interface FinishLocalReview {
+  inventory: FinishInventory
+}
+
+export interface FinishRaidResponse {
+  raid: RaidProjection
+  finalization: RaidFinalizationProjection
+}
+
+export interface SettleRaidResponse {
+  raid: RaidProjection
+  result: RaidResult
+}

--- a/docs/architecture/VP_ARCHITECTURE.md
+++ b/docs/architecture/VP_ARCHITECTURE.md
@@ -175,6 +175,29 @@ reload/replay, account isolation, service-worker update gate и mobile shell. Pr
 - Просроченный media intent заменяется новым operation ID при том же stable draft/SHA. WebSocket, Redis,
   S3 и native background upload для alpha не требуются.
 
+## Граница #37: завершение, результат и повод вернуться
+
+- Только owner завершает рейд online named command с `expectedVersion` и actor-wide `Idempotency-Key`.
+  Локальное нажатие offline — намерение, а не второй lifecycle. Перед finish PWA показывает route/check-in/media
+  inventory; обычный путь требует пустой очереди, а `confirmPartial` явно сохраняет bounded counts/reasons.
+- Finish под raid row lock закрывает activity window и navigator lease, замораживает cutoffs каждой
+  lease/generation и задаёт двухминутный server deadline. Route ingestion после перехода полностью закрыт;
+  новые полевые операции не создаются, а partial route/check-in inventory остаётся диагностическим evidence.
+- Finish, оставшиеся terminal claim/fallback/media commits и settle используют один raid row lock. Settle либо
+  завершается раньше при нулевом pending, либо после deadline атомарно expire-ит остаток, пишет immutable
+  summary v1 и переводит рейд в `completed`.
+- Командная дистанция суммирует только соседние route samples одной lease/generation и одного activity window
+  внутри frozen cutoff. Персональный сегмент дополнительно требует, чтобы обе точки находились внутри одного
+  participation interval; границы join/leave/pause/handoff никогда не соединяются.
+- Итог берёт points из immutable credits, фото — только accepted и не tombstoned на момент settle, участников —
+  из канонических интервалов. Исправление результата и универсальная analytics-модель отложены за VP.
+- Private membership-gated API выдаёт result, cursor history до 20 записей, detail и четыре метрики progress:
+  completed raids, distance, unique points и visible photos. IndexedDB cache привязан к identity; private media
+  и ответы не попадают в общий Cache Storage.
+- Share card — один детерминированный authenticated `image/png` с `private, no-store`: бренд, название/дата,
+  distance/time и counts. Маршрут, имена, фото, точная геолокация и публичная ссылка в VP не входят.
+- Redis/worker, BI/trends, публичная лента, достижения, видео и production observability для #37 не строятся.
+
 ## Локальная среда
 
 `infra/compose.yaml` поднимает только PostGIS и Mailpit. Для alpha медиа остаются в PostgreSQL, поэтому

--- a/docs/product/raid-lifecycle.md
+++ b/docs/product/raid-lifecycle.md
@@ -1,6 +1,6 @@
 # Жизненный цикл рейда VP
 
-Статус: proposed для VP #29. Визуальный UX утверждается отдельно в #31.
+Статус: рабочий контракт VP #29, материализованный delivery-задачами #34–#37. Визуальный UX утверждается отдельно в #31.
 
 Это целевой lifecycle всего VP. Delivery #34 материализует создание, планирование, lobby, старт,
 pause/resume и cancel; `finalizing/completed`, participant leave/cutoff и связанные команды входят в #37,
@@ -126,8 +126,18 @@ local -> pending -> sending -> accepted
   sequence/idempotency namespace не переиспользуется.
 - Handoff/recover также закрывают прежнюю generation до выдачи новой; клиентское время не определяет
   границу и не может обойти fencing.
-- Offline finish сохраняется как pending command. После reconnect сервер применяет или детерминированно отклоняет его по текущему состоянию.
-- `finalizing` ждёт bounded набор ранее созданных route/check-in/media операций и показывает, что итог ещё собирается.
+- Offline-нажатие finish остаётся локальным намерением и не изображает каноническое завершение. После reconnect
+  PWA сначала foreground-досылает identity-bound очередь, показывает её состав и только затем отправляет online
+  finish; явный `confirmPartial` фиксирует bounded причины и количество недосланных операций.
+- Finish под row lock закрывает activity window и navigator lease, замораживает cutoffs всех route generations и
+  переводит рейд в `finalizing` на две минуты server time. Route ingestion и создание новых check-in/claim/
+  fallback/media intent после этого полностью закрыты; разрешены только terminal decisions уже известных серверу
+  claims/fallbacks и завершение ранее выданных media intents в пределах cutoff.
+- Finish, terminal commits и settle сериализуются тем же raid row lock. Settle завершается раньше deadline только
+  при нулевом pending; после deadline он атомарно помечает остаток `expired_finalization`, считает результат и
+  сохраняет неизменяемый summary v1.
+- Media становится видимым только если нормализация завершилась до server `mediaCutoffAt`; после Sharp финальный
+  commit повторно берёт raid lock. Accepted replay после `completed` возвращает прежний receipt, но не меняет итог.
 - После `completed` рейд не открывается заново. Исправления имеют отдельную audit lineage.
 - Reload/process kill/service-worker update читают серверный raid state и совместимый identity-bound outbox; UI не угадывает состояние по старому client flag.
 
@@ -144,3 +154,6 @@ local -> pending -> sending -> accepted
 9. Local sample становится `saved` только после IndexedDB commit, а canonical — только после server receipt.
 10. Поздняя геолокация и pending claim/fallback не создают canonical credit.
 11. Один участник получает не более одного credit за одну snapshot-точку рейда независимо от replay.
+12. Канонический summary считает route sample только в пределах замороженного lease/generation cutoff и никогда
+    не соединяет сегмент через pause, handoff, join или leave.
+13. Finish, разрешённые finalizing commits и settle не обходят друг друга: их сериализует один raid row lock.

--- a/docs/testing/pwa-device-matrix.md
+++ b/docs/testing/pwa-device-matrix.md
@@ -51,6 +51,8 @@
 | Offline photo upload | 10 мин | draft переживает reload, после online появляется один accepted media | Pending | Pending |
 | Five-person check-in | 10 мин | claims видят только выбранные участники, credit не дублируется | Pending | Pending |
 | Web Share/download | 5 мин | evidence передаётся или скачивается | Pending | Pending |
+| Finish после offline-очереди | 10 мин | очередь видна, foreground replay не теряется, partial требует явного подтверждения | Pending | Pending |
+| Finalizing/reload | 5 мин | deadline и pending берутся с сервера, итог появляется один раз | Pending | Pending |
 | Storage pressure/clear site data | 10 мин | потеря/восстановление описаны без ложных обещаний | Pending | Pending |
 
 ## Метрики
@@ -67,6 +69,7 @@
 - время от primary action до durable local receipt;
 - время offline photo от reconnect до accepted gallery item;
 - количество duplicate credits/media после reload и повторного нажатия;
+- время от online finish до immutable result и причины partial finalization;
 - app-caused confusion и developer help requests.
 
 ## Решение

--- a/infra/postgres/migrations/0007_results_history.sql
+++ b/infra/postgres/migrations/0007_results_history.sql
@@ -1,0 +1,118 @@
+ALTER TABLE raids
+  ADD COLUMN finalization_deadline_at timestamptz,
+  ADD COLUMN finalization_partial boolean NOT NULL DEFAULT false,
+  ADD COLUMN finalization_inventory jsonb;
+
+ALTER TABLE raids ADD CHECK (
+  finalization_inventory IS NULL OR octet_length(finalization_inventory::text) <= 1024
+);
+
+ALTER TABLE raids ADD CHECK (
+  (state NOT IN ('finalizing', 'completed'))
+  OR (finalizing_at IS NOT NULL AND finalization_deadline_at IS NOT NULL)
+);
+
+ALTER TABLE raid_navigator_leases
+  DROP CONSTRAINT raid_navigator_leases_ended_reason_check;
+ALTER TABLE raid_navigator_leases
+  ADD CHECK (
+    ended_reason IS NULL OR ended_reason IN ('pause', 'cancel', 'handoff', 'recover', 'finish')
+  );
+
+ALTER TABLE raid_checkin_claims DROP CONSTRAINT raid_checkin_claims_status_check;
+ALTER TABLE raid_checkin_claims ADD CHECK (
+  status IN ('pending', 'confirmed', 'declined', 'expired_finalization')
+);
+
+ALTER TABLE raid_checkin_fallbacks DROP CONSTRAINT raid_checkin_fallbacks_status_check;
+ALTER TABLE raid_checkin_fallbacks ADD CHECK (
+  status IN ('pending_verifier', 'confirmed', 'declined', 'expired_finalization')
+);
+
+ALTER TABLE raid_media DROP CONSTRAINT raid_media_state_check;
+ALTER TABLE raid_media ADD CHECK (
+  state IN ('pending_upload', 'processing', 'ready', 'tombstoned', 'expired_finalization')
+);
+ALTER TABLE raid_media ADD COLUMN processing_token uuid;
+UPDATE raid_media SET state = 'pending_upload', processing_started_at = NULL
+  WHERE state = 'processing';
+ALTER TABLE raid_media ADD CHECK (
+  (state = 'processing' AND processing_started_at IS NOT NULL AND processing_token IS NOT NULL)
+  OR (state <> 'processing' AND processing_token IS NULL)
+);
+ALTER TABLE raid_media ADD CHECK (
+  state <> 'expired_finalization' OR content_bytes IS NULL
+);
+
+CREATE TABLE raid_route_finalization_cutoffs (
+  raid_id uuid NOT NULL REFERENCES raids(id) ON DELETE RESTRICT,
+  lease_id uuid NOT NULL,
+  generation integer NOT NULL CHECK (generation > 0),
+  max_sequence bigint NOT NULL CHECK (max_sequence >= 0),
+  cutoff_at timestamptz NOT NULL,
+  PRIMARY KEY (raid_id, lease_id),
+  UNIQUE (raid_id, generation),
+  FOREIGN KEY (raid_id, lease_id)
+    REFERENCES raid_navigator_leases(raid_id, id) ON DELETE RESTRICT
+);
+
+CREATE TABLE raid_results (
+  raid_id uuid PRIMARY KEY REFERENCES raids(id) ON DELETE RESTRICT,
+  kabanda_id uuid NOT NULL REFERENCES kabandas(id) ON DELETE RESTRICT,
+  schema_version integer NOT NULL CHECK (schema_version = 1),
+  partial boolean NOT NULL,
+  started_at timestamptz NOT NULL,
+  completed_at timestamptz NOT NULL,
+  team_duration_seconds integer NOT NULL CHECK (team_duration_seconds >= 0),
+  team_distance_meters double precision NOT NULL CHECK (team_distance_meters >= 0),
+  team_unique_points integer NOT NULL CHECK (team_unique_points >= 0),
+  team_photos integer NOT NULL CHECK (team_photos >= 0),
+  result_json jsonb NOT NULL CHECK (octet_length(result_json::text) <= 65536),
+  share_png bytea NOT NULL CHECK (octet_length(share_png) BETWEEN 64 AND 1048576),
+  share_sha256 char(64) NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX raid_results_history_idx
+  ON raid_results (kabanda_id, completed_at DESC, raid_id DESC);
+
+CREATE TABLE raid_result_participants (
+  raid_id uuid NOT NULL REFERENCES raid_results(raid_id) ON DELETE RESTRICT,
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  display_name text NOT NULL CHECK (char_length(display_name) BETWEEN 1 AND 160),
+  duration_seconds integer NOT NULL CHECK (duration_seconds >= 0),
+  distance_meters double precision NOT NULL CHECK (distance_meters >= 0),
+  unique_points integer NOT NULL CHECK (unique_points >= 0),
+  photos integer NOT NULL CHECK (photos >= 0),
+  PRIMARY KEY (raid_id, user_id)
+);
+
+CREATE INDEX raid_result_participants_progress_idx
+  ON raid_result_participants (user_id, raid_id);
+
+CREATE TABLE raid_result_points (
+  raid_id uuid NOT NULL REFERENCES raid_results(raid_id) ON DELETE RESTRICT,
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  source_point_id uuid NOT NULL REFERENCES points(id) ON DELETE RESTRICT,
+  PRIMARY KEY (raid_id, user_id, source_point_id)
+);
+
+CREATE INDEX raid_result_points_user_idx
+  ON raid_result_points (user_id, source_point_id);
+
+CREATE FUNCTION prevent_raid_result_mutation() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'raid result rows are immutable' USING ERRCODE = '55000';
+END;
+$$;
+
+CREATE TRIGGER raid_results_immutable
+  BEFORE UPDATE OR DELETE ON raid_results
+  FOR EACH ROW EXECUTE FUNCTION prevent_raid_result_mutation();
+CREATE TRIGGER raid_result_participants_immutable
+  BEFORE UPDATE OR DELETE ON raid_result_participants
+  FOR EACH ROW EXECUTE FUNCTION prevent_raid_result_mutation();
+CREATE TRIGGER raid_result_points_immutable
+  BEFORE UPDATE OR DELETE ON raid_result_points
+  FOR EACH ROW EXECUTE FUNCTION prevent_raid_result_mutation();

--- a/packages/domain/src/index.test.ts
+++ b/packages/domain/src/index.test.ts
@@ -78,6 +78,45 @@ describe('raid lifecycle', () => {
     ).toContain('start')
   })
 
+  it('exposes finish, leave and settle only to the eligible actor and state', () => {
+    for (const state of ['active', 'paused'] as const) {
+      expect(
+        getRaidAllowedActions({
+          state,
+          role: 'owner',
+          participantState: 'active',
+          navigatorReady: false,
+        }),
+      ).toContain('finish')
+      expect(
+        getRaidAllowedActions({
+          state,
+          role: 'member',
+          participantState: 'active',
+          navigatorReady: false,
+        }),
+      ).toContain('leave')
+    }
+    expect(
+      getRaidAllowedActions({
+        state: 'finalizing',
+        role: 'owner',
+        participantState: 'active',
+        navigatorReady: false,
+        finalizationCanSettle: false,
+      }),
+    ).not.toContain('settle-finalization')
+    expect(
+      getRaidAllowedActions({
+        state: 'finalizing',
+        role: 'owner',
+        participantState: 'active',
+        navigatorReady: false,
+        finalizationCanSettle: true,
+      }),
+    ).toContain('settle-finalization')
+  })
+
   it('fails route health closed across lease and pause boundaries', () => {
     expect(
       getRouteStatusCode({

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -75,6 +75,9 @@ export type RaidAction =
   | 'start'
   | 'pause'
   | 'resume'
+  | 'finish'
+  | 'leave'
+  | 'settle-finalization'
   | 'cancel'
 
 export function isRaidStateTransitionAllowed(state: RaidState, action: RaidAction): boolean {
@@ -93,6 +96,12 @@ export function isRaidStateTransitionAllowed(state: RaidState, action: RaidActio
       return state === 'active' || state === 'paused'
     case 'resume':
       return state === 'paused'
+    case 'finish':
+      return state === 'active' || state === 'paused'
+    case 'leave':
+      return state === 'active' || state === 'paused'
+    case 'settle-finalization':
+      return state === 'finalizing'
     case 'cancel':
       return ['draft', 'planned', 'lobby', 'active', 'paused'].includes(state)
   }
@@ -103,6 +112,7 @@ export function getRaidAllowedActions(input: {
   role: 'owner' | 'member'
   participantState: RaidParticipantState | null
   navigatorReady: boolean
+  finalizationCanSettle?: boolean
 }): RaidAction[] {
   const actions: RaidAction[] = []
   if (input.role === 'owner') {
@@ -113,6 +123,10 @@ export function getRaidAllowedActions(input: {
     }
     if (input.state === 'active') actions.push('pause')
     if (input.state === 'paused') actions.push('resume')
+    if (input.state === 'active' || input.state === 'paused') actions.push('finish')
+    if (input.state === 'finalizing' && input.finalizationCanSettle) {
+      actions.push('settle-finalization')
+    }
     if (input.state === 'active' || input.state === 'paused') {
       actions.push('handoff-navigator')
     }
@@ -123,6 +137,13 @@ export function getRaidAllowedActions(input: {
   }
   if (input.state === 'lobby' && input.participantState === 'accepted') {
     actions.push('ready')
+  }
+  if (
+    input.role === 'member' &&
+    input.participantState === 'active' &&
+    (input.state === 'active' || input.state === 'paused')
+  ) {
+    actions.push('leave')
   }
   return actions
 }


### PR DESCRIPTION
## Что входит

- owner-only online finish с явным partial inventory, двухминутной server-time финализацией и immutable result v1;
- row-lock fencing для claims, fallbacks, media и settle, frozen route cutoffs и processing-token для Sharp retry;
- server-owned team/personal metrics, history, progress и authenticated private PNG share card;
- PWA foreground drain, finalizing/result/history UI, identity-bound IndexedDB cache и safe Web Share/download;
- self-leave, completed read projection и risk-focused regressions.

## Проверки

- `pnpm check` — green;
- domain: 11/11;
- PWA: 83/83;
- API unit: 23/23;
- 23 PostgreSQL/PostGIS tests prepared; local environment skips them, GitHub CI is the execution gate;
- independent working-tree review: `APPROVE #37 working-tree — P0/P1/P2 none`.

Stacked on `codex/vp-7-checkins-media` / approved #36 head `0d01524`.

Closes #37
