### PR TITLE
fix(#30): recover capability lab after GPS watch error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import {
 } from './capabilities'
 import { appendEvent, db, getOrCreateSession } from './db'
 import { buildEvidenceBundle, buildGeoJson, downloadJson } from './evidence'
+import { resetGpsWatch } from './gps-watch'
 import type {
   CapabilityEvent,
   CapabilitySession,
@@ -223,9 +224,15 @@ export function App() {
         })
       },
       (error) => {
-        setRecorderStatus('error')
-        setMessage(`${error.code}: ${error.message}`)
-        void appendEvent(session.id, 'gps.error', { code: error.code, message: error.message })
+        const reportError = () => {
+          setRecorderStatus('error')
+          setMessage(`${error.code}: ${error.message}`)
+          void appendEvent(session.id, 'gps.error', { code: error.code, message: error.message })
+        }
+        void resetGpsWatch(navigator.geolocation, watchIdRef, releaseWakeLock).then(
+          reportError,
+          reportError,
+        )
       },
       {
         enableHighAccuracy: true,
@@ -233,13 +240,11 @@ export function App() {
         timeout: STALE_AFTER_MS,
       },
     )
-  }, [recordEvent, requestWakeLock, session])
+  }, [recordEvent, releaseWakeLock, requestWakeLock, session])
 
   const stopRecording = useCallback(async () => {
-    if (watchIdRef.current !== null) navigator.geolocation.clearWatch(watchIdRef.current)
-    watchIdRef.current = null
+    await resetGpsWatch(navigator.geolocation, watchIdRef, releaseWakeLock)
     setRecorderStatus('stopped')
-    await releaseWakeLock()
     await recordEvent('gps.stopped', { sampleCount })
   }, [recordEvent, releaseWakeLock, sampleCount])
 

--- a/src/gps-watch.test.ts
+++ b/src/gps-watch.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resetGpsWatch, type WatchIdRef } from './gps-watch'
+
+describe('resetGpsWatch', () => {
+  it('clears a failed watch and allows a fresh retry', async () => {
+    const watchIdRef: WatchIdRef = { current: null }
+    const clearWatch = vi.fn()
+    const releaseWakeLock = vi.fn(async () => undefined)
+    let nextWatchId = 0
+
+    const start = () => {
+      if (watchIdRef.current !== null) return false
+      nextWatchId += 1
+      watchIdRef.current = nextWatchId
+      return true
+    }
+
+    expect(start()).toBe(true)
+    expect(watchIdRef.current).toBe(1)
+
+    await resetGpsWatch({ clearWatch }, watchIdRef, releaseWakeLock)
+
+    expect(clearWatch).toHaveBeenCalledOnce()
+    expect(clearWatch).toHaveBeenCalledWith(1)
+    expect(releaseWakeLock).toHaveBeenCalledOnce()
+    expect(watchIdRef.current).toBeNull()
+    expect(start()).toBe(true)
+    expect(watchIdRef.current).toBe(2)
+  })
+})

--- a/src/gps-watch.ts
+++ b/src/gps-watch.ts
@@ -1,0 +1,14 @@
+export interface WatchIdRef {
+  current: number | null
+}
+
+export async function resetGpsWatch(
+  geolocation: Pick<Geolocation, 'clearWatch'>,
+  watchIdRef: WatchIdRef,
+  releaseWakeLock: () => Promise<void>,
+) {
+  const watchId = watchIdRef.current
+  watchIdRef.current = null
+  if (watchId !== null) geolocation.clearWatch(watchId)
+  await releaseWakeLock()
+}


### PR DESCRIPTION
## Что исправлено

Follow-up к #39 по exact-head review задачи #30. После ошибки `watchPosition` capability lab теперь fail-closed очищает старый watch и освобождает Wake Lock до показа retry.

## Проверка

- regression: start → GPS error cleanup → retry starts a new watch
- `pnpm test` — 7/7
- `pnpm typecheck`
- `pnpm build`

## Границы

- физическая iPhone/Android matrix и решение GO PWA остаются pending;
- PR draft;
- merge/deploy не выполнялись;
- ветка не запускает Pages workflow.

Refs #30, #39.