### PR TITLE
feat: конструктор маршрутов для всех участников

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ NOMINATIM_BASE_URL=https://nominatim.openstreetmap.org
 # Production same-origin stand only; leave unset for split local Vite dev.
 # PWA_DIST_DIR=/absolute/path/to/apps/pwa/dist
 # TRUST_PROXY_ADDRESS=127.0.0.1
-EXPECTED_MIGRATION=0011_raid_templates.sql
+EXPECTED_MIGRATION=0012_raid_template_visibility.sql
 ALPHA_ACCESS_MODE=disabled
 # Required with ALPHA_ACCESS_MODE=enforced; generate a distinct random value of at least 32 characters.
 # ALPHA_ACCESS_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -8,10 +8,11 @@ API_HOST=127.0.0.1
 API_PORT=3000
 APP_ORIGIN=http://localhost:5173
 APP_BASE_PATH=/
+NOMINATIM_BASE_URL=https://nominatim.openstreetmap.org
 # Production same-origin stand only; leave unset for split local Vite dev.
 # PWA_DIST_DIR=/absolute/path/to/apps/pwa/dist
 # TRUST_PROXY_ADDRESS=127.0.0.1
-EXPECTED_MIGRATION=0010_kabanda_cover.sql
+EXPECTED_MIGRATION=0011_raid_templates.sql
 ALPHA_ACCESS_MODE=disabled
 # Required with ALPHA_ACCESS_MODE=enforced; generate a distinct random value of at least 32 characters.
 # ALPHA_ACCESS_SECRET=

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,7 +9,7 @@
     "start": "node dist/server.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
-    "test:postgres": "vitest run test/auth.postgres.test.ts test/alpha-access.postgres.test.ts test/kabandas.postgres.test.ts --no-file-parallelism",
+    "test:postgres": "vitest run test/auth.postgres.test.ts test/alpha-access.postgres.test.ts test/kabandas.postgres.test.ts test/raid-templates.postgres.test.ts --no-file-parallelism",
     "e2e:fixture": "tsx src/e2e-fixture-cli.ts",
     "e2e:run": "tsx src/e2e-run.ts",
     "points:import": "tsx src/import-alpha.ts",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -17,15 +17,21 @@ import Fastify, { LogController, type FastifyInstance } from 'fastify'
 import { z, ZodError } from 'zod'
 import type { AuthService } from './auth.js'
 import type { ApiConfig } from './config.js'
+import { registerGeocodingRoutes } from './geocoding-routes.js'
+import { GeocodingError, type GeocodingService } from './geocoding.js'
 import { registerKabandaRoutes } from './kabanda-routes.js'
 import { KabandaError, type KabandaService } from './kabandas.js'
 import { registerRaidRoutes } from './raid-routes.js'
 import { RaidError, type RaidService } from './raids.js'
+import { registerRaidTemplateRoutes } from './raid-template-routes.js'
+import { RaidTemplateError, type RaidTemplateService } from './raid-templates.js'
 
 export interface AppDependencies {
   auth: AuthService
   kabandas: KabandaService
   raids?: RaidService
+  raidTemplates?: RaidTemplateService
+  geocoding?: GeocodingService
   config: ApiConfig
   readiness: () => Promise<void>
   onDiagnosticSignal?: (signal: AlphaDiagnosticSignal) => void
@@ -202,6 +208,16 @@ export async function buildApp(dependencies: AppDependencies): Promise<FastifyIn
         error: { code: error.code, message: error.message, details: error.details },
       })
     }
+    if (error instanceof RaidTemplateError) {
+      return reply.status(error.statusCode).send({
+        error: { code: error.code, message: error.message, details: error.details },
+      })
+    }
+    if (error instanceof GeocodingError) {
+      return reply.status(error.statusCode).send({
+        error: { code: error.code, message: error.message },
+      })
+    }
     const databaseError = error as { code?: string; constraint?: string }
     request.log.error(
       {
@@ -332,6 +348,18 @@ export async function buildApp(dependencies: AppDependencies): Promise<FastifyIn
 
   await registerKabandaRoutes(app, dependencies)
   if (dependencies.raids) await registerRaidRoutes(app, { ...dependencies, raids: dependencies.raids })
+  if (dependencies.raidTemplates) {
+    await registerRaidTemplateRoutes(app, {
+      ...dependencies,
+      raidTemplates: dependencies.raidTemplates,
+    })
+  }
+  if (dependencies.geocoding) {
+    await registerGeocodingRoutes(app, {
+      ...dependencies,
+      geocoding: dependencies.geocoding,
+    })
+  }
 
   app.setNotFoundHandler((request, reply) => {
     const acceptsHtml = request.headers.accept

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -17,7 +17,7 @@ const environmentSchema = z.object({
   NOMINATIM_BASE_URL: z.url().default('https://nominatim.openstreetmap.org'),
   PWA_DIST_DIR: z.string().min(1).optional(),
   TRUST_PROXY_ADDRESS: z.string().min(1).optional(),
-  EXPECTED_MIGRATION: z.string().regex(/^\d{4}_[a-z0-9_]+\.sql$/).default('0011_raid_templates.sql'),
+  EXPECTED_MIGRATION: z.string().regex(/^\d{4}_[a-z0-9_]+\.sql$/).default('0012_raid_template_visibility.sql'),
   DATABASE_URL: z
     .string()
     .min(1)

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -14,9 +14,10 @@ const environmentSchema = z.object({
   API_PORT: z.coerce.number().int().min(1).max(65_535).default(3000),
   APP_ORIGIN: z.url().default('http://localhost:5173'),
   APP_BASE_PATH: z.string().regex(/^\/([^?#]*\/)?$/).default('/'),
+  NOMINATIM_BASE_URL: z.url().default('https://nominatim.openstreetmap.org'),
   PWA_DIST_DIR: z.string().min(1).optional(),
   TRUST_PROXY_ADDRESS: z.string().min(1).optional(),
-  EXPECTED_MIGRATION: z.string().regex(/^\d{4}_[a-z0-9_]+\.sql$/).default('0010_kabanda_cover.sql'),
+  EXPECTED_MIGRATION: z.string().regex(/^\d{4}_[a-z0-9_]+\.sql$/).default('0011_raid_templates.sql'),
   DATABASE_URL: z
     .string()
     .min(1)

--- a/apps/api/src/geocoding-routes.ts
+++ b/apps/api/src/geocoding-routes.ts
@@ -1,0 +1,41 @@
+import { reverseGeocodeQuerySchema } from '@kabanda/contracts'
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
+import type { AuthService } from './auth.js'
+import type { ApiConfig } from './config.js'
+import type { GeocodingService } from './geocoding.js'
+
+type RouteDependencies = {
+  auth: AuthService
+  config: ApiConfig
+  geocoding: GeocodingService
+}
+
+function authRequired(reply: FastifyReply) {
+  return reply.status(401).send({
+    error: { code: 'AUTH_REQUIRED', message: 'Нужно войти в аккаунт' },
+  })
+}
+
+async function currentUser(request: FastifyRequest, dependencies: RouteDependencies) {
+  const token = request.cookies[dependencies.config.cookieName]
+  return token ? dependencies.auth.getUser(token) : null
+}
+
+export async function registerGeocodingRoutes(
+  app: FastifyInstance,
+  dependencies: RouteDependencies,
+): Promise<void> {
+  app.get(
+    '/api/geocoding/reverse',
+    { config: { rateLimit: { max: 30, timeWindow: '1 minute' } } },
+    async (request, reply) => {
+      const user = await currentUser(request, dependencies)
+      if (!user) return authRequired(reply)
+      const query = reverseGeocodeQuerySchema.parse(request.query)
+      const result = await dependencies.geocoding.reverse(query.latitude, query.longitude)
+      return reply
+        .header('Cache-Control', 'private, no-store')
+        .send(result)
+    },
+  )
+}

--- a/apps/api/src/geocoding.ts
+++ b/apps/api/src/geocoding.ts
@@ -1,0 +1,238 @@
+import type { ReverseGeocodeResult } from '@kabanda/contracts'
+
+export class GeocodingError extends Error {
+  constructor(
+    readonly code: 'GEOCODING_PROVIDER_UNAVAILABLE',
+    readonly statusCode: 503,
+    message: string,
+  ) {
+    super(message)
+  }
+}
+
+export interface GeocodingService {
+  reverse(latitude: number, longitude: number): Promise<ReverseGeocodeResult>
+}
+
+type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>
+
+type NominatimReverseGeocoderOptions = {
+  baseUrl: string
+  appOrigin: string
+  userAgent: string
+  fetch?: FetchLike
+  now?: () => number
+  sleep?: (milliseconds: number) => Promise<void>
+  timeoutMilliseconds?: number
+  cacheTtlMilliseconds?: number
+  maximumCacheEntries?: number
+  maximumQueuedRequests?: number
+  queueDeadlineMilliseconds?: number
+}
+
+type CacheEntry = {
+  expiresAt: number
+  result: ReverseGeocodeResult
+}
+
+const upstreamIntervalMilliseconds = 1_000
+const maximumUpstreamBodyBytes = 64 * 1024
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds))
+}
+
+function boundedText(value: unknown, maximumLength: number): string {
+  if (typeof value !== 'string') return ''
+  return value.replace(/\s+/g, ' ').trim().slice(0, maximumLength)
+}
+
+function firstBoundedValue(
+  record: Record<string, unknown>,
+  keys: string[],
+  maximumLength: number,
+): string {
+  for (const key of keys) {
+    const candidate = boundedText(record[key], maximumLength)
+    if (candidate) return candidate
+  }
+  return ''
+}
+
+function providerUnavailable(): GeocodingError {
+  return new GeocodingError(
+    'GEOCODING_PROVIDER_UNAVAILABLE',
+    503,
+    'Не удалось определить адрес. Введите его вручную',
+  )
+}
+
+export class NominatimReverseGeocoder implements GeocodingService {
+  private readonly fetchImplementation: FetchLike
+  private readonly now: () => number
+  private readonly sleep: (milliseconds: number) => Promise<void>
+  private readonly timeoutMilliseconds: number
+  private readonly cacheTtlMilliseconds: number
+  private readonly maximumCacheEntries: number
+  private readonly maximumQueuedRequests: number
+  private readonly queueDeadlineMilliseconds: number
+  private readonly cache = new Map<string, CacheEntry>()
+  private readonly inflight = new Map<string, Promise<ReverseGeocodeResult>>()
+  private upstreamQueue: Promise<void> = Promise.resolve()
+  private nextUpstreamAt = 0
+  private queuedRequests = 0
+
+  constructor(private readonly options: NominatimReverseGeocoderOptions) {
+    this.fetchImplementation = options.fetch ?? fetch
+    this.now = options.now ?? Date.now
+    this.sleep = options.sleep ?? delay
+    this.timeoutMilliseconds = options.timeoutMilliseconds ?? 4_000
+    this.cacheTtlMilliseconds = options.cacheTtlMilliseconds ?? 24 * 60 * 60 * 1_000
+    this.maximumCacheEntries = options.maximumCacheEntries ?? 500
+    this.maximumQueuedRequests = options.maximumQueuedRequests ?? 6
+    this.queueDeadlineMilliseconds = options.queueDeadlineMilliseconds ?? 6_000
+  }
+
+  async reverse(latitude: number, longitude: number): Promise<ReverseGeocodeResult> {
+    const roundedLatitude = Number(latitude.toFixed(5))
+    const roundedLongitude = Number(longitude.toFixed(5))
+    const cacheKey = `${roundedLatitude.toFixed(5)},${roundedLongitude.toFixed(5)}`
+    const cached = this.cache.get(cacheKey)
+    if (cached && cached.expiresAt > this.now()) {
+      this.cache.delete(cacheKey)
+      this.cache.set(cacheKey, cached)
+      return cached.result
+    }
+    if (cached) this.cache.delete(cacheKey)
+
+    const active = this.inflight.get(cacheKey)
+    if (active) return active
+    if (this.queuedRequests >= this.maximumQueuedRequests) throw providerUnavailable()
+
+    this.queuedRequests += 1
+    const deadline = this.now() + this.queueDeadlineMilliseconds
+    const request = this.enqueueUpstream(roundedLatitude, roundedLongitude, deadline)
+      .then((result) => {
+        this.storeCache(cacheKey, result)
+        return result
+      })
+      .finally(() => {
+        this.queuedRequests -= 1
+        this.inflight.delete(cacheKey)
+      })
+    this.inflight.set(cacheKey, request)
+    return request
+  }
+
+  private enqueueUpstream(
+    latitude: number,
+    longitude: number,
+    deadline: number,
+  ): Promise<ReverseGeocodeResult> {
+    const request = this.upstreamQueue.then(async () => {
+      const remainingMilliseconds = deadline - this.now()
+      if (remainingMilliseconds <= 0) throw providerUnavailable()
+      const waitMilliseconds = Math.max(0, this.nextUpstreamAt - this.now())
+      if (waitMilliseconds >= remainingMilliseconds) throw providerUnavailable()
+      if (waitMilliseconds > 0) await this.sleep(waitMilliseconds)
+      if (this.now() >= deadline) throw providerUnavailable()
+      this.nextUpstreamAt = this.now() + upstreamIntervalMilliseconds
+      return this.requestUpstream(latitude, longitude, deadline)
+    })
+    this.upstreamQueue = request.then(() => undefined, () => undefined)
+    return request
+  }
+
+  private async requestUpstream(
+    latitude: number,
+    longitude: number,
+    deadline: number,
+  ): Promise<ReverseGeocodeResult> {
+    const baseUrl = this.options.baseUrl.endsWith('/')
+      ? this.options.baseUrl
+      : `${this.options.baseUrl}/`
+    const url = new URL('reverse', baseUrl)
+    url.searchParams.set('format', 'jsonv2')
+    url.searchParams.set('lat', latitude.toFixed(5))
+    url.searchParams.set('lon', longitude.toFixed(5))
+    url.searchParams.set('zoom', '18')
+    url.searchParams.set('addressdetails', '1')
+
+    const remainingMilliseconds = deadline - this.now()
+    if (remainingMilliseconds <= 0) throw providerUnavailable()
+    const controller = new AbortController()
+    const timeout = setTimeout(
+      () => controller.abort(),
+      Math.min(this.timeoutMilliseconds, remainingMilliseconds),
+    )
+    try {
+      const response = await this.fetchImplementation(url, {
+        headers: {
+          Accept: 'application/json',
+          'Accept-Language': 'ru',
+          Referer: this.options.appOrigin,
+          'User-Agent': this.options.userAgent,
+        },
+        redirect: 'error',
+        signal: controller.signal,
+      })
+      if (!response.ok) throw providerUnavailable()
+      const declaredLength = Number(response.headers.get('content-length'))
+      if (Number.isFinite(declaredLength) && declaredLength > maximumUpstreamBodyBytes) {
+        throw providerUnavailable()
+      }
+      const responseText = await response.text()
+      if (Buffer.byteLength(responseText, 'utf8') > maximumUpstreamBodyBytes) {
+        throw providerUnavailable()
+      }
+      return this.normalizeResponse(responseText)
+    } catch (error) {
+      if (error instanceof GeocodingError) throw error
+      throw providerUnavailable()
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+
+  private normalizeResponse(responseText: string): ReverseGeocodeResult {
+    let value: unknown
+    try {
+      value = JSON.parse(responseText)
+    } catch {
+      throw providerUnavailable()
+    }
+    if (!value || typeof value !== 'object' || Array.isArray(value)) throw providerUnavailable()
+    const response = value as Record<string, unknown>
+    if ('error' in response) throw providerUnavailable()
+    const addressParts = response.address && typeof response.address === 'object'
+      && !Array.isArray(response.address)
+      ? response.address as Record<string, unknown>
+      : {}
+    const address = boundedText(response.display_name, 300)
+    if (!address) throw providerUnavailable()
+    const name = boundedText(response.name, 160) || firstBoundedValue(addressParts, [
+      'amenity',
+      'shop',
+      'tourism',
+      'leisure',
+      'building',
+      'road',
+      'pedestrian',
+      'neighbourhood',
+      'suburb',
+    ], 160)
+    return { name, address, source: 'openstreetmap' }
+  }
+
+  private storeCache(cacheKey: string, result: ReverseGeocodeResult): void {
+    while (this.cache.size >= this.maximumCacheEntries) {
+      const oldestKey = this.cache.keys().next().value
+      if (typeof oldestKey !== 'string') break
+      this.cache.delete(oldestKey)
+    }
+    this.cache.set(cacheKey, {
+      expiresAt: this.now() + this.cacheTtlMilliseconds,
+      result,
+    })
+  }
+}

--- a/apps/api/src/raid-template-cover.ts
+++ b/apps/api/src/raid-template-cover.ts
@@ -1,0 +1,76 @@
+import { createHash } from 'node:crypto'
+import sharp from 'sharp'
+
+const jpegDataUrlPattern = /^data:image\/jpeg;base64,([A-Za-z0-9+/]+={0,2})$/
+const maximumDataUrlLength = 420_000
+const maximumInputPixels = 12_000_000
+const maximumOutputBytes = 3 * 1024 * 1024
+
+export class RaidTemplateCoverError extends Error {
+  constructor(
+    readonly code: 'RAID_TEMPLATE_COVER_INVALID' | 'RAID_TEMPLATE_COVER_TOO_LARGE',
+    message: string,
+  ) {
+    super(message)
+  }
+}
+
+export type ProcessedRaidTemplateCover = {
+  bytes: Buffer
+  contentType: 'image/jpeg'
+  sizeBytes: number
+  width: number
+  height: number
+  sha256: string
+}
+
+export async function processRaidTemplateCover(dataUrl: string): Promise<ProcessedRaidTemplateCover> {
+  if (dataUrl.length > maximumDataUrlLength) {
+    throw new RaidTemplateCoverError('RAID_TEMPLATE_COVER_TOO_LARGE', 'Обложка слишком большая')
+  }
+  const encoded = jpegDataUrlPattern.exec(dataUrl)?.[1]
+  if (!encoded) {
+    throw new RaidTemplateCoverError('RAID_TEMPLATE_COVER_INVALID', 'Нужна корректная JPEG-обложка')
+  }
+
+  const source = Buffer.from(encoded, 'base64')
+  if (source.length === 0 || source.toString('base64') !== encoded) {
+    throw new RaidTemplateCoverError('RAID_TEMPLATE_COVER_INVALID', 'Нужна корректная JPEG-обложка')
+  }
+
+  try {
+    const image = sharp(source, { failOn: 'error', limitInputPixels: maximumInputPixels })
+    const metadata = await image.metadata()
+    if (
+      metadata.format !== 'jpeg' ||
+      !metadata.width ||
+      !metadata.height ||
+      metadata.width > 8_000 ||
+      metadata.height > 8_000 ||
+      metadata.width * metadata.height > maximumInputPixels
+    ) {
+      throw new RaidTemplateCoverError('RAID_TEMPLATE_COVER_INVALID', 'Нужна корректная JPEG-обложка')
+    }
+
+    const normalized = await image
+      .rotate()
+      .resize({ width: 2_048, height: 2_048, fit: 'inside', withoutEnlargement: true })
+      .jpeg({ quality: 82, mozjpeg: true })
+      .toBuffer({ resolveWithObject: true })
+    const { width, height, size } = normalized.info
+    if (!width || !height || size < 1 || size > maximumOutputBytes) {
+      throw new RaidTemplateCoverError('RAID_TEMPLATE_COVER_TOO_LARGE', 'Обложка слишком большая')
+    }
+    return {
+      bytes: normalized.data,
+      contentType: 'image/jpeg',
+      sizeBytes: size,
+      width,
+      height,
+      sha256: createHash('sha256').update(normalized.data).digest('hex'),
+    }
+  } catch (error) {
+    if (error instanceof RaidTemplateCoverError) throw error
+    throw new RaidTemplateCoverError('RAID_TEMPLATE_COVER_INVALID', 'Нужна корректная JPEG-обложка')
+  }
+}

--- a/apps/api/src/raid-template-routes.ts
+++ b/apps/api/src/raid-template-routes.ts
@@ -1,0 +1,92 @@
+import { createRaidTemplateSchema, idempotencyKeySchema } from '@kabanda/contracts'
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
+import { z } from 'zod'
+import type { AuthService } from './auth.js'
+import type { ApiConfig } from './config.js'
+import type { RaidTemplateService } from './raid-templates.js'
+
+type RouteDependencies = {
+  auth: AuthService
+  config: ApiConfig
+  raidTemplates: RaidTemplateService
+}
+
+const resourceIdSchema = z.uuid()
+
+function authRequired(reply: FastifyReply) {
+  return reply.status(401).send({
+    error: { code: 'AUTH_REQUIRED', message: 'Нужно войти в аккаунт' },
+  })
+}
+
+async function currentUser(request: FastifyRequest, dependencies: RouteDependencies) {
+  const token = request.cookies[dependencies.config.cookieName]
+  return token ? dependencies.auth.getUser(token) : null
+}
+
+export async function registerRaidTemplateRoutes(
+  app: FastifyInstance,
+  dependencies: RouteDependencies,
+): Promise<void> {
+  app.post(
+    '/api/kabandas/:kabandaId/raid-templates',
+    { bodyLimit: 768 * 1024 },
+    async (request, reply) => {
+      const user = await currentUser(request, dependencies)
+      if (!user) return authRequired(reply)
+      const kabandaId = resourceIdSchema.parse(
+        (request.params as { kabandaId: string }).kabandaId,
+      )
+      const operationId = idempotencyKeySchema.parse(request.headers['idempotency-key'])
+      const input = createRaidTemplateSchema.parse(request.body)
+      const response = await dependencies.raidTemplates.createTemplate(
+        user.id,
+        kabandaId,
+        input,
+        operationId,
+      )
+      return reply
+        .header('Cache-Control', 'private, no-store')
+        .status(201)
+        .send(response)
+    },
+  )
+
+  app.get('/api/kabandas/:kabandaId/raid-templates', async (request, reply) => {
+    const user = await currentUser(request, dependencies)
+    if (!user) return authRequired(reply)
+    const kabandaId = resourceIdSchema.parse(
+      (request.params as { kabandaId: string }).kabandaId,
+    )
+    const templates = await dependencies.raidTemplates.listTemplates(user.id, kabandaId)
+    return reply
+      .header('Cache-Control', 'private, no-store')
+      .send({ templates })
+  })
+
+  app.get('/api/raid-templates/:templateId', async (request, reply) => {
+    const user = await currentUser(request, dependencies)
+    if (!user) return authRequired(reply)
+    const templateId = resourceIdSchema.parse(
+      (request.params as { templateId: string }).templateId,
+    )
+    const template = await dependencies.raidTemplates.getTemplate(user.id, templateId)
+    return reply
+      .header('Cache-Control', 'private, no-store')
+      .send({ template })
+  })
+
+  app.get('/api/raid-templates/:templateId/cover', async (request, reply) => {
+    const user = await currentUser(request, dependencies)
+    if (!user) return authRequired(reply)
+    const templateId = resourceIdSchema.parse(
+      (request.params as { templateId: string }).templateId,
+    )
+    const cover = await dependencies.raidTemplates.readCover(user.id, templateId)
+    return reply
+      .header('Cache-Control', 'private, no-store')
+      .header('ETag', `"${cover.sha256}"`)
+      .type(cover.contentType)
+      .send(cover.bytes)
+  })
+}

--- a/apps/api/src/raid-templates.ts
+++ b/apps/api/src/raid-templates.ts
@@ -1,0 +1,463 @@
+import { createHash } from 'node:crypto'
+import type { CreateRaidTemplate } from '@kabanda/contracts'
+import type { Pool, PoolClient } from 'pg'
+import {
+  processRaidTemplateCover,
+  RaidTemplateCoverError,
+  type ProcessedRaidTemplateCover,
+} from './raid-template-cover.js'
+
+export class RaidTemplateError extends Error {
+  constructor(
+    readonly code: string,
+    readonly statusCode: number,
+    message: string,
+    readonly details?: Record<string, unknown>,
+  ) {
+    super(message)
+  }
+}
+
+export type RaidTemplateEstimateProjection = {
+  method: 'straight_segments'
+  distanceMeters: number
+}
+
+export type RaidTemplateCoverProjection = {
+  url: string
+  sha256: string
+  width: number
+  height: number
+}
+
+export type RaidTemplateSummary = {
+  id: string
+  scope: 'kabanda'
+  kabandaId: string
+  createdByUserId: string
+  title: string
+  version: number
+  cover: RaidTemplateCoverProjection
+  pointCount: number
+  estimate: RaidTemplateEstimateProjection
+  createdAt: string
+  updatedAt: string
+}
+
+export type RaidTemplatePointProjection = {
+  id: string
+  position: number
+  name: string
+  address: string
+  comment: string
+  latitude: number
+  longitude: number
+}
+
+export type RaidTemplateProjection = RaidTemplateSummary & {
+  points: RaidTemplatePointProjection[]
+}
+
+export type CreateRaidTemplateResponse = {
+  receipt: {
+    operationId: string
+    command: 'create-raid-template'
+    resultingVersion: number
+    serverAt: string
+  }
+  template: RaidTemplateProjection
+}
+
+export type RaidTemplateCover = {
+  bytes: Buffer
+  contentType: 'image/jpeg'
+  sha256: string
+}
+
+export interface RaidTemplateService {
+  createTemplate(
+    actorUserId: string,
+    kabandaId: string,
+    input: CreateRaidTemplate,
+    operationId: string,
+  ): Promise<CreateRaidTemplateResponse>
+  listTemplates(actorUserId: string, kabandaId: string): Promise<RaidTemplateSummary[]>
+  getTemplate(actorUserId: string, templateId: string): Promise<RaidTemplateProjection>
+  readCover(actorUserId: string, templateId: string): Promise<RaidTemplateCover>
+}
+
+type RaidTemplateRow = {
+  id: string
+  scope: 'kabanda'
+  kabanda_id: string
+  created_by_user_id: string
+  title: string
+  version: number
+  point_count: number
+  cover_sha256: string
+  cover_width: number
+  cover_height: number
+  distance_method: 'straight_segments'
+  estimated_distance_meters: number
+  created_at: Date
+  updated_at: Date
+}
+
+type CoverProcessor = (dataUrl: string) => Promise<ProcessedRaidTemplateCover>
+
+function requestFingerprint(
+  kabandaId: string,
+  input: CreateRaidTemplate,
+): string {
+  return createHash('sha256')
+    .update(JSON.stringify({
+      command: 'create-raid-template',
+      kabandaId,
+      title: input.title,
+      coverImage: input.coverImage,
+      points: input.points,
+    }))
+    .digest('hex')
+}
+
+const maximumActiveTemplatesPerKabanda = 100
+
+const earthRadiusMeters = 6_371_000
+
+function radians(degrees: number): number {
+  return degrees * Math.PI / 180
+}
+
+export function straightSegmentsDistanceMeters(
+  points: CreateRaidTemplate['points'],
+): number {
+  let distanceMeters = 0
+  for (let index = 1; index < points.length; index += 1) {
+    const previous = points[index - 1]!
+    const current = points[index]!
+    const latitudeDelta = radians(current.latitude - previous.latitude)
+    const longitudeDelta = radians(current.longitude - previous.longitude)
+    const previousLatitude = radians(previous.latitude)
+    const currentLatitude = radians(current.latitude)
+    const haversine = Math.sin(latitudeDelta / 2) ** 2
+      + Math.cos(previousLatitude) * Math.cos(currentLatitude)
+      * Math.sin(longitudeDelta / 2) ** 2
+    const boundedHaversine = Math.min(1, Math.max(0, haversine))
+    distanceMeters += 2 * earthRadiusMeters * Math.atan2(
+      Math.sqrt(boundedHaversine),
+      Math.sqrt(1 - boundedHaversine),
+    )
+  }
+  return Math.round(distanceMeters)
+}
+
+async function transaction<T>(pool: Pool, task: (client: PoolClient) => Promise<T>): Promise<T> {
+  const client = await pool.connect()
+  try {
+    await client.query('BEGIN')
+    const result = await task(client)
+    await client.query('COMMIT')
+    return result
+  } catch (error) {
+    await client.query('ROLLBACK')
+    throw error
+  } finally {
+    client.release()
+  }
+}
+
+const templateSelect = `SELECT t.id, t.scope, t.kabanda_id, t.created_by_user_id,
+  t.title, t.version, t.point_count, t.cover_sha256, t.cover_width, t.cover_height,
+  t.distance_method, t.estimated_distance_meters, t.created_at, t.updated_at
+ FROM raid_templates t`
+
+export class DatabaseRaidTemplateService implements RaidTemplateService {
+  constructor(
+    private readonly pool: Pool,
+    private readonly coverProcessor: CoverProcessor = processRaidTemplateCover,
+  ) {}
+
+  async createTemplate(
+    actorUserId: string,
+    kabandaId: string,
+    input: CreateRaidTemplate,
+    operationId: string,
+  ): Promise<CreateRaidTemplateResponse> {
+    const fingerprint = requestFingerprint(kabandaId, input)
+    const estimatedDistanceMeters = straightSegmentsDistanceMeters(input.points)
+    return transaction(this.pool, async (client) => {
+      await client.query('SELECT pg_advisory_xact_lock(hashtextextended($1, 0))', [
+        `${actorUserId}:${operationId}`,
+      ])
+      const replay = await this.replay(client, actorUserId, operationId, fingerprint)
+      if (replay) return replay
+
+      const membership = await client.query(
+        `SELECT 1 FROM kabanda_memberships m
+         JOIN kabandas k ON k.id = m.kabanda_id AND k.archived_at IS NULL
+         WHERE m.kabanda_id = $1 AND m.user_id = $2 AND m.removed_at IS NULL
+         FOR UPDATE OF k, m`,
+        [kabandaId, actorUserId],
+      )
+      if (!membership.rowCount) throw this.notFound()
+
+      const activeTemplateCount = await client.query<{ count: string }>(
+        `SELECT count(*)::text AS count
+         FROM raid_templates
+         WHERE kabanda_id = $1 AND scope = 'kabanda' AND archived_at IS NULL`,
+        [kabandaId],
+      )
+      if (Number(activeTemplateCount.rows[0]?.count ?? 0) >= maximumActiveTemplatesPerKabanda) {
+        throw new RaidTemplateError(
+          'RAID_TEMPLATE_LIMIT_REACHED',
+          409,
+          `В Кабанде может быть не больше ${maximumActiveTemplatesPerKabanda} маршрутов`,
+          { maximum: maximumActiveTemplatesPerKabanda },
+        )
+      }
+
+      let cover: ProcessedRaidTemplateCover
+      try {
+        cover = await this.coverProcessor(input.coverImage)
+      } catch (error) {
+        if (error instanceof RaidTemplateCoverError) {
+          throw new RaidTemplateError(error.code, 400, error.message)
+        }
+        throw error
+      }
+
+      const inserted = await client.query<{ id: string; created_at: Date }>(
+        `INSERT INTO raid_templates
+          (kabanda_id, created_by_user_id, title, point_count,
+           cover_bytes, cover_content_type, cover_size_bytes, cover_width, cover_height,
+           cover_sha256, distance_method, estimated_distance_meters)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
+           'straight_segments', $11)
+         RETURNING id, created_at`,
+        [
+          kabandaId,
+          actorUserId,
+          input.title,
+          input.points.length,
+          cover.bytes,
+          cover.contentType,
+          cover.sizeBytes,
+          cover.width,
+          cover.height,
+          cover.sha256,
+          estimatedDistanceMeters,
+        ],
+      )
+      const template = inserted.rows[0]
+      if (!template) throw new Error('Raid template create did not return a row')
+
+      const points = input.points.map((point, position) => ({ ...point, position }))
+      await client.query(
+        `INSERT INTO raid_template_points
+          (template_id, position, name, address, comment, location)
+         SELECT $1, point.position, point.name, point.address, point.comment,
+           ST_SetSRID(ST_MakePoint(point.longitude, point.latitude), 4326)::geography
+         FROM jsonb_to_recordset($2::jsonb) AS point(
+           position smallint,
+           name text,
+           address text,
+           comment text,
+           latitude double precision,
+           longitude double precision
+         )`,
+        [template.id, JSON.stringify(points)],
+      )
+
+      const response: CreateRaidTemplateResponse = {
+        receipt: {
+          operationId,
+          command: 'create-raid-template',
+          resultingVersion: 1,
+          serverAt: template.created_at.toISOString(),
+        },
+        template: await this.project(client, template.id),
+      }
+      await client.query(
+        `INSERT INTO raid_template_receipts
+          (actor_user_id, operation_id, template_id, command, request_fingerprint,
+           resulting_version, response_json)
+         VALUES ($1, $2, $3, 'create-raid-template', $4, 1, $5)`,
+        [actorUserId, operationId, template.id, fingerprint, response],
+      )
+      return response
+    })
+  }
+
+  async listTemplates(actorUserId: string, kabandaId: string): Promise<RaidTemplateSummary[]> {
+    return transaction(this.pool, async (client) => {
+      const membership = await client.query(
+        `SELECT 1 FROM kabanda_memberships m
+         JOIN kabandas k ON k.id = m.kabanda_id AND k.archived_at IS NULL
+         WHERE m.kabanda_id = $1 AND m.user_id = $2 AND m.removed_at IS NULL
+         FOR SHARE OF k, m`,
+        [kabandaId, actorUserId],
+      )
+      if (!membership.rowCount) throw this.notFound()
+      const result = await client.query<RaidTemplateRow>(
+        `${templateSelect}
+         WHERE t.kabanda_id = $1 AND t.scope = 'kabanda' AND t.archived_at IS NULL
+         ORDER BY t.updated_at DESC, t.id DESC
+         LIMIT 100`,
+        [kabandaId],
+      )
+      return result.rows.map((row) => this.summary(row))
+    })
+  }
+
+  async getTemplate(actorUserId: string, templateId: string): Promise<RaidTemplateProjection> {
+    return transaction(this.pool, async (client) => {
+      await this.visibleTemplate(client, actorUserId, templateId)
+      return this.project(client, templateId)
+    })
+  }
+
+  async readCover(actorUserId: string, templateId: string): Promise<RaidTemplateCover> {
+    const result = await this.pool.query<{
+      cover_bytes: Buffer
+      cover_content_type: 'image/jpeg'
+      cover_sha256: string
+    }>(
+      `SELECT t.cover_bytes, t.cover_content_type, t.cover_sha256
+       FROM raid_templates t
+       JOIN kabandas k ON k.id = t.kabanda_id AND k.archived_at IS NULL
+       JOIN kabanda_memberships m
+         ON m.kabanda_id = t.kabanda_id AND m.user_id = $2 AND m.removed_at IS NULL
+       WHERE t.id = $1 AND t.scope = 'kabanda' AND t.archived_at IS NULL`,
+      [templateId, actorUserId],
+    )
+    const cover = result.rows[0]
+    if (!cover) throw this.notFound()
+    return {
+      bytes: cover.cover_bytes,
+      contentType: 'image/jpeg',
+      sha256: cover.cover_sha256,
+    }
+  }
+
+  private async replay(
+    client: PoolClient,
+    actorUserId: string,
+    operationId: string,
+    fingerprint: string,
+  ): Promise<CreateRaidTemplateResponse | null> {
+    const result = await client.query<{
+      request_fingerprint: string
+      response_json: CreateRaidTemplateResponse
+      access_active: boolean
+    }>(
+      `SELECT receipt.request_fingerprint, receipt.response_json,
+         (template.archived_at IS NULL AND kabanda.archived_at IS NULL
+           AND membership.user_id IS NOT NULL) AS access_active
+       FROM raid_template_receipts receipt
+       JOIN raid_templates template ON template.id = receipt.template_id
+       JOIN kabandas kabanda ON kabanda.id = template.kabanda_id
+       LEFT JOIN kabanda_memberships membership
+         ON membership.kabanda_id = template.kabanda_id
+           AND membership.user_id = $1 AND membership.removed_at IS NULL
+       WHERE receipt.actor_user_id = $1 AND receipt.operation_id = $2`,
+      [actorUserId, operationId],
+    )
+    const receipt = result.rows[0]
+    if (!receipt) return null
+    if (!receipt.access_active) throw this.notFound()
+    if (receipt.request_fingerprint !== fingerprint) {
+      throw new RaidTemplateError(
+        'RAID_TEMPLATE_IDEMPOTENCY_CONFLICT',
+        409,
+        'Ключ уже использован для другого шаблона',
+      )
+    }
+    return receipt.response_json
+  }
+
+  private async visibleTemplate(
+    client: PoolClient,
+    actorUserId: string,
+    templateId: string,
+  ): Promise<void> {
+    const result = await client.query(
+      `SELECT 1 FROM raid_templates template
+       JOIN kabandas kabanda
+         ON kabanda.id = template.kabanda_id AND kabanda.archived_at IS NULL
+       JOIN kabanda_memberships membership
+         ON membership.kabanda_id = template.kabanda_id
+           AND membership.user_id = $2 AND membership.removed_at IS NULL
+       WHERE template.id = $1 AND template.scope = 'kabanda'
+         AND template.archived_at IS NULL
+       FOR SHARE OF template, kabanda, membership`,
+      [templateId, actorUserId],
+    )
+    if (!result.rowCount) throw this.notFound()
+  }
+
+  private async project(client: PoolClient, templateId: string): Promise<RaidTemplateProjection> {
+    const templateResult = await client.query<RaidTemplateRow>(
+      `${templateSelect} WHERE t.id = $1 AND t.archived_at IS NULL`,
+      [templateId],
+    )
+    const row = templateResult.rows[0]
+    if (!row) throw this.notFound()
+    const points = await client.query<{
+      id: string
+      position: number
+      name: string
+      address: string
+      comment: string
+      latitude: number
+      longitude: number
+    }>(
+      `SELECT id, position, name, address, comment,
+         ST_Y(location::geometry) AS latitude,
+         ST_X(location::geometry) AS longitude
+       FROM raid_template_points
+       WHERE template_id = $1
+       ORDER BY position`,
+      [templateId],
+    )
+    return {
+      ...this.summary(row),
+      points: points.rows.map((point) => ({
+        id: point.id,
+        position: Number(point.position),
+        name: point.name,
+        address: point.address,
+        comment: point.comment,
+        latitude: Number(point.latitude),
+        longitude: Number(point.longitude),
+      })),
+    }
+  }
+
+  private summary(row: RaidTemplateRow): RaidTemplateSummary {
+    return {
+      id: row.id,
+      scope: 'kabanda',
+      kabandaId: row.kabanda_id,
+      createdByUserId: row.created_by_user_id,
+      title: row.title,
+      version: Number(row.version),
+      cover: {
+        url: `/api/raid-templates/${encodeURIComponent(row.id)}/cover`,
+        sha256: row.cover_sha256,
+        width: Number(row.cover_width),
+        height: Number(row.cover_height),
+      },
+      pointCount: Number(row.point_count),
+      estimate: {
+        method: row.distance_method,
+        distanceMeters: Number(row.estimated_distance_meters),
+      },
+      createdAt: row.created_at.toISOString(),
+      updatedAt: row.updated_at.toISOString(),
+    }
+  }
+
+  private notFound(): RaidTemplateError {
+    return new RaidTemplateError('RAID_TEMPLATE_NOT_FOUND', 404, 'Шаблон рейда не найден')
+  }
+}

--- a/apps/api/src/raid-templates.ts
+++ b/apps/api/src/raid-templates.ts
@@ -119,6 +119,21 @@ function requestFingerprint(
     .digest('hex')
 }
 
+function legacyRequestFingerprint(
+  kabandaId: string,
+  input: CreateRaidTemplate,
+): string {
+  return createHash('sha256')
+    .update(JSON.stringify({
+      command: 'create-raid-template',
+      kabandaId,
+      title: input.title,
+      coverImage: input.coverImage,
+      points: input.points,
+    }))
+    .digest('hex')
+}
+
 const maximumActiveTemplatesPerKabanda = 100
 
 const earthRadiusMeters = 6_371_000
@@ -183,12 +198,20 @@ export class DatabaseRaidTemplateService implements RaidTemplateService {
     operationId: string,
   ): Promise<CreateRaidTemplateResponse> {
     const fingerprint = requestFingerprint(kabandaId, input)
+    const acceptedReplayFingerprints = input.scope === 'kabanda'
+      ? [fingerprint, legacyRequestFingerprint(kabandaId, input)]
+      : [fingerprint]
     const estimatedDistanceMeters = straightSegmentsDistanceMeters(input.points)
     return transaction(this.pool, async (client) => {
       await client.query('SELECT pg_advisory_xact_lock(hashtextextended($1, 0))', [
         `${actorUserId}:${operationId}`,
       ])
-      const replay = await this.replay(client, actorUserId, operationId, fingerprint)
+      const replay = await this.replay(
+        client,
+        actorUserId,
+        operationId,
+        acceptedReplayFingerprints,
+      )
       if (replay) return replay
 
       const membership = await client.query(
@@ -352,7 +375,7 @@ export class DatabaseRaidTemplateService implements RaidTemplateService {
     client: PoolClient,
     actorUserId: string,
     operationId: string,
-    fingerprint: string,
+    acceptedFingerprints: readonly string[],
   ): Promise<CreateRaidTemplateResponse | null> {
     const result = await client.query<{
       request_fingerprint: string
@@ -374,7 +397,7 @@ export class DatabaseRaidTemplateService implements RaidTemplateService {
     const receipt = result.rows[0]
     if (!receipt) return null
     if (!receipt.access_active) throw this.notFound()
-    if (receipt.request_fingerprint !== fingerprint) {
+    if (!acceptedFingerprints.includes(receipt.request_fingerprint)) {
       throw new RaidTemplateError(
         'RAID_TEMPLATE_IDEMPOTENCY_CONFLICT',
         409,

--- a/apps/api/src/raid-templates.ts
+++ b/apps/api/src/raid-templates.ts
@@ -32,9 +32,8 @@ export type RaidTemplateCoverProjection = {
 
 export type RaidTemplateSummary = {
   id: string
-  scope: 'kabanda'
+  scope: 'kabanda' | 'all_authenticated'
   kabandaId: string
-  createdByUserId: string
   title: string
   version: number
   cover: RaidTemplateCoverProjection
@@ -88,9 +87,8 @@ export interface RaidTemplateService {
 
 type RaidTemplateRow = {
   id: string
-  scope: 'kabanda'
+  scope: 'kabanda' | 'all_authenticated'
   kabanda_id: string
-  created_by_user_id: string
   title: string
   version: number
   point_count: number
@@ -113,6 +111,7 @@ function requestFingerprint(
     .update(JSON.stringify({
       command: 'create-raid-template',
       kabandaId,
+      scope: input.scope,
       title: input.title,
       coverImage: input.coverImage,
       points: input.points,
@@ -166,7 +165,7 @@ async function transaction<T>(pool: Pool, task: (client: PoolClient) => Promise<
   }
 }
 
-const templateSelect = `SELECT t.id, t.scope, t.kabanda_id, t.created_by_user_id,
+const templateSelect = `SELECT t.id, t.scope, t.kabanda_id,
   t.title, t.version, t.point_count, t.cover_sha256, t.cover_width, t.cover_height,
   t.distance_method, t.estimated_distance_meters, t.created_at, t.updated_at
  FROM raid_templates t`
@@ -204,7 +203,7 @@ export class DatabaseRaidTemplateService implements RaidTemplateService {
       const activeTemplateCount = await client.query<{ count: string }>(
         `SELECT count(*)::text AS count
          FROM raid_templates
-         WHERE kabanda_id = $1 AND scope = 'kabanda' AND archived_at IS NULL`,
+         WHERE kabanda_id = $1 AND archived_at IS NULL`,
         [kabandaId],
       )
       if (Number(activeTemplateCount.rows[0]?.count ?? 0) >= maximumActiveTemplatesPerKabanda) {
@@ -228,14 +227,15 @@ export class DatabaseRaidTemplateService implements RaidTemplateService {
 
       const inserted = await client.query<{ id: string; created_at: Date }>(
         `INSERT INTO raid_templates
-          (kabanda_id, created_by_user_id, title, point_count,
+          (kabanda_id, scope, created_by_user_id, title, point_count,
            cover_bytes, cover_content_type, cover_size_bytes, cover_width, cover_height,
            cover_sha256, distance_method, estimated_distance_meters)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
-           'straight_segments', $11)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11,
+           'straight_segments', $12)
          RETURNING id, created_at`,
         [
           kabandaId,
+          input.scope,
           actorUserId,
           input.title,
           input.points.length,
@@ -300,7 +300,10 @@ export class DatabaseRaidTemplateService implements RaidTemplateService {
       if (!membership.rowCount) throw this.notFound()
       const result = await client.query<RaidTemplateRow>(
         `${templateSelect}
-         WHERE t.kabanda_id = $1 AND t.scope = 'kabanda' AND t.archived_at IS NULL
+         JOIN kabandas source_kabanda
+           ON source_kabanda.id = t.kabanda_id AND source_kabanda.archived_at IS NULL
+         WHERE t.archived_at IS NULL
+           AND (t.scope = 'all_authenticated' OR (t.scope = 'kabanda' AND t.kabanda_id = $1))
          ORDER BY t.updated_at DESC, t.id DESC
          LIMIT 100`,
         [kabandaId],
@@ -325,9 +328,15 @@ export class DatabaseRaidTemplateService implements RaidTemplateService {
       `SELECT t.cover_bytes, t.cover_content_type, t.cover_sha256
        FROM raid_templates t
        JOIN kabandas k ON k.id = t.kabanda_id AND k.archived_at IS NULL
-       JOIN kabanda_memberships m
-         ON m.kabanda_id = t.kabanda_id AND m.user_id = $2 AND m.removed_at IS NULL
-       WHERE t.id = $1 AND t.scope = 'kabanda' AND t.archived_at IS NULL`,
+       WHERE t.id = $1 AND t.archived_at IS NULL
+         AND (
+           t.scope = 'all_authenticated'
+           OR EXISTS (
+             SELECT 1 FROM kabanda_memberships m
+             WHERE m.kabanda_id = t.kabanda_id
+               AND m.user_id = $2 AND m.removed_at IS NULL
+           )
+         )`,
       [templateId, actorUserId],
     )
     const cover = result.rows[0]
@@ -384,12 +393,16 @@ export class DatabaseRaidTemplateService implements RaidTemplateService {
       `SELECT 1 FROM raid_templates template
        JOIN kabandas kabanda
          ON kabanda.id = template.kabanda_id AND kabanda.archived_at IS NULL
-       JOIN kabanda_memberships membership
-         ON membership.kabanda_id = template.kabanda_id
-           AND membership.user_id = $2 AND membership.removed_at IS NULL
-       WHERE template.id = $1 AND template.scope = 'kabanda'
-         AND template.archived_at IS NULL
-       FOR SHARE OF template, kabanda, membership`,
+       WHERE template.id = $1 AND template.archived_at IS NULL
+         AND (
+           template.scope = 'all_authenticated'
+           OR EXISTS (
+             SELECT 1 FROM kabanda_memberships membership
+             WHERE membership.kabanda_id = template.kabanda_id
+               AND membership.user_id = $2 AND membership.removed_at IS NULL
+           )
+         )
+       FOR SHARE OF template, kabanda`,
       [templateId, actorUserId],
     )
     if (!result.rowCount) throw this.notFound()
@@ -436,9 +449,8 @@ export class DatabaseRaidTemplateService implements RaidTemplateService {
   private summary(row: RaidTemplateRow): RaidTemplateSummary {
     return {
       id: row.id,
-      scope: 'kabanda',
+      scope: row.scope,
       kabandaId: row.kabanda_id,
-      createdByUserId: row.created_by_user_id,
       title: row.title,
       version: Number(row.version),
       cover: {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -3,9 +3,11 @@ import { DatabaseAuthService } from './auth.js'
 import { buildApp } from './app.js'
 import { loadConfig } from './config.js'
 import { assertDatabaseReady, createDatabase } from './database.js'
+import { NominatimReverseGeocoder } from './geocoding.js'
 import { SmtpMagicLinkMailer } from './mailer.js'
 import { DatabaseKabandaService } from './kabandas.js'
 import { DatabaseRaidService } from './raids.js'
+import { DatabaseRaidTemplateService } from './raid-templates.js'
 
 dotenv.config({ path: new URL('../../../.env', import.meta.url) })
 
@@ -28,10 +30,18 @@ const kabandas = new DatabaseKabandaService(database, {
   sessionTtlDays: config.SESSION_TTL_DAYS,
 })
 const raids = new DatabaseRaidService(database, config.MEDIA_CAPABILITY_SECRET)
+const raidTemplates = new DatabaseRaidTemplateService(database)
+const geocoding = new NominatimReverseGeocoder({
+  baseUrl: config.NOMINATIM_BASE_URL,
+  appOrigin: config.APP_ORIGIN,
+  userAgent: `KabandaClosedAlpha/${config.API_BUILD_ID} (${config.APP_ORIGIN})`,
+})
 const app = await buildApp({
   auth,
   kabandas,
   raids,
+  raidTemplates,
+  geocoding,
   config,
   readiness: () => assertDatabaseReady(database, config.EXPECTED_MIGRATION),
 })

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -11,6 +11,7 @@ import {
 import { buildApp, privacySafeOperationRef } from '../src/app.js'
 import { loadConfig } from '../src/config.js'
 import type { KabandaService } from '../src/kabandas.js'
+import { GeocodingError, type GeocodingService } from '../src/geocoding.js'
 import {
   deriveMediaUploadCapability,
   escapeShareCardXml,
@@ -19,6 +20,11 @@ import {
   type RaidResult,
   type RaidService,
 } from '../src/raids.js'
+import {
+  RaidTemplateError,
+  type RaidTemplateProjection,
+  type RaidTemplateService,
+} from '../src/raid-templates.js'
 
 const user: User = {
   id: '7484a9f8-11dd-45bd-9740-44b52413fa6b',
@@ -107,6 +113,16 @@ function createRaids(overrides: Partial<RaidService> = {}): RaidService {
   }
 }
 
+function createRaidTemplates(overrides: Partial<RaidTemplateService> = {}): RaidTemplateService {
+  return {
+    createTemplate: vi.fn(),
+    listTemplates: vi.fn().mockResolvedValue([]),
+    getTemplate: vi.fn(),
+    readCover: vi.fn(),
+    ...overrides,
+  }
+}
+
 const apps: Array<Awaited<ReturnType<typeof buildApp>>> = []
 const temporaryDirectories: string[] = []
 
@@ -122,12 +138,16 @@ async function createTestApp(
   options: {
     environment?: Record<string, string>
     onDiagnosticSignal?: (signal: Parameters<NonNullable<import('../src/app.js').AppDependencies['onDiagnosticSignal']>>[0]) => void
+    raidTemplates?: RaidTemplateService
+    geocoding?: GeocodingService
   } = {},
 ) {
   const app = await buildApp({
     auth,
     kabandas,
     ...(raids ? { raids } : {}),
+    ...(options.raidTemplates ? { raidTemplates: options.raidTemplates } : {}),
+    ...(options.geocoding ? { geocoding: options.geocoding } : {}),
     config: loadConfig({ NODE_ENV: 'test', ...options.environment }),
     readiness: vi.fn().mockResolvedValue(undefined),
     ...(options.onDiagnosticSignal ? { onDiagnosticSignal: options.onDiagnosticSignal } : {}),
@@ -1251,5 +1271,308 @@ describe('API foundation', () => {
       expect(response.statusCode).toBe(200)
       expect(handler).toHaveBeenCalledWith(user.id, raidId, 9, `operation-${path}`)
     }
+  })
+
+  it('registers the atomic raid-template create, catalog, detail and cover routes', async () => {
+    const kabandaId = 'c0e4f157-6a6d-43aa-a9ba-04aee1ff0f14'
+    const templateId = '49b5f9ca-11fb-4474-a616-ddeec22445a6'
+    const template: RaidTemplateProjection = {
+      id: templateId,
+      scope: 'kabanda',
+      kabandaId,
+      createdByUserId: user.id,
+      title: 'Набережные и мосты',
+      version: 1,
+      cover: {
+        url: `/api/raid-templates/${templateId}/cover`,
+        sha256: 'a'.repeat(64),
+        width: 1_280,
+        height: 720,
+      },
+      pointCount: 2,
+      estimate: {
+        method: 'straight_segments',
+        distanceMeters: 1_269,
+      },
+      points: [
+        {
+          id: '3497db55-dfb9-4820-8fa5-c16932fc3c5c',
+          position: 0,
+          name: 'Старт',
+          address: 'Улица Первая, 1',
+          comment: '',
+          latitude: 56.85,
+          longitude: 53.2,
+        },
+        {
+          id: 'f33da1a3-e7fc-4d10-bcc8-17417c3eb1e1',
+          position: 1,
+          name: 'Финиш',
+          address: 'Улица Вторая, 2',
+          comment: 'Собираемся у входа',
+          latitude: 56.86,
+          longitude: 53.21,
+        },
+      ],
+      createdAt: '2026-09-01T08:01:00.000Z',
+      updatedAt: '2026-09-01T08:01:00.000Z',
+    }
+    const createTemplate = vi.fn().mockResolvedValue({
+      receipt: {
+        operationId: 'template-operation',
+        command: 'create-raid-template',
+        resultingVersion: 1,
+        serverAt: template.createdAt,
+      },
+      template,
+    })
+    const listTemplates = vi.fn().mockResolvedValue([{ ...template, points: undefined }])
+    const getTemplate = vi.fn().mockResolvedValue(template)
+    const readCover = vi.fn().mockResolvedValue({
+      bytes: Buffer.from([0xff, 0xd8, 0xff, 0xd9]),
+      contentType: 'image/jpeg',
+      sha256: 'a'.repeat(64),
+    })
+    const app = await createTestApp(
+      createAuth({ getUser: vi.fn().mockResolvedValue(user) }),
+      createKabandas(),
+      undefined,
+      {
+        raidTemplates: createRaidTemplates({
+          createTemplate,
+          listTemplates,
+          getTemplate,
+          readCover,
+        }),
+      },
+    )
+    const input = {
+      title: ' Набережные и мосты ',
+      coverImage: `data:image/jpeg;base64,${'A'.repeat(140_000)}`,
+      points: template.points.map(({ name, address, comment, latitude, longitude }) => ({
+        name,
+        address,
+        comment,
+        latitude,
+        longitude,
+      })),
+    }
+    const created = await app.inject({
+      method: 'POST',
+      url: `/api/kabandas/${kabandaId}/raid-templates`,
+      headers: {
+        origin: testOrigin,
+        cookie: 'kabanda_session=session',
+        'idempotency-key': 'template-operation',
+      },
+      payload: input,
+    })
+    expect(created.statusCode).toBe(201)
+    expect(created.headers['cache-control']).toBe('private, no-store')
+    expect(createTemplate).toHaveBeenCalledWith(
+      user.id,
+      kabandaId,
+      { ...input, title: 'Набережные и мосты' },
+      'template-operation',
+    )
+
+    const catalog = await app.inject({
+      method: 'GET',
+      url: `/api/kabandas/${kabandaId}/raid-templates`,
+      headers: { cookie: 'kabanda_session=session' },
+    })
+    expect(catalog.statusCode).toBe(200)
+    expect(catalog.headers['cache-control']).toBe('private, no-store')
+    expect(listTemplates).toHaveBeenCalledWith(user.id, kabandaId)
+
+    const detail = await app.inject({
+      method: 'GET',
+      url: `/api/raid-templates/${templateId}`,
+      headers: { cookie: 'kabanda_session=session' },
+    })
+    expect(detail.json()).toEqual({ template })
+    expect(getTemplate).toHaveBeenCalledWith(user.id, templateId)
+
+    const cover = await app.inject({
+      method: 'GET',
+      url: `/api/raid-templates/${templateId}/cover`,
+      headers: { cookie: 'kabanda_session=session' },
+    })
+    expect(cover.statusCode).toBe(200)
+    expect(cover.headers['content-type']).toMatch(/^image\/jpeg/)
+    expect(cover.headers.etag).toBe(`"${'a'.repeat(64)}"`)
+    expect(cover.rawPayload).toEqual(Buffer.from([0xff, 0xd8, 0xff, 0xd9]))
+    expect(readCover).toHaveBeenCalledWith(user.id, templateId)
+  })
+
+  it('bounds raid-template writes and preserves not-found authorization semantics', async () => {
+    const kabandaId = 'c0e4f157-6a6d-43aa-a9ba-04aee1ff0f14'
+    const createTemplate = vi.fn()
+    const listTemplates = vi.fn().mockRejectedValue(
+      new RaidTemplateError('RAID_TEMPLATE_NOT_FOUND', 404, 'Шаблон рейда не найден'),
+    )
+    const service = createRaidTemplates({ createTemplate, listTemplates })
+    const anonymousApp = await createTestApp(createAuth(), createKabandas(), undefined, {
+      raidTemplates: service,
+    })
+    const anonymous = await anonymousApp.inject({
+      method: 'GET',
+      url: `/api/kabandas/${kabandaId}/raid-templates`,
+    })
+    expect(anonymous.statusCode).toBe(401)
+    expect(listTemplates).not.toHaveBeenCalled()
+
+    const app = await createTestApp(
+      createAuth({ getUser: vi.fn().mockResolvedValue(user) }),
+      createKabandas(),
+      undefined,
+      { raidTemplates: service },
+    )
+    const headers = {
+      origin: testOrigin,
+      cookie: 'kabanda_session=session',
+      'idempotency-key': 'template-operation',
+    }
+    const point = {
+      name: 'Точка',
+      address: 'Адрес',
+      comment: '',
+      latitude: 56.85,
+      longitude: 53.2,
+    }
+    const invalid = await app.inject({
+      method: 'POST',
+      url: `/api/kabandas/${kabandaId}/raid-templates`,
+      headers,
+      payload: {
+        title: 'Слишком много точек',
+        coverImage: 'data:image/jpeg;base64,AAAA',
+        points: Array.from({ length: 11 }, () => point),
+      },
+    })
+    expect(invalid.statusCode).toBe(400)
+    expect(createTemplate).not.toHaveBeenCalled()
+
+    const legacyClientEstimate = await app.inject({
+      method: 'POST',
+      url: `/api/kabandas/${kabandaId}/raid-templates`,
+      headers,
+      payload: {
+        title: 'Маршрут без сохраняемой оценки Яндекса',
+        coverImage: 'data:image/jpeg;base64,AAAA',
+        points: [point, { ...point, longitude: 53.21 }],
+        estimate: {
+          status: 'ready',
+          mode: 'bicycle',
+          distanceMeters: 8_400,
+          computedAt: '2026-09-01T08:00:00.000Z',
+        },
+      },
+    })
+    expect(legacyClientEstimate.statusCode).toBe(400)
+    expect(createTemplate).not.toHaveBeenCalled()
+
+    const oversized = await app.inject({
+      method: 'POST',
+      url: `/api/kabandas/${kabandaId}/raid-templates`,
+      headers,
+      payload: {
+        title: 'Слишком большая обложка',
+        coverImage: `data:image/jpeg;base64,${'A'.repeat(800_000)}`,
+        points: [point, point],
+      },
+    })
+    expect(oversized.statusCode).toBe(413)
+
+    createTemplate.mockRejectedValueOnce(new RaidTemplateError(
+      'RAID_TEMPLATE_LIMIT_REACHED',
+      409,
+      'В Кабанде может быть не больше 100 маршрутов',
+      { maximum: 100 },
+    ))
+    const atLimit = await app.inject({
+      method: 'POST',
+      url: `/api/kabandas/${kabandaId}/raid-templates`,
+      headers,
+      payload: {
+        title: 'Маршрут 101',
+        coverImage: 'data:image/jpeg;base64,AAAA',
+        points: [point, { ...point, longitude: 53.21 }],
+      },
+    })
+    expect(atLimit.statusCode).toBe(409)
+    expect(atLimit.json()).toMatchObject({
+      error: {
+        code: 'RAID_TEMPLATE_LIMIT_REACHED',
+        message: 'В Кабанде может быть не больше 100 маршрутов',
+        details: { maximum: 100 },
+      },
+    })
+
+    const hidden = await app.inject({
+      method: 'GET',
+      url: `/api/kabandas/${kabandaId}/raid-templates`,
+      headers: { cookie: 'kabanda_session=session' },
+    })
+    expect(hidden.statusCode).toBe(404)
+    expect(hidden.json().error.code).toBe('RAID_TEMPLATE_NOT_FOUND')
+  })
+
+  it('keeps reverse geocoding authenticated, inside Izhevsk and response-bounded', async () => {
+    const reverse = vi.fn().mockResolvedValue({
+      name: 'Ротонда',
+      address: 'Набережная, Ижевск',
+      source: 'openstreetmap',
+    })
+    const anonymousApp = await createTestApp(createAuth(), createKabandas(), undefined, {
+      geocoding: { reverse },
+    })
+    const anonymous = await anonymousApp.inject({
+      method: 'GET',
+      url: '/api/geocoding/reverse?latitude=56.85&longitude=53.2',
+    })
+    expect(anonymous.statusCode).toBe(401)
+    expect(reverse).not.toHaveBeenCalled()
+
+    const app = await createTestApp(
+      createAuth({ getUser: vi.fn().mockResolvedValue(user) }),
+      createKabandas(),
+      undefined,
+      { geocoding: { reverse } },
+    )
+    const outsideIzhevsk = await app.inject({
+      method: 'GET',
+      url: '/api/geocoding/reverse?latitude=55.75&longitude=37.62',
+      headers: { cookie: 'kabanda_session=session' },
+    })
+    expect(outsideIzhevsk.statusCode).toBe(400)
+    expect(reverse).not.toHaveBeenCalled()
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/geocoding/reverse?latitude=56.85&longitude=53.2',
+      headers: { cookie: 'kabanda_session=session' },
+    })
+    expect(response.statusCode).toBe(200)
+    expect(response.headers['cache-control']).toBe('private, no-store')
+    expect(response.json()).toEqual({
+      name: 'Ротонда',
+      address: 'Набережная, Ижевск',
+      source: 'openstreetmap',
+    })
+    expect(reverse).toHaveBeenCalledWith(56.85, 53.2)
+
+    reverse.mockRejectedValueOnce(new GeocodingError(
+      'GEOCODING_PROVIDER_UNAVAILABLE',
+      503,
+      'Не удалось определить адрес. Введите его вручную',
+    ))
+    const unavailable = await app.inject({
+      method: 'GET',
+      url: '/api/geocoding/reverse?latitude=56.86&longitude=53.21',
+      headers: { cookie: 'kabanda_session=session' },
+    })
+    expect(unavailable.statusCode).toBe(503)
+    expect(unavailable.json().error.code).toBe('GEOCODING_PROVIDER_UNAVAILABLE')
   })
 })

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -1280,7 +1280,6 @@ describe('API foundation', () => {
       id: templateId,
       scope: 'kabanda',
       kabandaId,
-      createdByUserId: user.id,
       title: 'Набережные и мосты',
       version: 1,
       cover: {
@@ -1372,7 +1371,7 @@ describe('API foundation', () => {
     expect(createTemplate).toHaveBeenCalledWith(
       user.id,
       kabandaId,
-      { ...input, title: 'Набережные и мосты' },
+      { ...input, scope: 'kabanda', title: 'Набережные и мосты' },
       'template-operation',
     )
 

--- a/apps/api/test/geocoding.test.ts
+++ b/apps/api/test/geocoding.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  GeocodingError,
+  NominatimReverseGeocoder,
+} from '../src/geocoding.js'
+
+function providerResponse(name = 'Ротонда', address = 'Набережная, Ижевск, Россия') {
+  return new Response(JSON.stringify({
+    name,
+    display_name: address,
+    address: { road: 'Набережная', city: 'Ижевск' },
+    place_id: 123,
+    osm_id: 456,
+    licence: 'raw provider fields must not escape',
+  }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>
+
+function service(fetchImplementation: FetchLike, options: {
+  now?: () => number
+  sleep?: (milliseconds: number) => Promise<void>
+  timeoutMilliseconds?: number
+  maximumQueuedRequests?: number
+  queueDeadlineMilliseconds?: number
+} = {}) {
+  return new NominatimReverseGeocoder({
+    baseUrl: 'https://nominatim.openstreetmap.org',
+    appOrigin: 'https://kabanda.example',
+    userAgent: 'KabandaClosedAlpha/test (https://kabanda.example)',
+    fetch: fetchImplementation,
+    ...options,
+  })
+}
+
+describe('Nominatim reverse geocoder', () => {
+  it('identifies the app, rounds coordinates, caches them and exposes only bounded labels', async () => {
+    const fetchImplementation = vi.fn(async (_input: string | URL, _init?: RequestInit) => providerResponse(
+      `  ${'Очень длинное имя '.repeat(20)}  `,
+      `  ${'Длинный адрес '.repeat(40)}  `,
+    ))
+    const geocoding = service(fetchImplementation)
+
+    const first = await geocoding.reverse(56.850001, 53.200001)
+    const cached = await geocoding.reverse(56.850004, 53.200004)
+
+    expect(cached).toEqual(first)
+    expect(first).toEqual({
+      name: expect.any(String),
+      address: expect.any(String),
+      source: 'openstreetmap',
+    })
+    expect(first.name.length).toBeLessThanOrEqual(160)
+    expect(first.address.length).toBeLessThanOrEqual(300)
+    expect(first).not.toHaveProperty('place_id')
+    expect(fetchImplementation).toHaveBeenCalledOnce()
+    const [rawUrl, init] = fetchImplementation.mock.calls[0]!
+    const url = new URL(String(rawUrl))
+    expect(url.origin + url.pathname).toBe('https://nominatim.openstreetmap.org/reverse')
+    expect(Object.fromEntries(url.searchParams)).toMatchObject({
+      format: 'jsonv2',
+      lat: '56.85000',
+      lon: '53.20000',
+      zoom: '18',
+      addressdetails: '1',
+    })
+    const headers = new Headers(init?.headers)
+    expect(headers.get('user-agent')).toBe(
+      'KabandaClosedAlpha/test (https://kabanda.example)',
+    )
+    expect(headers.get('referer')).toBe('https://kabanda.example')
+    expect(headers.get('accept-language')).toBe('ru')
+  })
+
+  it('coalesces identical requests and starts distinct upstream calls at least one second apart', async () => {
+    let clock = 0
+    const starts: number[] = []
+    const sleep = vi.fn(async (milliseconds: number) => {
+      clock += milliseconds
+    })
+    const fetchImplementation = vi.fn(async () => {
+      starts.push(clock)
+      return providerResponse()
+    })
+    const geocoding = service(fetchImplementation, { now: () => clock, sleep })
+
+    const [first, coalesced, second, third] = await Promise.all([
+      geocoding.reverse(56.81, 53.11),
+      geocoding.reverse(56.81, 53.11),
+      geocoding.reverse(56.82, 53.12),
+      geocoding.reverse(56.83, 53.13),
+    ])
+
+    expect(coalesced).toEqual(first)
+    expect(second.source).toBe('openstreetmap')
+    expect(third.source).toBe('openstreetmap')
+    expect(fetchImplementation).toHaveBeenCalledTimes(3)
+    expect(starts).toEqual([0, 1_000, 2_000])
+    expect(sleep).toHaveBeenCalledTimes(2)
+  })
+
+  it('bounds the queue and rejects work that cannot start before its total deadline', async () => {
+    let clock = 0
+    const fetchImplementation = vi.fn(async () => providerResponse())
+    const geocoding = service(fetchImplementation, {
+      now: () => clock,
+      sleep: async (milliseconds) => { clock += milliseconds },
+      maximumQueuedRequests: 3,
+      queueDeadlineMilliseconds: 1_500,
+    })
+
+    const results = await Promise.allSettled([
+      geocoding.reverse(56.81, 53.11),
+      geocoding.reverse(56.82, 53.12),
+      geocoding.reverse(56.83, 53.13),
+    ])
+
+    expect(results[0]?.status).toBe('fulfilled')
+    expect(results[1]?.status).toBe('fulfilled')
+    expect(results[2]).toMatchObject({
+      status: 'rejected',
+      reason: {
+        code: 'GEOCODING_PROVIDER_UNAVAILABLE',
+        statusCode: 503,
+      },
+    })
+    expect(fetchImplementation).toHaveBeenCalledTimes(2)
+
+    const saturated = service(vi.fn(async () => new Promise<Response>(() => {})), {
+      maximumQueuedRequests: 1,
+      queueDeadlineMilliseconds: 50,
+    })
+    void saturated.reverse(56.84, 53.14).catch(() => undefined)
+    await expect(saturated.reverse(56.85, 53.15)).rejects.toMatchObject({
+      code: 'GEOCODING_PROVIDER_UNAVAILABLE',
+      statusCode: 503,
+    })
+  })
+
+  it('maps provider, payload and timeout failures to the typed 503', async () => {
+    const failed = service(vi.fn(async () => new Response('busy', { status: 503 })))
+    await expect(failed.reverse(56.85, 53.2)).rejects.toMatchObject({
+      code: 'GEOCODING_PROVIDER_UNAVAILABLE',
+      statusCode: 503,
+    })
+
+    const invalid = service(vi.fn(async () => new Response('{not-json', { status: 200 })))
+    await expect(invalid.reverse(56.85, 53.2)).rejects.toBeInstanceOf(GeocodingError)
+
+    const timedOut = service(
+      vi.fn((_input, init) => new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(new Error('aborted')))
+      })),
+      { timeoutMilliseconds: 5 },
+    )
+    await expect(timedOut.reverse(56.85, 53.2)).rejects.toMatchObject({
+      code: 'GEOCODING_PROVIDER_UNAVAILABLE',
+      statusCode: 503,
+    })
+  })
+})

--- a/apps/api/test/raid-template-cover.test.ts
+++ b/apps/api/test/raid-template-cover.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import sharp from 'sharp'
+import {
+  processRaidTemplateCover,
+  RaidTemplateCoverError,
+} from '../src/raid-template-cover.js'
+
+async function jpegDataUrl(width = 64, height = 36): Promise<string> {
+  const bytes = await sharp({
+    create: {
+      width,
+      height,
+      channels: 3,
+      background: { r: 35, g: 91, b: 61 },
+    },
+  }).jpeg().toBuffer()
+  return `data:image/jpeg;base64,${bytes.toString('base64')}`
+}
+
+describe('raid template cover processing', () => {
+  it('decodes and normalizes a bounded JPEG without retaining the data URL', async () => {
+    const cover = await processRaidTemplateCover(await jpegDataUrl())
+
+    expect(cover.contentType).toBe('image/jpeg')
+    expect(cover.sizeBytes).toBe(cover.bytes.length)
+    expect(cover.width).toBe(64)
+    expect(cover.height).toBe(36)
+    expect(cover.sha256).toMatch(/^[a-f0-9]{64}$/)
+    expect(cover.bytes.subarray(0, 2)).toEqual(Buffer.from([0xff, 0xd8]))
+  })
+
+  it('rejects malformed base64 and a non-JPEG disguised by the data URL', async () => {
+    await expect(
+      processRaidTemplateCover('data:image/jpeg;base64,%%%'),
+    ).rejects.toBeInstanceOf(RaidTemplateCoverError)
+
+    const png = await sharp({
+      create: {
+        width: 4,
+        height: 4,
+        channels: 3,
+        background: { r: 255, g: 0, b: 0 },
+      },
+    }).png().toBuffer()
+    await expect(
+      processRaidTemplateCover(`data:image/jpeg;base64,${png.toString('base64')}`),
+    ).rejects.toMatchObject({ code: 'RAID_TEMPLATE_COVER_INVALID' })
+  })
+
+  it('rejects the transport before decoding when it exceeds the fixed bound', async () => {
+    await expect(
+      processRaidTemplateCover(`data:image/jpeg;base64,${'A'.repeat(420_000)}`),
+    ).rejects.toMatchObject({ code: 'RAID_TEMPLATE_COVER_TOO_LARGE' })
+  })
+})

--- a/apps/api/test/raid-templates.postgres.test.ts
+++ b/apps/api/test/raid-templates.postgres.test.ts
@@ -79,6 +79,18 @@ function input(title = 'Набережные и мосты'): CreateRaidTemplate
   }
 }
 
+function legacyFingerprint(kabandaId: string, value: CreateRaidTemplate): string {
+  return createHash('sha256')
+    .update(JSON.stringify({
+      command: 'create-raid-template',
+      kabandaId,
+      title: value.title,
+      coverImage: value.coverImage,
+      points: value.points,
+    }))
+    .digest('hex')
+}
+
 describePostgres('raid template PostgreSQL invariants', () => {
   beforeEach(async () => {
     await pool!.query(
@@ -206,6 +218,35 @@ describePostgres('raid template PostgreSQL invariants', () => {
       statusCode: 409,
     })
     expect(coverProcessor).toHaveBeenCalledOnce()
+  })
+
+  it('replays a private create receipt written before visibility existed', async () => {
+    const { kabandaId } = await createKabanda('legacy-idempotency')
+    const memberId = await addMember(kabandaId, 'legacy-idempotency')
+    const value = input('Старый закрытый маршрут')
+    const operationId = 'legacy-template-operation'
+    const created = await raidTemplates!.createTemplate(memberId, kabandaId, value, operationId)
+    await pool!.query(
+      `UPDATE raid_template_receipts
+       SET request_fingerprint = $1
+       WHERE actor_user_id = $2 AND operation_id = $3`,
+      [legacyFingerprint(kabandaId, value), memberId, operationId],
+    )
+
+    await expect(
+      raidTemplates!.createTemplate(memberId, kabandaId, value, operationId),
+    ).resolves.toEqual(created)
+    await expect(
+      raidTemplates!.createTemplate(
+        memberId,
+        kabandaId,
+        { ...value, title: 'Подменённый маршрут' },
+        operationId,
+      ),
+    ).rejects.toMatchObject({
+      code: 'RAID_TEMPLATE_IDEMPOTENCY_CONFLICT',
+      statusCode: 409,
+    })
   })
 
   it('shows a public template to another Kabanda but keeps a private template inside its own', async () => {

--- a/apps/api/test/raid-templates.postgres.test.ts
+++ b/apps/api/test/raid-templates.postgres.test.ts
@@ -1,0 +1,293 @@
+import { createHash, randomUUID } from 'node:crypto'
+import type { CreateRaidTemplate } from '@kabanda/contracts'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Pool } from 'pg'
+import { DatabaseRaidTemplateService } from '../src/raid-templates.js'
+
+const databaseUrl = process.env.DATABASE_URL
+const describePostgres = databaseUrl ? describe : describe.skip
+const pool = databaseUrl ? new Pool({ connectionString: databaseUrl }) : null
+const normalizedCoverBytes = Buffer.from([0xff, 0xd8, 0xff, 0xd9])
+const normalizedCoverSha256 = createHash('sha256').update(normalizedCoverBytes).digest('hex')
+const raidTemplates = pool
+  ? new DatabaseRaidTemplateService(pool, async () => ({
+      bytes: normalizedCoverBytes,
+      contentType: 'image/jpeg',
+      sizeBytes: normalizedCoverBytes.length,
+      width: 1_280,
+      height: 720,
+      sha256: normalizedCoverSha256,
+    }))
+  : null
+
+async function createUser(label: string): Promise<string> {
+  const result = await pool!.query<{ id: string }>(
+    'INSERT INTO users (email, display_name) VALUES ($1, $2) RETURNING id',
+    [`${label}-${randomUUID()}@example.com`, label],
+  )
+  return result.rows[0]!.id
+}
+
+async function createKabanda(label: string) {
+  const ownerId = await createUser(`owner-${label}`)
+  const created = await pool!.query<{ id: string }>(
+    `INSERT INTO kabandas (name, avatar, owner_id, create_idempotency_key)
+     VALUES ($1, '🐗', $2, $3)
+     RETURNING id`,
+    [`Кабанда ${label}`, ownerId, `kabanda-${randomUUID()}`],
+  )
+  const kabandaId = created.rows[0]!.id
+  await pool!.query(
+    `INSERT INTO kabanda_memberships (kabanda_id, user_id, role)
+     VALUES ($1, $2, 'owner')`,
+    [kabandaId, ownerId],
+  )
+  return { ownerId, kabandaId }
+}
+
+async function addMember(kabandaId: string, label: string): Promise<string> {
+  const memberId = await createUser(`member-${label}`)
+  await pool!.query(
+    `INSERT INTO kabanda_memberships (kabanda_id, user_id, role)
+     VALUES ($1, $2, 'member')`,
+    [kabandaId, memberId],
+  )
+  return memberId
+}
+
+function input(title = 'Набережные и мосты'): CreateRaidTemplate {
+  return {
+    title,
+    coverImage: 'data:image/jpeg;base64,transport-is-never-stored',
+    points: [
+      {
+        name: 'Старт у ротонды',
+        address: 'Набережная, 1',
+        comment: 'Подождать всех',
+        latitude: 56.85001,
+        longitude: 53.20001,
+      },
+      {
+        name: 'Финиш у моста',
+        address: 'Мостовая, 2',
+        comment: '',
+        latitude: 56.86002,
+        longitude: 53.21002,
+      },
+    ],
+  }
+}
+
+describePostgres('raid template PostgreSQL invariants', () => {
+  beforeEach(async () => {
+    await pool!.query(
+      `TRUNCATE raid_template_receipts, raid_template_points, raid_templates,
+       raid_participants, raids, kabanda_memberships, kabandas, users CASCADE`,
+    )
+  })
+
+  afterAll(async () => {
+    await pool?.end()
+  })
+
+  it('lets any active member create and read an ordered template without creating a raid', async () => {
+    const { ownerId, kabandaId } = await createKabanda('member-author')
+    const memberId = await addMember(kabandaId, 'author')
+
+    const created = await raidTemplates!.createTemplate(
+      memberId,
+      kabandaId,
+      input(),
+      'member-template-operation',
+    )
+
+    expect(created.receipt).toMatchObject({
+      operationId: 'member-template-operation',
+      command: 'create-raid-template',
+      resultingVersion: 1,
+    })
+    expect(created.template).toMatchObject({
+      scope: 'kabanda',
+      kabandaId,
+      createdByUserId: memberId,
+      title: 'Набережные и мосты',
+      version: 1,
+      pointCount: 2,
+      cover: {
+        url: `/api/raid-templates/${created.template.id}/cover`,
+        sha256: normalizedCoverSha256,
+        width: 1_280,
+        height: 720,
+      },
+      estimate: {
+        method: 'straight_segments',
+        distanceMeters: 1_269,
+      },
+    })
+    expect(created.template.points.map((point) => [point.position, point.name])).toEqual([
+      [0, 'Старт у ротонды'],
+      [1, 'Финиш у моста'],
+    ])
+    expect(JSON.stringify(created)).not.toContain('data:image')
+
+    const ownerCatalog = await raidTemplates!.listTemplates(ownerId, kabandaId)
+    expect(ownerCatalog).toEqual([
+      expect.objectContaining({ id: created.template.id, pointCount: 2 }),
+    ])
+    expect(ownerCatalog[0]).not.toHaveProperty('points')
+    await expect(
+      raidTemplates!.getTemplate(ownerId, created.template.id),
+    ).resolves.toEqual(created.template)
+    const cover = await raidTemplates!.readCover(memberId, created.template.id)
+    expect(cover).toEqual({
+      bytes: normalizedCoverBytes,
+      contentType: 'image/jpeg',
+      sha256: normalizedCoverSha256,
+    })
+
+    expect(Number((await pool!.query('SELECT count(*) FROM raids')).rows[0]!.count)).toBe(0)
+    expect(Number((await pool!.query('SELECT count(*) FROM raid_participants')).rows[0]!.count)).toBe(0)
+    const stored = await pool!.query<{
+      cover_bytes: Buffer
+      point_count: number
+      distance_method: string
+      estimated_distance_meters: number
+      archived_at: Date | null
+    }>(
+      `SELECT cover_bytes, point_count, distance_method, estimated_distance_meters,
+         archived_at
+       FROM raid_templates WHERE id = $1`,
+      [created.template.id],
+    )
+    expect(stored.rows[0]).toMatchObject({
+      cover_bytes: normalizedCoverBytes,
+      point_count: 2,
+      distance_method: 'straight_segments',
+      estimated_distance_meters: 1_269,
+      archived_at: null,
+    })
+  })
+
+  it('replays the same idempotent create and rejects a changed request', async () => {
+    const { kabandaId } = await createKabanda('idempotency')
+    const memberId = await addMember(kabandaId, 'idempotency')
+    const coverProcessor = vi.fn(async () => ({
+      bytes: normalizedCoverBytes,
+      contentType: 'image/jpeg' as const,
+      sizeBytes: normalizedCoverBytes.length,
+      width: 1_280,
+      height: 720,
+      sha256: normalizedCoverSha256,
+    }))
+    const idempotentService = new DatabaseRaidTemplateService(pool!, coverProcessor)
+
+    const [first, replay] = await Promise.all([
+      idempotentService.createTemplate(memberId, kabandaId, input(), 'same-template-operation'),
+      idempotentService.createTemplate(memberId, kabandaId, input(), 'same-template-operation'),
+    ])
+    expect(replay).toEqual(first)
+    expect(coverProcessor).toHaveBeenCalledOnce()
+    expect(
+      Number((await pool!.query('SELECT count(*) FROM raid_templates')).rows[0]!.count),
+    ).toBe(1)
+    expect(
+      Number((await pool!.query('SELECT count(*) FROM raid_template_points')).rows[0]!.count),
+    ).toBe(2)
+
+    await expect(
+      idempotentService.createTemplate(
+        memberId,
+        kabandaId,
+        input('Другой маршрут'),
+        'same-template-operation',
+      ),
+    ).rejects.toMatchObject({
+      code: 'RAID_TEMPLATE_IDEMPOTENCY_CONFLICT',
+      statusCode: 409,
+    })
+    expect(coverProcessor).toHaveBeenCalledOnce()
+  })
+
+  it('caps active templates per Kabanda before processing another cover', async () => {
+    const { kabandaId } = await createKabanda('limit')
+    const memberId = await addMember(kabandaId, 'limit')
+    await pool!.query(
+      `WITH inserted AS (
+         INSERT INTO raid_templates
+           (kabanda_id, created_by_user_id, title, point_count,
+            cover_bytes, cover_content_type, cover_size_bytes, cover_width, cover_height,
+            cover_sha256, distance_method, estimated_distance_meters)
+         SELECT $1, $2, 'Маршрут ' || sequence, 2,
+           $3, 'image/jpeg', $4, 1280, 720, $5, 'straight_segments', 1000
+         FROM generate_series(1, 100) AS sequence
+         RETURNING id
+       )
+       INSERT INTO raid_template_points
+         (template_id, position, name, address, comment, location)
+       SELECT inserted.id, point.position, point.name, point.address, '',
+         ST_SetSRID(ST_MakePoint(point.longitude, point.latitude), 4326)::geography
+       FROM inserted
+       CROSS JOIN (VALUES
+         (0::smallint, 'Старт'::text, 'Адрес 1'::text, 53.2::double precision, 56.85::double precision),
+         (1::smallint, 'Финиш'::text, 'Адрес 2'::text, 53.21::double precision, 56.86::double precision)
+       ) AS point(position, name, address, longitude, latitude)`,
+      [
+        kabandaId,
+        memberId,
+        normalizedCoverBytes,
+        normalizedCoverBytes.length,
+        normalizedCoverSha256,
+      ],
+    )
+    const coverProcessor = vi.fn(async () => {
+      throw new Error('cover processing must not run after the limit is reached')
+    })
+    const limitedService = new DatabaseRaidTemplateService(pool!, coverProcessor)
+
+    await expect(
+      limitedService.createTemplate(memberId, kabandaId, input(), 'limit-operation'),
+    ).rejects.toMatchObject({
+      code: 'RAID_TEMPLATE_LIMIT_REACHED',
+      statusCode: 409,
+      details: { maximum: 100 },
+    })
+    expect(coverProcessor).not.toHaveBeenCalled()
+  })
+
+  it('returns the same 404 to outsiders and removed members on every operation', async () => {
+    const { ownerId, kabandaId } = await createKabanda('hidden')
+    const memberId = await addMember(kabandaId, 'removed')
+    const outsiderId = await createUser('outsider')
+    const created = await raidTemplates!.createTemplate(
+      ownerId,
+      kabandaId,
+      input(),
+      'hidden-template-operation',
+    )
+    await pool!.query(
+      `UPDATE kabanda_memberships SET removed_at = now()
+       WHERE kabanda_id = $1 AND user_id = $2`,
+      [kabandaId, memberId],
+    )
+
+    for (const hiddenUserId of [outsiderId, memberId]) {
+      const attempts = [
+        () => raidTemplates!.createTemplate(
+          hiddenUserId,
+          kabandaId,
+          input('Скрытый маршрут'),
+          `hidden-${hiddenUserId}`,
+        ),
+        () => raidTemplates!.listTemplates(hiddenUserId, kabandaId),
+        () => raidTemplates!.getTemplate(hiddenUserId, created.template.id),
+        () => raidTemplates!.readCover(hiddenUserId, created.template.id),
+      ]
+      for (const attempt of attempts) {
+        await expect(attempt()).rejects.toMatchObject({
+          code: 'RAID_TEMPLATE_NOT_FOUND',
+          statusCode: 404,
+        })
+      }
+    }
+  })
+})

--- a/apps/api/test/raid-templates.postgres.test.ts
+++ b/apps/api/test/raid-templates.postgres.test.ts
@@ -57,6 +57,7 @@ async function addMember(kabandaId: string, label: string): Promise<string> {
 
 function input(title = 'Набережные и мосты'): CreateRaidTemplate {
   return {
+    scope: 'kabanda',
     title,
     coverImage: 'data:image/jpeg;base64,transport-is-never-stored',
     points: [
@@ -109,7 +110,6 @@ describePostgres('raid template PostgreSQL invariants', () => {
     expect(created.template).toMatchObject({
       scope: 'kabanda',
       kabandaId,
-      createdByUserId: memberId,
       title: 'Набережные и мосты',
       version: 1,
       pointCount: 2,
@@ -206,6 +206,45 @@ describePostgres('raid template PostgreSQL invariants', () => {
       statusCode: 409,
     })
     expect(coverProcessor).toHaveBeenCalledOnce()
+  })
+
+  it('shows a public template to another Kabanda but keeps a private template inside its own', async () => {
+    const source = await createKabanda('visibility-source')
+    const target = await createKabanda('visibility-target')
+    const publicTemplate = await raidTemplates!.createTemplate(
+      source.ownerId,
+      source.kabandaId,
+      { ...input('Общий маршрут'), scope: 'all_authenticated' },
+      'public-template-operation',
+    )
+    const privateTemplate = await raidTemplates!.createTemplate(
+      source.ownerId,
+      source.kabandaId,
+      input('Маршрут для своих'),
+      'private-template-operation',
+    )
+
+    await expect(raidTemplates!.listTemplates(target.ownerId, target.kabandaId)).resolves.toEqual([
+      expect.objectContaining({ id: publicTemplate.template.id, scope: 'all_authenticated' }),
+    ])
+    await expect(
+      raidTemplates!.getTemplate(target.ownerId, publicTemplate.template.id),
+    ).resolves.toMatchObject({ id: publicTemplate.template.id, scope: 'all_authenticated' })
+    await expect(
+      raidTemplates!.readCover(target.ownerId, publicTemplate.template.id),
+    ).resolves.toMatchObject({ sha256: normalizedCoverSha256 })
+    await expect(
+      raidTemplates!.getTemplate(target.ownerId, privateTemplate.template.id),
+    ).rejects.toMatchObject({ code: 'RAID_TEMPLATE_NOT_FOUND', statusCode: 404 })
+    await expect(
+      raidTemplates!.readCover(target.ownerId, privateTemplate.template.id),
+    ).rejects.toMatchObject({ code: 'RAID_TEMPLATE_NOT_FOUND', statusCode: 404 })
+
+    await pool!.query('UPDATE kabandas SET archived_at = now() WHERE id = $1', [source.kabandaId])
+    await expect(
+      raidTemplates!.getTemplate(target.ownerId, publicTemplate.template.id),
+    ).rejects.toMatchObject({ code: 'RAID_TEMPLATE_NOT_FOUND', statusCode: 404 })
+    await expect(raidTemplates!.listTemplates(target.ownerId, target.kabandaId)).resolves.toEqual([])
   })
 
   it('caps active templates per Kabanda before processing another cover', async () => {

--- a/apps/api/test/raid-templates.test.ts
+++ b/apps/api/test/raid-templates.test.ts
@@ -1,3 +1,4 @@
+import { createRaidTemplateSchema } from '@kabanda/contracts'
 import { describe, expect, it } from 'vitest'
 import { straightSegmentsDistanceMeters } from '../src/raid-templates.js'
 
@@ -22,5 +23,24 @@ describe('raid template distance', () => {
       { name: 'A', address: 'A', comment: '', latitude: 56.85, longitude: 53.2 },
       { name: 'B', address: 'B', comment: '', latitude: 56.85, longitude: 53.2 },
     ])).toBe(0)
+  })
+})
+
+describe('raid template access contract', () => {
+  const legacyRequest = {
+    title: 'Маршрут для своих',
+    coverImage: 'data:image/jpeg;base64,YQ==',
+    points: [
+      { name: 'A', address: 'A', comment: '', latitude: 56.8, longitude: 53.2 },
+      { name: 'B', address: 'B', comment: '', latitude: 56.9, longitude: 53.3 },
+    ],
+  }
+
+  it('defaults a cached old client to Kabanda-only access', () => {
+    expect(createRaidTemplateSchema.parse(legacyRequest).scope).toBe('kabanda')
+  })
+
+  it('rejects an unknown access value', () => {
+    expect(() => createRaidTemplateSchema.parse({ ...legacyRequest, scope: 'anonymous' })).toThrow()
   })
 })

--- a/apps/api/test/raid-templates.test.ts
+++ b/apps/api/test/raid-templates.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { straightSegmentsDistanceMeters } from '../src/raid-templates.js'
+
+describe('raid template distance', () => {
+  it('computes and rounds the Haversine sum in the submitted point order', () => {
+    const oneSegment = straightSegmentsDistanceMeters([
+      { name: 'A', address: 'A', comment: '', latitude: 0, longitude: 0 },
+      { name: 'B', address: 'B', comment: '', latitude: 0, longitude: 1 },
+    ])
+    const twoSegments = straightSegmentsDistanceMeters([
+      { name: 'A', address: 'A', comment: '', latitude: 0, longitude: 0 },
+      { name: 'B', address: 'B', comment: '', latitude: 0, longitude: 1 },
+      { name: 'C', address: 'C', comment: '', latitude: 0, longitude: 2 },
+    ])
+
+    expect(oneSegment).toBe(111_195)
+    expect(twoSegments).toBe(222_390)
+  })
+
+  it('allows a zero straight-segment estimate for coincident points', () => {
+    expect(straightSegmentsDistanceMeters([
+      { name: 'A', address: 'A', comment: '', latitude: 56.85, longitude: 53.2 },
+      { name: 'B', address: 'B', comment: '', latitude: 56.85, longitude: 53.2 },
+    ])).toBe(0)
+  })
+})

--- a/apps/pwa/src/features/kabandas/yandex-maps.ts
+++ b/apps/pwa/src/features/kabandas/yandex-maps.ts
@@ -1,21 +1,28 @@
+/** JavaScript API 2.1 boundary order: [latitude, longitude]. */
 export type YandexCoordinates = readonly [number, number]
 
-type YandexEvent = {
-  get: (name: string) => unknown
+export type YandexEvent = {
+  get: <Value = unknown>(name: string) => Value
   stopPropagation?: () => void
 }
 
-type YandexEventManager = {
-  add: (name: string, handler: (event: YandexEvent) => void) => void
+export type YandexEventHandler = (event: YandexEvent) => void
+
+export type YandexEventManager = {
+  add: (name: string, handler: YandexEventHandler) => void
+  remove?: (name: string, handler: YandexEventHandler) => void
 }
 
-type YandexDataManager = {
+export type YandexDataManager = {
+  get: <Value = unknown>(name: string) => Value
   set: (name: string, value: unknown) => void
 }
 
-type YandexOptionManager = {
+export type YandexOptionManager = {
   set: (name: string, value: unknown) => void
 }
+
+export type YandexMapObject = object
 
 export type YandexPlacemark = {
   events: YandexEventManager
@@ -26,8 +33,8 @@ export type YandexPlacemark = {
 export type YandexMap = {
   events: YandexEventManager
   geoObjects: {
-    add: (object: YandexPlacemark) => void
-    remove: (object: YandexPlacemark) => void
+    add: (object: YandexMapObject) => void
+    remove: (object: YandexMapObject) => void
   }
   getCenter: () => YandexCoordinates
   getZoom: () => number
@@ -37,6 +44,28 @@ export type YandexMap = {
   }) => void
   setZoom: (zoom: number, options?: { duration?: number }) => void
   destroy: () => void
+}
+
+export type YandexPolyline = {
+  geometry: {
+    getCoordinates?: () => unknown
+    setCoordinates: (coordinates: readonly YandexCoordinates[] | YandexCoordinates) => void
+  }
+  editor?: {
+    startEditing: () => void
+    stopEditing: () => void
+  }
+}
+
+export type YandexMultiRouteRoute = {
+  properties: YandexDataManager
+}
+
+export type YandexMultiRoute = {
+  model: {
+    events: YandexEventManager
+  }
+  getActiveRoute: () => YandexMultiRouteRoute | null
 }
 
 export type YandexMapsRuntime = {
@@ -49,6 +78,26 @@ export type YandexMapsRuntime = {
     type?: string
   }, options?: { suppressMapOpenBlock?: boolean }) => YandexMap
   Placemark: new (coordinates: YandexCoordinates, properties?: Record<string, unknown>, options?: Record<string, unknown>) => YandexPlacemark
+  Polyline: new (
+    coordinates: readonly YandexCoordinates[],
+    properties?: Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ) => YandexPolyline
+  multiRouter: {
+    MultiRoute: new (model: {
+      referencePoints: readonly YandexCoordinates[]
+      params?: {
+        results?: number
+        reverseGeocoding?: boolean
+        routingMode?: 'auto' | 'masstransit' | 'pedestrian' | 'bicycle'
+      }
+    }, options?: Record<string, unknown>) => YandexMultiRoute
+  }
+  coordSystem: {
+    geo: {
+      getDistance: (from: YandexCoordinates, to: YandexCoordinates) => number
+    }
+  }
   templateLayoutFactory: {
     createClass: (template: string) => unknown
   }

--- a/apps/pwa/src/features/kabandas/yandex-maps.ts
+++ b/apps/pwa/src/features/kabandas/yandex-maps.ts
@@ -31,6 +31,9 @@ export type YandexPlacemark = {
 }
 
 export type YandexMap = {
+  container?: {
+    fitToViewport?: () => void
+  }
   events: YandexEventManager
   geoObjects: {
     add: (object: YandexMapObject) => void

--- a/apps/pwa/src/features/raid-plans/RaidTemplateCatalog.test.tsx
+++ b/apps/pwa/src/features/raid-plans/RaidTemplateCatalog.test.tsx
@@ -8,7 +8,6 @@ function template(id: string, title: string, createdAt: string): RaidTemplateSum
     id,
     kabandaId: 'kabanda-1',
     scope: 'kabanda',
-    createdByUserId: 'member-1',
     title,
     version: 1,
     cover: { url: `/api/raid-templates/${id}/cover`, sha256: 'sha', width: 1280, height: 720 },

--- a/apps/pwa/src/features/raid-plans/RaidTemplateCatalog.test.tsx
+++ b/apps/pwa/src/features/raid-plans/RaidTemplateCatalog.test.tsx
@@ -1,0 +1,36 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { RaidTemplateGrid } from './RaidTemplateCatalog'
+import type { RaidTemplateSummary } from './types'
+
+function template(id: string, title: string, createdAt: string): RaidTemplateSummary {
+  return {
+    id,
+    kabandaId: 'kabanda-1',
+    scope: 'kabanda',
+    createdByUserId: 'member-1',
+    title,
+    version: 1,
+    cover: { url: `/api/raid-templates/${id}/cover`, sha256: 'sha', width: 1280, height: 720 },
+    pointCount: 3,
+    estimate: { method: 'straight_segments', distanceMeters: 4_200 },
+    createdAt,
+    updatedAt: createdAt,
+  }
+}
+
+describe('raid template catalog', () => {
+  it('keeps newly created routes below older cards without a details button', () => {
+    const markup = renderToStaticMarkup(<RaidTemplateGrid templates={[
+      template('new', 'Новый маршрут', '2026-09-02T10:00:00.000Z'),
+      template('old', 'Старый маршрут', '2026-09-01T10:00:00.000Z'),
+    ]} />)
+
+    expect(markup.indexOf('Старый маршрут')).toBeLessThan(markup.indexOf('Новый маршрут'))
+    expect(markup).toContain('4,2 км')
+    expect(markup).toContain('Расстояние по прямым отрезкам')
+    expect(markup).not.toContain('Веломаршрут')
+    expect(markup).not.toContain('Подробнее')
+    expect(markup.match(/class="prd-template-card"/g)).toHaveLength(2)
+  })
+})

--- a/apps/pwa/src/features/raid-plans/RaidTemplateCatalog.tsx
+++ b/apps/pwa/src/features/raid-plans/RaidTemplateCatalog.tsx
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { listRaidTemplates } from './api'
+import { formatPlanDistance } from './editor/route-estimate'
+import type { RaidTemplateSummary } from './types'
+
+export function RaidTemplateCatalog({ kabandaId }: { kabandaId: string }) {
+  const requestVersion = useRef(0)
+  const [state, setState] = useState<
+    | { status: 'loading' }
+    | { status: 'ready'; templates: RaidTemplateSummary[] }
+    | { status: 'error' }
+  >({ status: 'loading' })
+
+  const load = useCallback(async () => {
+    const version = ++requestVersion.current
+    setState({ status: 'loading' })
+    try {
+      const templates = await listRaidTemplates(kabandaId)
+      if (requestVersion.current === version) setState({ status: 'ready', templates })
+    } catch {
+      if (requestVersion.current === version) setState({ status: 'error' })
+    }
+  }, [kabandaId])
+
+  useEffect(() => {
+    void load()
+    return () => {
+      requestVersion.current += 1
+    }
+  }, [load])
+
+  return <section className="rdp-section prd-template-catalog" aria-labelledby="production-routes-heading" data-testid="production-route-catalog">
+    <div className="prd-section-heading">
+      <div>
+        <h2 id="production-routes-heading">Доступные маршруты</h2>
+        <p>Созданные участниками маршруты для будущих рейдов.</p>
+      </div>
+      {state.status === 'ready' && state.templates.length > 0 && <span>{state.templates.length}</span>}
+    </div>
+    {state.status === 'loading' && <div aria-label="Загружаем маршруты" className="prd-template-grid prd-template-grid--loading"><i /><i /></div>}
+    {state.status === 'error' && <div className="prd-template-error" role="status">
+      <span>Маршруты не загрузились.</span>
+      <button onClick={() => void load()} type="button">Повторить</button>
+    </div>}
+    {state.status === 'ready' && state.templates.length === 0 && <div className="prd-template-empty">
+      <strong>Маршрутов пока нет</strong>
+      <span>Создайте первый: добавьте обложку и точки на карте.</span>
+    </div>}
+    {state.status === 'ready' && state.templates.length > 0 && <RaidTemplateGrid templates={state.templates} />}
+  </section>
+}
+
+export function RaidTemplateGrid({ templates }: { templates: readonly RaidTemplateSummary[] }) {
+  const chronological = [...templates].sort((left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt))
+  return <div className="prd-template-grid">
+    {chronological.map((template) => <article className="prd-template-card" key={template.id}>
+      <img alt="" decoding="async" loading="lazy" src={template.cover.url} />
+      <div>
+        <h3>{template.title}</h3>
+        <p>
+          <span>{template.pointCount} {pointWord(template.pointCount)}</span>
+          <span aria-hidden="true">·</span>
+          <span>≈ {formatPlanDistance(template.estimate.distanceMeters)}</span>
+        </p>
+        <small>Расстояние по прямым отрезкам</small>
+      </div>
+    </article>)}
+  </div>
+}
+
+function pointWord(count: number): string {
+  const mod100 = count % 100
+  const mod10 = count % 10
+  if (mod100 >= 11 && mod100 <= 14) return 'точек'
+  if (mod10 === 1) return 'точка'
+  if (mod10 >= 2 && mod10 <= 4) return 'точки'
+  return 'точек'
+}

--- a/apps/pwa/src/features/raid-plans/api.test.ts
+++ b/apps/pwa/src/features/raid-plans/api.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createRaidTemplate, reverseGeocodeTemplatePoint } from './api'
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('raid template API', () => {
+  it('saves only through the template endpoint with a stable idempotency key', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => new Response(JSON.stringify({
+      receipt: { operationId: 'op', command: 'create-raid-template', resultingVersion: 1, serverAt: '2026-09-01T10:00:00.000Z' },
+      template: {},
+    }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await createRaidTemplate('kabanda-1', {
+      title: 'Центр',
+      coverImage: 'data:image/jpeg;base64,cover',
+      points: [
+        { name: 'A', address: 'A', comment: '', latitude: 56.8, longitude: 53.2 },
+        { name: 'B', address: 'B', comment: '', latitude: 56.9, longitude: 53.3 },
+      ],
+    }, 'stable-key')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe('/api/kabandas/kabanda-1/raid-templates')
+    expect(init?.method).toBe('POST')
+    expect(new Headers(init?.headers).get('Idempotency-Key')).toBe('stable-key')
+    expect(String(url)).not.toMatch(/\/raids(?:\/|$)/)
+    expect(Object.keys(JSON.parse(String(init?.body))).sort()).toEqual(['coverImage', 'points', 'title'])
+  })
+
+  it('uses the authenticated reverse-geocode proxy instead of a browser provider call', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL) => new Response(JSON.stringify({
+      name: 'Набережная',
+      address: 'Ижевск, набережная Зодчего Дудина',
+      source: 'openstreetmap',
+    }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(reverseGeocodeTemplatePoint(56.8528, 53.2045)).resolves.toMatchObject({ source: 'openstreetmap' })
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/geocoding/reverse?latitude=56.8528&longitude=53.2045')
+  })
+})

--- a/apps/pwa/src/features/raid-plans/api.test.ts
+++ b/apps/pwa/src/features/raid-plans/api.test.ts
@@ -12,6 +12,7 @@ describe('raid template API', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     await createRaidTemplate('kabanda-1', {
+      scope: 'all_authenticated',
       title: 'Центр',
       coverImage: 'data:image/jpeg;base64,cover',
       points: [
@@ -26,7 +27,7 @@ describe('raid template API', () => {
     expect(init?.method).toBe('POST')
     expect(new Headers(init?.headers).get('Idempotency-Key')).toBe('stable-key')
     expect(String(url)).not.toMatch(/\/raids(?:\/|$)/)
-    expect(Object.keys(JSON.parse(String(init?.body))).sort()).toEqual(['coverImage', 'points', 'title'])
+    expect(JSON.parse(String(init?.body))).toMatchObject({ scope: 'all_authenticated', title: 'Центр' })
   })
 
   it('uses the authenticated reverse-geocode proxy instead of a browser provider call', async () => {

--- a/apps/pwa/src/features/raid-plans/api.ts
+++ b/apps/pwa/src/features/raid-plans/api.ts
@@ -1,0 +1,44 @@
+import { requestJson } from '../../lib/http'
+import type {
+  CreateRaidTemplateInput,
+  CreateRaidTemplateResponse,
+  RaidTemplate,
+  RaidTemplateSummary,
+} from './types'
+
+export async function listRaidTemplates(kabandaId: string): Promise<RaidTemplateSummary[]> {
+  const response = await requestJson<{ templates: RaidTemplateSummary[] }>(
+    `/api/kabandas/${encodeURIComponent(kabandaId)}/raid-templates`,
+  )
+  return response.templates
+}
+
+export function getRaidTemplate(templateId: string): Promise<{ template: RaidTemplate }> {
+  return requestJson<{ template: RaidTemplate }>(
+    `/api/raid-templates/${encodeURIComponent(templateId)}`,
+  )
+}
+
+export function createRaidTemplate(
+  kabandaId: string,
+  input: CreateRaidTemplateInput,
+  idempotencyKey: string,
+): Promise<CreateRaidTemplateResponse> {
+  return requestJson<CreateRaidTemplateResponse>(
+    `/api/kabandas/${encodeURIComponent(kabandaId)}/raid-templates`,
+    {
+      method: 'POST',
+      headers: { 'Idempotency-Key': idempotencyKey },
+      body: JSON.stringify(input),
+    },
+  )
+}
+
+export function reverseGeocodeTemplatePoint(latitude: number, longitude: number): Promise<{
+  name: string
+  address: string
+  source: 'openstreetmap'
+}> {
+  const query = new URLSearchParams({ latitude: String(latitude), longitude: String(longitude) })
+  return requestJson(`/api/geocoding/reverse?${query.toString()}`)
+}

--- a/apps/pwa/src/features/raid-plans/editor/RaidTemplateEditorMap.test.tsx
+++ b/apps/pwa/src/features/raid-plans/editor/RaidTemplateEditorMap.test.tsx
@@ -1,0 +1,51 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import {
+  beginLocationRequest,
+  invalidateLocationRequests,
+  isCurrentLocationRequest,
+  RaidTemplateMapControls,
+  raidTemplatePointAtMapCenter,
+} from './RaidTemplateEditorMap'
+
+describe('raid template editor map controls', () => {
+  it('invalidates a pending location request before its callback can use a destroyed map', () => {
+    const generationRef = { current: 0 }
+    const requestGeneration = beginLocationRequest(generationRef)
+
+    expect(isCurrentLocationRequest(generationRef, requestGeneration)).toBe(true)
+    invalidateLocationRequests(generationRef)
+    expect(isCurrentLocationRequest(generationRef, requestGeneration)).toBe(false)
+  })
+
+  it('reads a valid point from the current map center', () => {
+    let centerReads = 0
+    const point = raidTemplatePointAtMapCenter({
+      getCenter: () => {
+        centerReads += 1
+        return [56.8528, 53.2045]
+      },
+    })
+
+    expect(centerReads).toBe(1)
+    expect(point).toEqual({ latitude: 56.8528, longitude: 53.2045 })
+  })
+
+  it('exposes the add-at-center action to keyboard users and disables it at the point limit', () => {
+    const renderControls = (canAddPoint: boolean) => renderToStaticMarkup(<RaidTemplateMapControls
+      canAddPoint={canAddPoint}
+      locating={false}
+      onAddPointAtCenter={() => undefined}
+      onChangeZoom={() => undefined}
+      onLocate={() => undefined}
+      zoom={12}
+    />)
+
+    const enabledMarkup = renderControls(true)
+    expect(enabledMarkup).toContain('aria-label="Добавить точку в центре карты"')
+    expect(enabledMarkup).not.toContain('class="rt-map__add-point" disabled=""')
+
+    const disabledMarkup = renderControls(false)
+    expect(disabledMarkup).toContain('class="rt-map__add-point" disabled=""')
+  })
+})

--- a/apps/pwa/src/features/raid-plans/editor/RaidTemplateEditorMap.test.tsx
+++ b/apps/pwa/src/features/raid-plans/editor/RaidTemplateEditorMap.test.tsx
@@ -5,6 +5,7 @@ import {
   invalidateLocationRequests,
   isCurrentLocationRequest,
   RaidTemplateMapControls,
+  raidTemplateSelectedPointCenter,
   raidTemplatePointAtMapCenter,
 } from './RaidTemplateEditorMap'
 
@@ -29,6 +30,15 @@ describe('raid template editor map controls', () => {
 
     expect(centerReads).toBe(1)
     expect(point).toEqual({ latitude: 56.8528, longitude: 53.2045 })
+  })
+
+  it('centres a selected point in the map area left above the sheet', () => {
+    const point = { latitude: 56.861663, longitude: 53.202876 }
+    const center = raidTemplateSelectedPointCenter(point, 15, 844, 340)
+
+    expect(center[0]).toBeLessThan(point.latitude)
+    expect(center[0]).toBeGreaterThan(point.latitude - 1)
+    expect(center[1]).toBe(point.longitude)
   })
 
   it('exposes the add-at-center action to keyboard users and disables it at the point limit', () => {

--- a/apps/pwa/src/features/raid-plans/editor/RaidTemplateEditorMap.tsx
+++ b/apps/pwa/src/features/raid-plans/editor/RaidTemplateEditorMap.tsx
@@ -16,6 +16,8 @@ const INITIAL_CENTER = [56.8528, 53.2045] as const
 const INITIAL_ZOOM = 12
 const MIN_ZOOM = 10
 const MAX_ZOOM = 18
+const POINT_EDIT_ZOOM = 15
+const WEB_MERCATOR_MAX_LATITUDE = 85.05112878
 
 type RequestGenerationRef = { current: number }
 
@@ -38,9 +40,39 @@ export function raidTemplatePointAtMapCenter(map: Pick<YandexMap, 'getCenter'>):
   return { latitude, longitude }
 }
 
+function latitudeToMercatorY(latitude: number) {
+  const safeLatitude = Math.max(-WEB_MERCATOR_MAX_LATITUDE, Math.min(WEB_MERCATOR_MAX_LATITUDE, latitude))
+  const sine = Math.sin(safeLatitude * Math.PI / 180)
+  return .5 - Math.log((1 + sine) / (1 - sine)) / (4 * Math.PI)
+}
+
+function mercatorYToLatitude(value: number) {
+  const safeValue = Math.max(0, Math.min(1, value))
+  return Math.atan(Math.sinh(Math.PI * (1 - 2 * safeValue))) * 180 / Math.PI
+}
+
+/**
+ * Keeps the selected point in the visual centre of the map area that remains
+ * above the point sheet, rather than underneath the sheet itself.
+ */
+export function raidTemplateSelectedPointCenter(
+  point: RaidPlanGeoPoint,
+  zoom: number,
+  viewportHeight: number,
+  sheetHeight: number,
+): readonly [number, number] {
+  const safeViewportHeight = Math.max(1, viewportHeight)
+  const safeSheetHeight = Math.max(0, Math.min(sheetHeight, safeViewportHeight * .82))
+  const worldSize = 256 * 2 ** Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, zoom))
+  const pointY = latitudeToMercatorY(point.latitude)
+  const mapCenterY = pointY + safeSheetHeight / (2 * worldSize)
+  return [mercatorYToLatitude(mapCenterY), point.longitude]
+}
+
 export function RaidTemplateEditorMap({
   points,
   selectedPointId,
+  pointSheetHeight,
   canAddPoint,
   onAddPoint,
   onRouteState,
@@ -48,6 +80,7 @@ export function RaidTemplateEditorMap({
 }: {
   points: readonly DraftRaidTemplatePoint[]
   selectedPointId: string | null
+  pointSheetHeight: number
   canAddPoint: boolean
   onAddPoint: (point: RaidPlanGeoPoint) => void
   onRouteState: (state: BicycleRouteState) => void
@@ -64,6 +97,9 @@ export function RaidTemplateEditorMap({
   const [retryVersion, setRetryVersion] = useState(0)
   const [zoom, setZoom] = useState(INITIAL_ZOOM)
   const [locating, setLocating] = useState(false)
+  const selectedPoint = points.find((point) => point.clientId === selectedPointId) ?? null
+  const selectedLatitude = selectedPoint?.latitude ?? null
+  const selectedLongitude = selectedPoint?.longitude ?? null
   const coordinatesFingerprint = points.map((point) => `${point.latitude}:${point.longitude}`).join('|')
   const routePoints = useMemo<RaidPlanGeoPoint[]>(
     () => points.map(({ latitude, longitude }) => ({ latitude, longitude })),
@@ -119,6 +155,39 @@ export function RaidTemplateEditorMap({
       mapRef.current = null
     }
   }, [retryVersion])
+
+  useEffect(() => {
+    const map = mapRef.current
+    if (providerState !== 'ready' || !map) return
+    let frame = 0
+    const viewport = window.visualViewport
+
+    const fitAndCenter = () => {
+      map.container?.fitToViewport?.()
+      if (selectedLatitude === null || selectedLongitude === null) return
+      const viewportHeight = viewport?.height ?? window.innerHeight
+      const targetZoom = Math.max(POINT_EDIT_ZOOM, map.getZoom())
+      map.setCenter(raidTemplateSelectedPointCenter(
+        { latitude: selectedLatitude, longitude: selectedLongitude },
+        targetZoom,
+        viewportHeight,
+        pointSheetHeight,
+      ), targetZoom, { duration: 220, timingFunction: 'ease-in-out' })
+    }
+    const scheduleFit = () => {
+      window.cancelAnimationFrame(frame)
+      frame = window.requestAnimationFrame(fitAndCenter)
+    }
+
+    scheduleFit()
+    window.addEventListener('resize', scheduleFit)
+    viewport?.addEventListener('resize', scheduleFit)
+    return () => {
+      window.cancelAnimationFrame(frame)
+      window.removeEventListener('resize', scheduleFit)
+      viewport?.removeEventListener('resize', scheduleFit)
+    }
+  }, [pointSheetHeight, providerState, selectedLatitude, selectedLongitude])
 
   useEffect(() => {
     const map = mapRef.current
@@ -221,7 +290,7 @@ export function RaidTemplateEditorMap({
     if (point) addPointRef.current(point)
   }, [canAddPoint])
 
-  return <div className="rt-map" role="group" aria-label="Карта конструктора маршрута">
+  return <div className={`rt-map${selectedPoint ? ' rt-map--point-editing' : ''}`} role="group" aria-label="Карта конструктора маршрута">
     <div className="rt-map__stage" ref={containerRef} />
     {providerState === 'loading' && <div className="rt-map__status" role="status">Загружаем карту…</div>}
     {providerState === 'failed' && <div className="rt-map__status rt-map__status--error" role="alert">

--- a/apps/pwa/src/features/raid-plans/editor/RaidTemplateEditorMap.tsx
+++ b/apps/pwa/src/features/raid-plans/editor/RaidTemplateEditorMap.tsx
@@ -1,0 +1,282 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { YandexMap, YandexMapsRuntime } from '../../kabandas/yandex-maps'
+import {
+  attachBicycleRoute,
+  attachNumberedWaypointPlacemark,
+  attachRaidPlanMapClick,
+  loadRaidPlanYandex,
+  straightLineDistanceMeters,
+  toYandexCoordinates,
+  type BicycleRouteState,
+  type RaidPlanGeoPoint,
+} from '../yandex-adapter'
+import type { DraftRaidTemplatePoint } from '../types'
+
+const INITIAL_CENTER = [56.8528, 53.2045] as const
+const INITIAL_ZOOM = 12
+const MIN_ZOOM = 10
+const MAX_ZOOM = 18
+
+type RequestGenerationRef = { current: number }
+
+export function beginLocationRequest(generationRef: RequestGenerationRef) {
+  generationRef.current += 1
+  return generationRef.current
+}
+
+export function invalidateLocationRequests(generationRef: RequestGenerationRef) {
+  generationRef.current += 1
+}
+
+export function isCurrentLocationRequest(generationRef: RequestGenerationRef, requestGeneration: number) {
+  return generationRef.current === requestGeneration
+}
+
+export function raidTemplatePointAtMapCenter(map: Pick<YandexMap, 'getCenter'>): RaidPlanGeoPoint | null {
+  const [latitude, longitude] = map.getCenter()
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return null
+  return { latitude, longitude }
+}
+
+export function RaidTemplateEditorMap({
+  points,
+  selectedPointId,
+  canAddPoint,
+  onAddPoint,
+  onRouteState,
+  onSelectPoint,
+}: {
+  points: readonly DraftRaidTemplatePoint[]
+  selectedPointId: string | null
+  canAddPoint: boolean
+  onAddPoint: (point: RaidPlanGeoPoint) => void
+  onRouteState: (state: BicycleRouteState) => void
+  onSelectPoint: (pointId: string) => void
+}) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const mapRef = useRef<YandexMap | null>(null)
+  const runtimeRef = useRef<YandexMapsRuntime | null>(null)
+  const locationRequestGenerationRef = useRef(0)
+  const addPointRef = useRef(onAddPoint)
+  const selectPointRef = useRef(onSelectPoint)
+  const routeStateRef = useRef(onRouteState)
+  const [providerState, setProviderState] = useState<'loading' | 'ready' | 'failed'>('loading')
+  const [retryVersion, setRetryVersion] = useState(0)
+  const [zoom, setZoom] = useState(INITIAL_ZOOM)
+  const [locating, setLocating] = useState(false)
+  const coordinatesFingerprint = points.map((point) => `${point.latitude}:${point.longitude}`).join('|')
+  const routePoints = useMemo<RaidPlanGeoPoint[]>(
+    () => points.map(({ latitude, longitude }) => ({ latitude, longitude })),
+    // The coordinate string intentionally ignores labels/comments so they do not trigger a billed route request.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [coordinatesFingerprint],
+  )
+
+  addPointRef.current = onAddPoint
+  selectPointRef.current = onSelectPoint
+  routeStateRef.current = onRouteState
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    let active = true
+    setProviderState('loading')
+    const apiKey = import.meta.env.VITE_YANDEX_MAPS_API_KEY?.trim() ?? ''
+
+    void loadRaidPlanYandex(apiKey).then((runtime) => {
+      if (!active) return
+      const map = new runtime.Map(container, {
+        center: INITIAL_CENTER,
+        zoom: INITIAL_ZOOM,
+        controls: [],
+        behaviors: ['default', 'scrollZoom'],
+        type: 'yandex#map',
+      }, { suppressMapOpenBlock: true })
+      map.events.add('boundschange', (event) => {
+        const nextZoom = event.get<number | undefined>('newZoom')
+        if (typeof nextZoom === 'number') setZoom(nextZoom)
+      })
+      mapRef.current = map
+      runtimeRef.current = runtime
+      setProviderState('ready')
+    }).catch(() => {
+      if (!active) return
+      setProviderState('failed')
+      if (routePoints.length >= 2) {
+        routeStateRef.current({
+          status: 'failed',
+          code: 'provider_unavailable',
+          fallbackDistanceMeters: straightLineDistanceMeters(routePoints),
+        })
+      }
+    })
+
+    return () => {
+      active = false
+      invalidateLocationRequests(locationRequestGenerationRef)
+      runtimeRef.current = null
+      mapRef.current?.destroy()
+      mapRef.current = null
+    }
+  }, [retryVersion])
+
+  useEffect(() => {
+    const map = mapRef.current
+    if (providerState !== 'ready' || !map || !canAddPoint) return
+    return attachRaidPlanMapClick(map, (point) => addPointRef.current(point))
+  }, [canAddPoint, providerState])
+
+  useEffect(() => {
+    const map = mapRef.current
+    const runtime = runtimeRef.current
+    if (providerState !== 'ready' || !map || !runtime) return
+    const dispose = points.map((point, index) => attachNumberedWaypointPlacemark(
+      runtime,
+      map,
+      point,
+      index + 1,
+      {
+        selected: point.clientId === selectedPointId,
+        onSelect: () => selectPointRef.current(point.clientId),
+      },
+    ))
+    return () => dispose.forEach((cleanup) => cleanup())
+  }, [points, providerState, selectedPointId])
+
+  useEffect(() => {
+    const map = mapRef.current
+    const runtime = runtimeRef.current
+    if (providerState !== 'ready' || !map || !runtime || routePoints.length < 2) return
+    let disposeRoute = () => undefined
+    let fallbackLine: object | null = null
+    let fallbackTimer: number | null = null
+    const showFallbackLine = () => {
+      if (fallbackLine) return
+      fallbackLine = new runtime.Polyline(routePoints.map(toYandexCoordinates), {}, {
+        strokeColor: '#64676d',
+        strokeOpacity: 0.78,
+        strokeStyle: 'dash',
+        strokeWidth: 3,
+        zIndex: 1,
+      })
+      map.geoObjects.add(fallbackLine)
+    }
+    const timer = window.setTimeout(() => {
+      disposeRoute = attachBicycleRoute(runtime, map, routePoints, (state) => {
+        if (state.status === 'calculating') {
+          fallbackTimer = window.setTimeout(() => {
+            showFallbackLine()
+            routeStateRef.current({
+              status: 'failed',
+              code: 'provider_unavailable',
+              fallbackDistanceMeters: state.fallbackDistanceMeters,
+            })
+          }, 15_000)
+        } else if (state.status === 'failed') {
+          if (fallbackTimer !== null) window.clearTimeout(fallbackTimer)
+          showFallbackLine()
+        } else if (state.status === 'ready') {
+          if (fallbackTimer !== null) window.clearTimeout(fallbackTimer)
+          if (fallbackLine) {
+            map.geoObjects.remove(fallbackLine)
+            fallbackLine = null
+          }
+        }
+        routeStateRef.current(state)
+      })
+    }, 450)
+    return () => {
+      window.clearTimeout(timer)
+      if (fallbackTimer !== null) window.clearTimeout(fallbackTimer)
+      disposeRoute()
+      if (fallbackLine) map.geoObjects.remove(fallbackLine)
+    }
+  }, [providerState, routePoints])
+
+  const changeZoom = useCallback((delta: number) => {
+    const map = mapRef.current
+    if (!map) return
+    map.setZoom(Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, map.getZoom() + delta)), { duration: 180 })
+  }, [])
+
+  const locate = useCallback(() => {
+    const map = mapRef.current
+    if (!map || !('geolocation' in navigator)) return
+    const requestGeneration = beginLocationRequest(locationRequestGenerationRef)
+    setLocating(true)
+    navigator.geolocation.getCurrentPosition(({ coords }) => {
+      if (!isCurrentLocationRequest(locationRequestGenerationRef, requestGeneration) || mapRef.current !== map) return
+      map.setCenter([coords.latitude, coords.longitude], 15, { duration: 300, timingFunction: 'ease-in-out' })
+      setLocating(false)
+    }, () => {
+      if (!isCurrentLocationRequest(locationRequestGenerationRef, requestGeneration) || mapRef.current !== map) return
+      setLocating(false)
+    }, { enableHighAccuracy: true, timeout: 10_000, maximumAge: 30_000 })
+  }, [])
+
+  const addPointAtCenter = useCallback(() => {
+    const map = mapRef.current
+    if (!map || !canAddPoint) return
+    const point = raidTemplatePointAtMapCenter(map)
+    if (point) addPointRef.current(point)
+  }, [canAddPoint])
+
+  return <div className="rt-map" role="group" aria-label="Карта конструктора маршрута">
+    <div className="rt-map__stage" ref={containerRef} />
+    {providerState === 'loading' && <div className="rt-map__status" role="status">Загружаем карту…</div>}
+    {providerState === 'failed' && <div className="rt-map__status rt-map__status--error" role="alert">
+      <strong>Карта не загрузилась</strong>
+      <span>Черновик сохранён. Подключитесь к интернету и повторите.</span>
+      <button onClick={() => setRetryVersion((version) => version + 1)} type="button">Повторить</button>
+    </div>}
+    {providerState === 'ready' && <>
+      <div className="rt-map__instruction" aria-live="polite">
+        {canAddPoint ? 'Коснитесь карты или добавьте точку в центре' : 'Добавлено максимум 10 точек'}
+      </div>
+      <RaidTemplateMapControls
+        canAddPoint={canAddPoint}
+        locating={locating}
+        onAddPointAtCenter={addPointAtCenter}
+        onChangeZoom={changeZoom}
+        onLocate={locate}
+        zoom={zoom}
+      />
+    </>}
+  </div>
+}
+
+export function RaidTemplateMapControls({
+  canAddPoint,
+  locating,
+  onAddPointAtCenter,
+  onChangeZoom,
+  onLocate,
+  zoom,
+}: {
+  canAddPoint: boolean
+  locating: boolean
+  onAddPointAtCenter: () => void
+  onChangeZoom: (delta: number) => void
+  onLocate: () => void
+  zoom: number
+}) {
+  return <div aria-label="Управление картой" className="rt-map__controls" role="group">
+    <button aria-label="Приблизить карту" disabled={zoom >= MAX_ZOOM} onClick={() => onChangeZoom(1)} type="button">+</button>
+    <button aria-label="Отдалить карту" disabled={zoom <= MIN_ZOOM} onClick={() => onChangeZoom(-1)} type="button">−</button>
+    <button aria-label="Показать моё местоположение" disabled={locating} onClick={onLocate} type="button">
+      <svg aria-hidden="true" viewBox="0 0 24 24"><path d="M20.6 3.4 4.2 9.6a1 1 0 0 0 .1 1.9l6.2 2 2 6.3a1 1 0 0 0 1.9.1Z" /></svg>
+    </button>
+    <button
+      aria-label="Добавить точку в центре карты"
+      className="rt-map__add-point"
+      disabled={!canAddPoint}
+      onClick={onAddPointAtCenter}
+      type="button"
+    >
+      <svg aria-hidden="true" viewBox="0 0 24 24">
+        <path d="M12 21s6-5.1 6-11a6 6 0 1 0-12 0c0 5.9 6 11 6 11Z" />
+        <path d="M12 7v6M9 10h6" />
+      </svg>
+    </button>
+  </div>
+}

--- a/apps/pwa/src/features/raid-plans/editor/RaidTemplateEditorPage.tsx
+++ b/apps/pwa/src/features/raid-plans/editor/RaidTemplateEditorPage.tsx
@@ -85,6 +85,7 @@ function RaidTemplateEditor({ identityId, kabanda }: { identityId: string; kaban
   const [saveError, setSaveError] = useState<string | null>(null)
   const [submitAttempted, setSubmitAttempted] = useState(false)
   const [online, setOnline] = useState(() => navigator.onLine)
+  const [pointSheetHeight, setPointSheetHeight] = useState(0)
   const coordinateFingerprint = draft.points.map((point) => `${point.latitude}:${point.longitude}`).join('|')
   const selectedPoint = draft.points.find((point) => point.clientId === draft.selectedPointId) ?? null
   const selectedPointNumber = selectedPoint ? draft.points.findIndex((point) => point.clientId === selectedPoint.clientId) + 1 : 0
@@ -287,6 +288,7 @@ function RaidTemplateEditor({ identityId, kabanda }: { identityId: string; kaban
         onAddPoint={addPoint}
         onRouteState={handleRouteState}
         onSelectPoint={(pointId) => dispatch({ type: 'select-point', pointId })}
+        pointSheetHeight={pointSheetHeight}
         points={draft.points}
         selectedPointId={draft.selectedPointId}
       />
@@ -322,6 +324,7 @@ function RaidTemplateEditor({ identityId, kabanda }: { identityId: string; kaban
       }}
       onDelete={() => deletePoint(selectedPoint.clientId)}
       onRetryGeocode={() => void requestGeocode(selectedPoint)}
+      onHeightChange={setPointSheetHeight}
       onUpdate={(patch) => dispatch({ type: 'update-point', pointId: selectedPoint.clientId, patch })}
       point={selectedPoint}
       pointNumber={selectedPointNumber}

--- a/apps/pwa/src/features/raid-plans/editor/RaidTemplateEditorPage.tsx
+++ b/apps/pwa/src/features/raid-plans/editor/RaidTemplateEditorPage.tsx
@@ -64,15 +64,21 @@ export function RaidTemplateEditorRoute({ identityId, kabandaId }: { identityId:
 }
 
 function RaidTemplateEditor({ identityId, kabanda }: { identityId: string; kabanda: KabandaSummary }) {
-  const restoredDraft = useRef(readRaidTemplateDraft(identityId, kabanda.id))
+  const [initialDraft] = useState(() => {
+    const restored = readRaidTemplateDraft(identityId, kabanda.id)
+    return {
+      draft: restored ?? createRaidTemplateDraft(identityId, kabanda.id),
+      restored: restored !== null,
+    }
+  })
   const [draft, dispatch] = useReducer(
     raidTemplateDraftReducer,
-    restoredDraft.current ?? createRaidTemplateDraft(identityId, kabanda.id),
+    initialDraft.draft,
   )
   const draftRef = useRef(draft)
   const routeTimeoutRef = useRef<number | null>(null)
   const [routeEstimate, setRouteEstimate] = useState<DraftRouteEstimate>({ status: 'idle' })
-  const [localState, setLocalState] = useState<'saving' | 'saved' | 'failed'>(restoredDraft.current ? 'saved' : 'saving')
+  const [localState, setLocalState] = useState<'saving' | 'saved' | 'failed'>(initialDraft.restored ? 'saved' : 'saving')
   const [coverState, setCoverState] = useState<'idle' | 'processing'>('idle')
   const [coverError, setCoverError] = useState<string | null>(null)
   const [saveState, setSaveState] = useState<'idle' | 'saving' | 'error'>('idle')

--- a/apps/pwa/src/features/raid-plans/editor/RaidTemplateEditorPage.tsx
+++ b/apps/pwa/src/features/raid-plans/editor/RaidTemplateEditorPage.tsx
@@ -18,6 +18,7 @@ import {
   RAID_TEMPLATE_MAX_POINTS,
   type DraftRaidTemplatePoint,
   type DraftRouteEstimate,
+  type RaidTemplateDraft,
 } from '../types'
 import { type BicycleRouteState, type RaidPlanGeoPoint } from '../yandex-adapter'
 import {
@@ -228,6 +229,7 @@ function RaidTemplateEditor({ identityId, kabanda }: { identityId: string; kaban
     setSaveState('saving')
     try {
       await createRaidTemplate(kabanda.id, {
+        scope: current.scope,
         title: current.title.trim(),
         coverImage: current.coverImage!,
         points: current.points.map(({ name, address, comment, latitude, longitude }) => ({
@@ -277,6 +279,11 @@ function RaidTemplateEditor({ identityId, kabanda }: { identityId: string; kaban
         <span className="rt-cover__copy"><strong>{coverState === 'processing' ? 'Готовим изображение…' : draft.coverImage ? 'Заменить обложку' : 'Добавить обложку'}</strong><small>JPEG, PNG или WebP · до 12 МБ</small></span>
       </label>
       {coverError && <p className="rt-editor__error" role="alert">{coverError}</p>}
+      <RaidTemplateScopeControl
+        kabandaName={kabanda.name}
+        onChange={(scope) => dispatch({ type: 'set-scope', scope })}
+        scope={draft.scope}
+      />
     </section>
 
     <section className="rt-editor__route" aria-labelledby="rt-route-heading">
@@ -330,6 +337,43 @@ function RaidTemplateEditor({ identityId, kabanda }: { identityId: string; kaban
       pointNumber={selectedPointNumber}
     />}
   </EditorShell>
+}
+
+export function RaidTemplateScopeControl({
+  kabandaName,
+  onChange,
+  scope,
+}: {
+  kabandaName: string
+  onChange: (scope: RaidTemplateDraft['scope']) => void
+  scope: RaidTemplateDraft['scope']
+}) {
+  return <fieldset className="rt-visibility">
+    <legend>Доступ к маршруту</legend>
+    <div className="rt-visibility__options">
+      <label>
+        <input
+          checked={scope === 'kabanda'}
+          name="raid-template-scope"
+          onChange={() => onChange('kabanda')}
+          type="radio"
+        />
+        <span><strong>Только для своих</strong><small>{kabandaName}</small></span>
+      </label>
+      <label>
+        <input
+          checked={scope === 'all_authenticated'}
+          name="raid-template-scope"
+          onChange={() => onChange('all_authenticated')}
+          type="radio"
+        />
+        <span><strong>Для всех</strong><small>Все пользователи приложения</small></span>
+      </label>
+    </div>
+    <p>{scope === 'all_authenticated'
+      ? 'Обложку, комментарии и координаты увидят все участники приложения.'
+      : 'Маршрут увидят только участники вашей Кабанды.'}</p>
+  </fieldset>
 }
 
 function EditorShell({ kabandaId, children }: { kabandaId: string; children: ReactNode }) {

--- a/apps/pwa/src/features/raid-plans/editor/RaidTemplateEditorPage.tsx
+++ b/apps/pwa/src/features/raid-plans/editor/RaidTemplateEditorPage.tsx
@@ -1,0 +1,360 @@
+import '@fontsource-variable/manrope'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type ReactNode,
+} from 'react'
+import { listKabandas } from '../../kabandas/api'
+import type { KabandaSummary } from '../../kabandas/types'
+import { ApiError } from '../../../lib/http'
+import { appPath } from '../../../lib/paths'
+import { createRaidTemplate, reverseGeocodeTemplatePoint } from '../api'
+import {
+  RAID_TEMPLATE_MAX_POINTS,
+  type DraftRaidTemplatePoint,
+  type DraftRouteEstimate,
+} from '../types'
+import { type BicycleRouteState, type RaidPlanGeoPoint } from '../yandex-adapter'
+import {
+  clearRaidTemplateDraft,
+  createRaidTemplateDraft,
+  readRaidTemplateDraft,
+  saveRaidTemplateDraft,
+} from './draft-store'
+import { formatPlanDistance, geodesicRouteDistance } from './route-estimate'
+import { prepareRaidTemplateCover } from './prepare-cover'
+import {
+  raidTemplateDraftErrors,
+  raidTemplateDraftReducer,
+} from './reducer'
+import { RaidTemplateEditorMap } from './RaidTemplateEditorMap'
+import { RaidTemplatePointList } from './RaidTemplatePointList'
+import { RaidTemplatePointSheet } from './RaidTemplatePointSheet'
+import './raid-template-editor.css'
+
+export function RaidTemplateEditorRoute({ identityId, kabandaId }: { identityId: string; kabandaId: string }) {
+  const [state, setState] = useState<
+    | { status: 'loading' }
+    | { status: 'ready'; kabanda: KabandaSummary }
+    | { status: 'missing' }
+    | { status: 'error' }
+  >({ status: 'loading' })
+
+  useEffect(() => {
+    let active = true
+    listKabandas().then((kabandas) => {
+      if (!active) return
+      const kabanda = kabandas.find((item) => item.id === kabandaId)
+      setState(kabanda ? { status: 'ready', kabanda } : { status: 'missing' })
+    }).catch(() => active && setState({ status: 'error' }))
+    return () => {
+      active = false
+    }
+  }, [kabandaId])
+
+  if (state.status === 'loading') return <EditorShell kabandaId={kabandaId}><div className="rt-editor-state" aria-busy="true">Открываем конструктор…</div></EditorShell>
+  if (state.status === 'missing') return <EditorShell kabandaId={kabandaId}><EditorError title="Кабанда недоступна" detail="Создавать маршруты могут только её активные участники." /></EditorShell>
+  if (state.status === 'error') return <EditorShell kabandaId={kabandaId}><EditorError title="Не удалось проверить участие" detail="Подключитесь к интернету и откройте конструктор ещё раз." /></EditorShell>
+  return <RaidTemplateEditor identityId={identityId} kabanda={state.kabanda} />
+}
+
+function RaidTemplateEditor({ identityId, kabanda }: { identityId: string; kabanda: KabandaSummary }) {
+  const restoredDraft = useRef(readRaidTemplateDraft(identityId, kabanda.id))
+  const [draft, dispatch] = useReducer(
+    raidTemplateDraftReducer,
+    restoredDraft.current ?? createRaidTemplateDraft(identityId, kabanda.id),
+  )
+  const draftRef = useRef(draft)
+  const routeTimeoutRef = useRef<number | null>(null)
+  const [routeEstimate, setRouteEstimate] = useState<DraftRouteEstimate>({ status: 'idle' })
+  const [localState, setLocalState] = useState<'saving' | 'saved' | 'failed'>(restoredDraft.current ? 'saved' : 'saving')
+  const [coverState, setCoverState] = useState<'idle' | 'processing'>('idle')
+  const [coverError, setCoverError] = useState<string | null>(null)
+  const [saveState, setSaveState] = useState<'idle' | 'saving' | 'error'>('idle')
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [submitAttempted, setSubmitAttempted] = useState(false)
+  const [online, setOnline] = useState(() => navigator.onLine)
+  const coordinateFingerprint = draft.points.map((point) => `${point.latitude}:${point.longitude}`).join('|')
+  const selectedPoint = draft.points.find((point) => point.clientId === draft.selectedPointId) ?? null
+  const selectedPointNumber = selectedPoint ? draft.points.findIndex((point) => point.clientId === selectedPoint.clientId) + 1 : 0
+  const validationErrors = raidTemplateDraftErrors(draft)
+  const summary = estimateSummary(routeEstimate)
+  draftRef.current = draft
+
+  useEffect(() => {
+    const updateOnline = () => setOnline(navigator.onLine)
+    window.addEventListener('online', updateOnline)
+    window.addEventListener('offline', updateOnline)
+    return () => {
+      window.removeEventListener('online', updateOnline)
+      window.removeEventListener('offline', updateOnline)
+    }
+  }, [])
+
+  useEffect(() => {
+    setLocalState('saving')
+    const timer = window.setTimeout(() => {
+      setLocalState(saveRaidTemplateDraft(draft) ? 'saved' : 'failed')
+    }, 250)
+    return () => window.clearTimeout(timer)
+  }, [draft])
+
+  useEffect(() => {
+    if (routeTimeoutRef.current !== null) window.clearTimeout(routeTimeoutRef.current)
+    if (draft.points.length < 2) {
+      setRouteEstimate({ status: 'idle' })
+      return
+    }
+    const fallbackDistanceMeters = geodesicRouteDistance(draft.points)
+    setRouteEstimate({ status: 'calculating', fallbackDistanceMeters })
+    routeTimeoutRef.current = window.setTimeout(() => {
+      setRouteEstimate({ status: 'degraded', distanceMeters: fallbackDistanceMeters, failureCode: 'provider_unavailable' })
+    }, 15_000)
+    return () => {
+      if (routeTimeoutRef.current !== null) window.clearTimeout(routeTimeoutRef.current)
+    }
+    // Only coordinate/order changes make the current route estimate stale.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [coordinateFingerprint])
+
+  const requestGeocode = useCallback(async (point: Pick<DraftRaidTemplatePoint, 'clientId' | 'latitude' | 'longitude'>) => {
+    const requestId = randomId()
+    dispatch({ type: 'start-geocode', pointId: point.clientId, requestId })
+    try {
+      const suggestion = await reverseGeocodeTemplatePoint(point.latitude, point.longitude)
+      if (!suggestion.name && !suggestion.address) {
+        dispatch({ type: 'fail-geocode', pointId: point.clientId, requestId })
+        return
+      }
+      dispatch({
+        type: 'resolve-geocode',
+        pointId: point.clientId,
+        requestId,
+        name: suggestion.name,
+        address: suggestion.address,
+      })
+    } catch {
+      dispatch({ type: 'fail-geocode', pointId: point.clientId, requestId })
+    }
+  }, [])
+
+  useEffect(() => {
+    for (const point of draftRef.current.points) {
+      if (point.geocodeStatus === 'pending') void requestGeocode(point)
+    }
+  }, [requestGeocode])
+
+  const addPoint = useCallback((coordinates: RaidPlanGeoPoint) => {
+    const current = draftRef.current
+    if (current.points.length >= RAID_TEMPLATE_MAX_POINTS) return
+    const point: DraftRaidTemplatePoint = {
+      clientId: randomId(),
+      latitude: coordinates.latitude,
+      longitude: coordinates.longitude,
+      name: `Точка ${current.points.length + 1}`,
+      address: '',
+      comment: '',
+      geocodeStatus: 'pending',
+      geocodeRequestId: null,
+      labelsConfirmed: false,
+    }
+    dispatch({ type: 'add-point', point })
+    void requestGeocode(point)
+  }, [requestGeocode])
+
+  const handleRouteState = useCallback((state: BicycleRouteState) => {
+    if (routeTimeoutRef.current !== null) window.clearTimeout(routeTimeoutRef.current)
+    if (state.status === 'calculating') {
+      const fallbackDistanceMeters = Math.round(state.fallbackDistanceMeters)
+      setRouteEstimate({ status: 'calculating', fallbackDistanceMeters })
+      routeTimeoutRef.current = window.setTimeout(() => {
+        setRouteEstimate({ status: 'degraded', distanceMeters: fallbackDistanceMeters, failureCode: 'provider_unavailable' })
+      }, 15_000)
+      return
+    }
+    if (state.status === 'ready') {
+      setRouteEstimate({ status: 'ready', distanceMeters: Math.round(state.distanceMeters) })
+      return
+    }
+    setRouteEstimate({
+      status: 'degraded',
+      distanceMeters: Math.round(state.fallbackDistanceMeters),
+      failureCode: state.code,
+    })
+  }, [])
+
+  const prepareCover = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    event.target.value = ''
+    if (!file) return
+    setCoverState('processing')
+    setCoverError(null)
+    try {
+      dispatch({ type: 'set-cover', coverImage: await prepareRaidTemplateCover(file) })
+    } catch (error) {
+      setCoverError(error instanceof Error ? error.message : 'Не удалось подготовить обложку.')
+    } finally {
+      setCoverState('idle')
+    }
+  }
+
+  const deletePoint = (pointId: string) => {
+    if (!window.confirm('Удалить эту точку из маршрута?')) return
+    dispatch({ type: 'delete-point', pointId })
+  }
+
+  const save = async () => {
+    setSubmitAttempted(true)
+    setSaveError(null)
+    const current = draftRef.current
+    const errors = raidTemplateDraftErrors(current)
+    if (errors.length > 0) return
+    if (!navigator.onLine) {
+      setSaveError('Для сохранения маршрута в Кабанде нужно подключение к интернету. Локальный черновик не пропадёт.')
+      return
+    }
+    setSaveState('saving')
+    try {
+      await createRaidTemplate(kabanda.id, {
+        title: current.title.trim(),
+        coverImage: current.coverImage!,
+        points: current.points.map(({ name, address, comment, latitude, longitude }) => ({
+          name: name.trim(),
+          address: address.trim(),
+          comment: comment.trim(),
+          latitude,
+          longitude,
+        })),
+      }, current.idempotencyKey)
+      clearRaidTemplateDraft(identityId, kabanda.id)
+      window.location.assign(`${appPath('app')}?kabanda=${encodeURIComponent(kabanda.id)}&tab=raids`)
+    } catch (error) {
+      setSaveState('error')
+      setSaveError(error instanceof ApiError ? error.message : 'Маршрут не сохранился. Повтор использует тот же ключ и не создаст дубль.')
+    }
+  }
+
+  return <EditorShell kabandaId={kabanda.id}>
+    <header className="rt-editor__heading">
+      <div>
+        <p>{kabanda.name}</p>
+        <h1>Новый маршрут</h1>
+      </div>
+      <span className={`rt-editor__local-state rt-editor__local-state--${localState}`} role="status">
+        {localState === 'saving' ? 'Сохраняем черновик…' : localState === 'saved' ? 'Черновик на устройстве' : 'Черновик только в памяти'}
+      </span>
+    </header>
+
+    <section className="rt-editor__basics" aria-labelledby="rt-basics-heading">
+      <div className="rt-editor__section-head">
+        <span>1</span><div><h2 id="rt-basics-heading">Название и обложка</h2><p>Их увидят участники в каталоге маршрутов.</p></div>
+      </div>
+      <label htmlFor="rt-template-title">Название маршрута</label>
+      <input
+        autoCapitalize="sentences"
+        id="rt-template-title"
+        maxLength={120}
+        onChange={(event) => dispatch({ type: 'set-title', title: event.target.value })}
+        placeholder="Например, Набережная и центр"
+        required
+        value={draft.title}
+      />
+      <label className={`rt-cover${draft.coverImage ? ' rt-cover--ready' : ''}`}>
+        <input accept="image/jpeg,image/png,image/webp" aria-label={draft.coverImage ? 'Заменить обложку маршрута' : 'Добавить обложку маршрута'} disabled={coverState === 'processing'} onChange={(event) => void prepareCover(event)} type="file" />
+        {draft.coverImage ? <img alt="Предпросмотр обложки маршрута" src={draft.coverImage} /> : <span aria-hidden="true" className="rt-cover__icon">＋</span>}
+        <span className="rt-cover__copy"><strong>{coverState === 'processing' ? 'Готовим изображение…' : draft.coverImage ? 'Заменить обложку' : 'Добавить обложку'}</strong><small>JPEG, PNG или WebP · до 12 МБ</small></span>
+      </label>
+      {coverError && <p className="rt-editor__error" role="alert">{coverError}</p>}
+    </section>
+
+    <section className="rt-editor__route" aria-labelledby="rt-route-heading">
+      <div className="rt-editor__section-head">
+        <span>2</span><div><h2 id="rt-route-heading">Точки маршрута</h2><p>Добавьте от 2 до 10 мест в нужном порядке.</p></div>
+      </div>
+      <RaidTemplateEditorMap
+        canAddPoint={draft.points.length < RAID_TEMPLATE_MAX_POINTS}
+        onAddPoint={addPoint}
+        onRouteState={handleRouteState}
+        onSelectPoint={(pointId) => dispatch({ type: 'select-point', pointId })}
+        points={draft.points}
+        selectedPointId={draft.selectedPointId}
+      />
+      <div className="rt-route-summary" aria-live="polite">
+        <span><strong>{draft.points.length}</strong><small>{pointCountLabel(draft.points.length)}</small></span>
+        <span><strong>{summary.distance}</strong><small>{summary.label}</small></span>
+      </div>
+      <RaidTemplatePointList
+        onDelete={deletePoint}
+        onMove={(pointId, direction) => dispatch({ type: 'move-point', pointId, direction })}
+        onReorder={(activeId, overId) => dispatch({ type: 'reorder-point', activeId, overId })}
+        onSelect={(pointId) => dispatch({ type: 'select-point', pointId })}
+        points={draft.points}
+        selectedPointId={draft.selectedPointId}
+      />
+    </section>
+
+    {submitAttempted && validationErrors.length > 0 && <div className="rt-editor__validation" role="alert">
+      <strong>Маршрут пока не готов</strong>
+      <ul>{validationErrors.map((error) => <li key={error}>{error}</li>)}</ul>
+    </div>}
+    {!online && <p className="rt-editor__offline" role="status">Нет сети. Можно продолжать редактирование — черновик останется на устройстве.</p>}
+    {saveError && <p className="rt-editor__error rt-editor__save-error" role="alert">{saveError}</p>}
+    <button className="rt-editor__save" disabled={saveState === 'saving' || coverState === 'processing'} onClick={() => void save()} type="button">
+      {saveState === 'saving' ? 'Сохраняем маршрут…' : 'Сохранить маршрут'}
+    </button>
+
+    {selectedPoint && <RaidTemplatePointSheet
+      onClose={() => dispatch({ type: 'select-point', pointId: null })}
+      onConfirm={() => {
+        dispatch({ type: 'confirm-point-labels', pointId: selectedPoint.clientId })
+        dispatch({ type: 'select-point', pointId: null })
+      }}
+      onDelete={() => deletePoint(selectedPoint.clientId)}
+      onRetryGeocode={() => void requestGeocode(selectedPoint)}
+      onUpdate={(patch) => dispatch({ type: 'update-point', pointId: selectedPoint.clientId, patch })}
+      point={selectedPoint}
+      pointNumber={selectedPointNumber}
+    />}
+  </EditorShell>
+}
+
+function EditorShell({ kabandaId, children }: { kabandaId: string; children: ReactNode }) {
+  return <main className="rt-editor-shell">
+    <nav className="rt-editor-nav" aria-label="Навигация конструктора">
+      <a href={`${appPath('app')}?kabanda=${encodeURIComponent(kabandaId)}&tab=raids`} aria-label="Вернуться к рейдам">← <span>Рейды</span></a>
+      <a className="rt-editor-nav__brand" href={appPath('app')} aria-label="КАБАНДА — на главную"><img alt="" src={appPath('brand/kabanda-logo-reference.png')} /><strong>КАБАНДА</strong></a>
+    </nav>
+    {children}
+  </main>
+}
+
+function EditorError({ title, detail }: { title: string; detail: string }) {
+  return <section className="rt-editor-state"><h1>{title}</h1><p>{detail}</p><a href={appPath('app')}>На главную</a></section>
+}
+
+function estimateSummary(estimate: DraftRouteEstimate): { distance: string; label: string } {
+  if (estimate.status === 'idle') return { distance: '—', label: 'добавьте 2 точки' }
+  if (estimate.status === 'calculating') return {
+    distance: estimate.fallbackDistanceMeters === null ? '…' : `≈ ${formatPlanDistance(estimate.fallbackDistanceMeters)}`,
+    label: 'строим веломаршрут',
+  }
+  return {
+    distance: `≈ ${formatPlanDistance(estimate.distanceMeters)}`,
+    label: estimate.status === 'ready' ? 'веломаршрут Яндекса' : 'по прямым отрезкам',
+  }
+}
+
+function pointCountLabel(count: number): string {
+  if (count === 1) return 'точка'
+  if (count >= 2 && count <= 4) return 'точки'
+  return 'точек'
+}
+
+function randomId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`
+}

--- a/apps/pwa/src/features/raid-plans/editor/RaidTemplatePointList.tsx
+++ b/apps/pwa/src/features/raid-plans/editor/RaidTemplatePointList.tsx
@@ -1,0 +1,95 @@
+import { useRef, useState, type PointerEvent as ReactPointerEvent } from 'react'
+import type { DraftRaidTemplatePoint } from '../types'
+
+export function RaidTemplatePointList({
+  points,
+  selectedPointId,
+  onDelete,
+  onMove,
+  onReorder,
+  onSelect,
+}: {
+  points: readonly DraftRaidTemplatePoint[]
+  selectedPointId: string | null
+  onDelete: (pointId: string) => void
+  onMove: (pointId: string, direction: -1 | 1) => void
+  onReorder: (activeId: string, overId: string) => void
+  onSelect: (pointId: string) => void
+}) {
+  const activeIdRef = useRef<string | null>(null)
+  const [draggedId, setDraggedId] = useState<string | null>(null)
+
+  const startDrag = (pointId: string, event: ReactPointerEvent<HTMLButtonElement>) => {
+    if (event.pointerType === 'mouse' && event.button !== 0) return
+    activeIdRef.current = pointId
+    setDraggedId(pointId)
+    event.currentTarget.setPointerCapture(event.pointerId)
+    event.preventDefault()
+  }
+
+  const drag = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    const activeId = activeIdRef.current
+    if (!activeId) return
+    const element = document.elementFromPoint(event.clientX, event.clientY)
+    const item = element?.closest<HTMLElement>('[data-template-point-id]')
+    const overId = item?.dataset.templatePointId
+    if (overId && overId !== activeId) onReorder(activeId, overId)
+  }
+
+  const stopDrag = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) event.currentTarget.releasePointerCapture(event.pointerId)
+    activeIdRef.current = null
+    setDraggedId(null)
+  }
+
+  if (points.length === 0) {
+    return <div className="rt-editor__points-empty">
+      <strong>Точек пока нет</strong>
+      <span>Коснитесь карты, чтобы поставить первую точку маршрута.</span>
+    </div>
+  }
+
+  return <ol className="rt-point-list" aria-label="Порядок точек маршрута">
+    {points.map((point, index) => (
+      <li
+        className={`rt-point-card${selectedPointId === point.clientId ? ' rt-point-card--selected' : ''}${draggedId === point.clientId ? ' rt-point-card--dragged' : ''}`}
+        data-template-point-id={point.clientId}
+        key={point.clientId}
+      >
+        <button
+          aria-label={`Перетащить точку ${index + 1}: ${point.name || 'без названия'}`}
+          className="rt-point-card__drag"
+          onPointerCancel={stopDrag}
+          onPointerDown={(event) => startDrag(point.clientId, event)}
+          onPointerMove={drag}
+          onPointerUp={stopDrag}
+          type="button"
+        >
+          <span aria-hidden="true">⠿</span>
+        </button>
+        <button className="rt-point-card__main" onClick={() => onSelect(point.clientId)} type="button">
+          <span className="rt-point-card__number" aria-hidden="true">{index + 1}</span>
+          <span className="rt-point-card__copy">
+            <strong>{point.name.trim() || `Точка ${index + 1}`}</strong>
+            <small>{point.address.trim() || geocodeLabel(point.geocodeStatus)}</small>
+            {point.comment.trim() && <em>{point.comment}</em>}
+          </span>
+          <span className={`rt-point-card__state${point.labelsConfirmed ? ' rt-point-card__state--confirmed' : ''}`}>
+            {point.labelsConfirmed ? 'Проверено' : 'Проверьте'}
+          </span>
+        </button>
+        <span className="rt-point-card__actions">
+          <button aria-label={`Поднять точку ${index + 1} выше`} disabled={index === 0} onClick={() => onMove(point.clientId, -1)} type="button">↑</button>
+          <button aria-label={`Опустить точку ${index + 1} ниже`} disabled={index === points.length - 1} onClick={() => onMove(point.clientId, 1)} type="button">↓</button>
+          <button aria-label={`Удалить точку ${index + 1}`} className="rt-point-card__delete" onClick={() => onDelete(point.clientId)} type="button">×</button>
+        </span>
+      </li>
+    ))}
+  </ol>
+}
+
+function geocodeLabel(status: DraftRaidTemplatePoint['geocodeStatus']): string {
+  if (status === 'pending') return 'Определяем адрес…'
+  if (status === 'failed') return 'Адрес нужно ввести вручную'
+  return 'Добавьте адрес'
+}

--- a/apps/pwa/src/features/raid-plans/editor/RaidTemplatePointSheet.tsx
+++ b/apps/pwa/src/features/raid-plans/editor/RaidTemplatePointSheet.tsx
@@ -1,5 +1,18 @@
-import { useEffect, useRef, type FormEvent } from 'react'
+import {
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type FormEvent,
+  type PointerEvent as ReactPointerEvent,
+} from 'react'
 import type { DraftRaidTemplatePoint } from '../types'
+
+const POINT_SHEET_DISMISS_DISTANCE = 72
+
+export function shouldDismissPointSheet(startY: number, currentY: number) {
+  return currentY - startY >= POINT_SHEET_DISMISS_DISTANCE
+}
 
 export function RaidTemplatePointSheet({
   point,
@@ -7,6 +20,7 @@ export function RaidTemplatePointSheet({
   onClose,
   onConfirm,
   onDelete,
+  onHeightChange,
   onRetryGeocode,
   onUpdate,
 }: {
@@ -15,17 +29,21 @@ export function RaidTemplatePointSheet({
   onClose: () => void
   onConfirm: () => void
   onDelete: () => void
+  onHeightChange: (height: number) => void
   onRetryGeocode: () => void
   onUpdate: (patch: Partial<Pick<DraftRaidTemplatePoint, 'name' | 'address' | 'comment' | 'labelsConfirmed'>>) => void
 }) {
-  const nameRef = useRef<HTMLInputElement>(null)
   const sheetRef = useRef<HTMLElement>(null)
+  const dragRef = useRef<{ pointerId: number; startY: number; currentY: number } | null>(null)
   const onCloseRef = useRef(onClose)
+  const [dragOffset, setDragOffset] = useState(0)
+  const [dragging, setDragging] = useState(false)
   onCloseRef.current = onClose
 
   useEffect(() => {
     const opener = document.activeElement instanceof HTMLElement ? document.activeElement : null
-    nameRef.current?.focus({ preventScroll: true })
+    sheetRef.current?.focus({ preventScroll: true })
+    document.body.classList.add('rt-point-sheet-open')
     const handleKeyboard = (event: KeyboardEvent) => {
       if (event.key === 'Escape') onCloseRef.current()
       if (event.key !== 'Tab') return
@@ -44,9 +62,52 @@ export function RaidTemplatePointSheet({
     window.addEventListener('keydown', handleKeyboard)
     return () => {
       window.removeEventListener('keydown', handleKeyboard)
+      document.body.classList.remove('rt-point-sheet-open')
       opener?.focus({ preventScroll: true })
     }
   }, [])
+
+  useEffect(() => {
+    const sheet = sheetRef.current
+    if (!sheet) return
+    const reportHeight = () => onHeightChange(Math.ceil(sheet.getBoundingClientRect().height))
+    reportHeight()
+    const observer = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(reportHeight)
+    observer?.observe(sheet)
+    window.visualViewport?.addEventListener('resize', reportHeight)
+    return () => {
+      observer?.disconnect()
+      window.visualViewport?.removeEventListener('resize', reportHeight)
+      onHeightChange(0)
+    }
+  }, [onHeightChange])
+
+  const startDrag = (event: ReactPointerEvent<HTMLElement>) => {
+    if (event.pointerType === 'mouse' && event.button !== 0) return
+    dragRef.current = { pointerId: event.pointerId, startY: event.clientY, currentY: event.clientY }
+    event.currentTarget.setPointerCapture(event.pointerId)
+    setDragging(true)
+  }
+
+  const moveDrag = (event: ReactPointerEvent<HTMLElement>) => {
+    const drag = dragRef.current
+    if (!drag || drag.pointerId !== event.pointerId) return
+    drag.currentY = event.clientY
+    setDragOffset(Math.max(0, event.clientY - drag.startY))
+  }
+
+  const finishDrag = (event: ReactPointerEvent<HTMLElement>, allowDismiss: boolean) => {
+    const drag = dragRef.current
+    if (!drag || drag.pointerId !== event.pointerId) return
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) event.currentTarget.releasePointerCapture(event.pointerId)
+    dragRef.current = null
+    setDragging(false)
+    if (allowDismiss && shouldDismissPointSheet(drag.startY, drag.currentY)) {
+      onCloseRef.current()
+      return
+    }
+    setDragOffset(0)
+  }
 
   const submit = (event: FormEvent) => {
     event.preventDefault()
@@ -54,21 +115,32 @@ export function RaidTemplatePointSheet({
     onConfirm()
   }
 
-  return <div className="rt-point-sheet-backdrop" role="presentation" onMouseDown={(event) => event.target === event.currentTarget && onClose()}>
-    <section aria-labelledby="rt-point-sheet-title" aria-modal="true" className="rt-point-sheet" ref={sheetRef} role="dialog">
-      <span aria-hidden="true" className="rt-point-sheet__grabber" />
-      <header>
-        <div>
-          <span>Точка {pointNumber}</span>
-          <h2 id="rt-point-sheet-title">Проверьте место</h2>
-        </div>
-        <button aria-label="Закрыть карточку точки" className="rt-point-sheet__close" onClick={onClose} type="button">×</button>
+  const sheetStyle = { '--rt-point-sheet-drag': `${dragOffset}px` } as CSSProperties
+
+  return <div className="rt-point-sheet-backdrop" role="presentation" onPointerDown={(event) => event.target === event.currentTarget && onClose()}>
+    <section
+      aria-labelledby="rt-point-sheet-title"
+      aria-modal="true"
+      className={`rt-point-sheet${dragging ? ' rt-point-sheet--dragging' : ''}`}
+      ref={sheetRef}
+      role="dialog"
+      style={sheetStyle}
+      tabIndex={-1}
+    >
+      <header
+        className="rt-point-sheet__handle"
+        onPointerCancel={(event) => finishDrag(event, false)}
+        onPointerDown={startDrag}
+        onPointerMove={moveDrag}
+        onPointerUp={(event) => finishDrag(event, true)}
+      >
+        <span aria-hidden="true" className="rt-point-sheet__grabber" />
+        <h2 id="rt-point-sheet-title">Точка {pointNumber}</h2>
       </header>
-      <p className="rt-point-sheet__hint">
-        {point.geocodeStatus === 'pending' && 'Ищем название и адрес. Можно заполнить их вручную.'}
-        {point.geocodeStatus === 'ready' && 'Сервис адресов предложил подписи. Проверьте их перед сохранением.'}
-        {point.geocodeStatus === 'failed' && <>Сервис адресов не нашёл место. Заполните его вручную или <button onClick={onRetryGeocode} type="button">повторите поиск</button>.</>}
-      </p>
+      {point.geocodeStatus !== 'ready' && <p className="rt-point-sheet__hint">
+        {point.geocodeStatus === 'pending' && 'Определяем название и адрес…'}
+        {point.geocodeStatus === 'failed' && <>Адрес не найден. Введите его или <button onClick={onRetryGeocode} type="button">повторите поиск</button>.</>}
+      </p>}
       <form onSubmit={submit}>
         <label htmlFor="rt-point-name">Название точки</label>
         <input
@@ -76,11 +148,15 @@ export function RaidTemplatePointSheet({
           id="rt-point-name"
           maxLength={120}
           onChange={(event) => onUpdate({ name: event.target.value, labelsConfirmed: false })}
-          ref={nameRef}
           required
           value={point.name}
         />
-        <label htmlFor="rt-point-address">Адрес</label>
+        <div className="rt-point-sheet__field-head">
+          <label htmlFor="rt-point-address">Адрес</label>
+          <a className="rt-point-sheet__attribution" href="https://www.openstreetmap.org/copyright" rel="noreferrer" target="_blank">
+            © OpenStreetMap
+          </a>
+        </div>
         <input
           autoComplete="street-address"
           id="rt-point-address"
@@ -89,22 +165,23 @@ export function RaidTemplatePointSheet({
           required
           value={point.address}
         />
-        <a className="rt-point-sheet__attribution" href="https://www.openstreetmap.org/copyright" rel="noreferrer" target="_blank">
-          Адреса © OpenStreetMap contributors
-        </a>
-        <label htmlFor="rt-point-comment">Комментарий <span>необязательно</span></label>
+        <label htmlFor="rt-point-comment">Комментарий</label>
         <textarea
           id="rt-point-comment"
           maxLength={500}
           onChange={(event) => onUpdate({ comment: event.target.value })}
-          placeholder="Что здесь сделать или на что обратить внимание"
-          rows={3}
+          placeholder="Что важно знать в этой точке"
+          rows={1}
           value={point.comment}
         />
-        <button className="rt-point-sheet__confirm" disabled={!point.name.trim() || !point.address.trim()} type="submit">
-          {point.labelsConfirmed ? 'Подтверждено' : 'Подтвердить название и адрес'}
-        </button>
-        <button className="rt-point-sheet__delete" onClick={onDelete} type="button">Удалить точку</button>
+        <div className="rt-point-sheet__actions">
+          <button className="rt-point-sheet__confirm" disabled={!point.name.trim() || !point.address.trim()} type="submit">
+            {point.labelsConfirmed ? 'Готово' : 'Подтвердить'}
+          </button>
+          <button aria-label={`Удалить точку ${pointNumber}`} className="rt-point-sheet__delete" onClick={onDelete} type="button">
+            <svg aria-hidden="true" viewBox="0 0 24 24"><path d="M4 7h16M9 7V4h6v3m-8 0 1 13h8l1-13M10 11v5m4-5v5" /></svg>
+          </button>
+        </div>
       </form>
     </section>
   </div>

--- a/apps/pwa/src/features/raid-plans/editor/RaidTemplatePointSheet.tsx
+++ b/apps/pwa/src/features/raid-plans/editor/RaidTemplatePointSheet.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useRef, type FormEvent } from 'react'
+import type { DraftRaidTemplatePoint } from '../types'
+
+export function RaidTemplatePointSheet({
+  point,
+  pointNumber,
+  onClose,
+  onConfirm,
+  onDelete,
+  onRetryGeocode,
+  onUpdate,
+}: {
+  point: DraftRaidTemplatePoint
+  pointNumber: number
+  onClose: () => void
+  onConfirm: () => void
+  onDelete: () => void
+  onRetryGeocode: () => void
+  onUpdate: (patch: Partial<Pick<DraftRaidTemplatePoint, 'name' | 'address' | 'comment' | 'labelsConfirmed'>>) => void
+}) {
+  const nameRef = useRef<HTMLInputElement>(null)
+  const sheetRef = useRef<HTMLElement>(null)
+  const onCloseRef = useRef(onClose)
+  onCloseRef.current = onClose
+
+  useEffect(() => {
+    const opener = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    nameRef.current?.focus({ preventScroll: true })
+    const handleKeyboard = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onCloseRef.current()
+      if (event.key !== 'Tab') return
+      const focusable = sheetRef.current?.querySelectorAll<HTMLElement>('a[href], button:not(:disabled), input:not(:disabled), textarea:not(:disabled)')
+      if (!focusable?.length) return
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault()
+        last?.focus()
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault()
+        first?.focus()
+      }
+    }
+    window.addEventListener('keydown', handleKeyboard)
+    return () => {
+      window.removeEventListener('keydown', handleKeyboard)
+      opener?.focus({ preventScroll: true })
+    }
+  }, [])
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault()
+    if (!point.name.trim() || !point.address.trim()) return
+    onConfirm()
+  }
+
+  return <div className="rt-point-sheet-backdrop" role="presentation" onMouseDown={(event) => event.target === event.currentTarget && onClose()}>
+    <section aria-labelledby="rt-point-sheet-title" aria-modal="true" className="rt-point-sheet" ref={sheetRef} role="dialog">
+      <span aria-hidden="true" className="rt-point-sheet__grabber" />
+      <header>
+        <div>
+          <span>Точка {pointNumber}</span>
+          <h2 id="rt-point-sheet-title">Проверьте место</h2>
+        </div>
+        <button aria-label="Закрыть карточку точки" className="rt-point-sheet__close" onClick={onClose} type="button">×</button>
+      </header>
+      <p className="rt-point-sheet__hint">
+        {point.geocodeStatus === 'pending' && 'Ищем название и адрес. Можно заполнить их вручную.'}
+        {point.geocodeStatus === 'ready' && 'Сервис адресов предложил подписи. Проверьте их перед сохранением.'}
+        {point.geocodeStatus === 'failed' && <>Сервис адресов не нашёл место. Заполните его вручную или <button onClick={onRetryGeocode} type="button">повторите поиск</button>.</>}
+      </p>
+      <form onSubmit={submit}>
+        <label htmlFor="rt-point-name">Название точки</label>
+        <input
+          autoComplete="off"
+          id="rt-point-name"
+          maxLength={120}
+          onChange={(event) => onUpdate({ name: event.target.value, labelsConfirmed: false })}
+          ref={nameRef}
+          required
+          value={point.name}
+        />
+        <label htmlFor="rt-point-address">Адрес</label>
+        <input
+          autoComplete="street-address"
+          id="rt-point-address"
+          maxLength={240}
+          onChange={(event) => onUpdate({ address: event.target.value, labelsConfirmed: false })}
+          required
+          value={point.address}
+        />
+        <a className="rt-point-sheet__attribution" href="https://www.openstreetmap.org/copyright" rel="noreferrer" target="_blank">
+          Адреса © OpenStreetMap contributors
+        </a>
+        <label htmlFor="rt-point-comment">Комментарий <span>необязательно</span></label>
+        <textarea
+          id="rt-point-comment"
+          maxLength={500}
+          onChange={(event) => onUpdate({ comment: event.target.value })}
+          placeholder="Что здесь сделать или на что обратить внимание"
+          rows={3}
+          value={point.comment}
+        />
+        <button className="rt-point-sheet__confirm" disabled={!point.name.trim() || !point.address.trim()} type="submit">
+          {point.labelsConfirmed ? 'Подтверждено' : 'Подтвердить название и адрес'}
+        </button>
+        <button className="rt-point-sheet__delete" onClick={onDelete} type="button">Удалить точку</button>
+      </form>
+    </section>
+  </div>
+}

--- a/apps/pwa/src/features/raid-plans/editor/draft-store.test.ts
+++ b/apps/pwa/src/features/raid-plans/editor/draft-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createRaidTemplateDraft, draftKey, readRaidTemplateDraft, saveRaidTemplateDraft } from './draft-store'
 
 function memoryStorage() {
@@ -34,16 +34,55 @@ describe('raid template local draft', () => {
     expect(readRaidTemplateDraft('member-a', 'kabanda-a', storage)).toBeNull()
   })
 
-  it('scrubs legacy provider estimates instead of persisting them in the local draft', () => {
+  it('scrubs legacy provider estimates in memory without mutating storage during read', () => {
     const storage = memoryStorage()
     const key = draftKey('member-a', 'kabanda-a')
     storage.setItem(key, JSON.stringify({
       ...createRaidTemplateDraft('member-a', 'kabanda-a'),
       estimate: { status: 'ready', mode: 'bicycle', distanceMeters: 4_200 },
     }))
+    const storedValue = storage.getItem(key)
 
     const restored = readRaidTemplateDraft('member-a', 'kabanda-a', storage)
     expect(restored).not.toHaveProperty('estimate')
+    expect(storage.getItem(key)).toBe(storedValue)
+    expect(JSON.parse(storage.getItem(key) ?? '{}')).toHaveProperty('estimate')
+
+    expect(saveRaidTemplateDraft(restored!, storage)).toBe(true)
     expect(JSON.parse(storage.getItem(key) ?? '{}')).not.toHaveProperty('estimate')
+  })
+
+  it('restores a JPEG draft without rewriting or deleting it when setItem would fail', () => {
+    const draft = {
+      ...createRaidTemplateDraft('member-a', 'kabanda-a'),
+      title: 'Маршрут с обложкой',
+      coverImage: `data:image/jpeg;base64,${'a'.repeat(2_048)}`,
+    }
+    let storedValue: string | null = JSON.stringify(draft)
+    const storage = {
+      getItem: vi.fn(() => storedValue),
+      setItem: vi.fn(() => {
+        throw new Error('QuotaExceededError')
+      }),
+      removeItem: vi.fn(() => {
+        storedValue = null
+      }),
+    }
+
+    const restored = readRaidTemplateDraft('member-a', 'kabanda-a', storage)
+
+    expect(restored).toMatchObject({
+      title: 'Маршрут с обложкой',
+      coverImage: draft.coverImage,
+    })
+    expect(storage.getItem).toHaveBeenCalledOnce()
+    expect(storage.setItem).not.toHaveBeenCalled()
+    expect(storage.removeItem).not.toHaveBeenCalled()
+    expect(storedValue).toBe(JSON.stringify(draft))
+
+    expect(saveRaidTemplateDraft(restored!, storage)).toBe(false)
+    expect(storage.setItem).toHaveBeenCalledOnce()
+    expect(storage.removeItem).not.toHaveBeenCalled()
+    expect(storedValue).toBe(JSON.stringify(draft))
   })
 })

--- a/apps/pwa/src/features/raid-plans/editor/draft-store.test.ts
+++ b/apps/pwa/src/features/raid-plans/editor/draft-store.test.ts
@@ -34,6 +34,21 @@ describe('raid template local draft', () => {
     expect(readRaidTemplateDraft('member-a', 'kabanda-a', storage)).toBeNull()
   })
 
+  it('migrates an existing draft to private visibility without losing its content', () => {
+    const storage = memoryStorage()
+    const key = draftKey('member-a', 'kabanda-a')
+    const current = createRaidTemplateDraft('member-a', 'kabanda-a')
+    const legacy = { ...current, schemaVersion: 1, title: 'Старый черновик' }
+    delete (legacy as Partial<typeof current>).scope
+    storage.setItem(key, JSON.stringify(legacy))
+
+    expect(readRaidTemplateDraft('member-a', 'kabanda-a', storage)).toMatchObject({
+      schemaVersion: 2,
+      scope: 'kabanda',
+      title: 'Старый черновик',
+    })
+  })
+
   it('scrubs legacy provider estimates in memory without mutating storage during read', () => {
     const storage = memoryStorage()
     const key = draftKey('member-a', 'kabanda-a')

--- a/apps/pwa/src/features/raid-plans/editor/draft-store.test.ts
+++ b/apps/pwa/src/features/raid-plans/editor/draft-store.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { createRaidTemplateDraft, draftKey, readRaidTemplateDraft, saveRaidTemplateDraft } from './draft-store'
+
+function memoryStorage() {
+  const values = new Map<string, string>()
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => { values.set(key, value) },
+    removeItem: (key: string) => { values.delete(key) },
+  }
+}
+
+describe('raid template local draft', () => {
+  it('is isolated by identity and Kabanda', () => {
+    const storage = memoryStorage()
+    const saved = { ...createRaidTemplateDraft('member-a', 'kabanda-a'), title: 'Мой маршрут' }
+    expect(saveRaidTemplateDraft(saved, storage)).toBe(true)
+
+    expect(readRaidTemplateDraft('member-a', 'kabanda-a', storage)?.title).toBe('Мой маршрут')
+    expect(readRaidTemplateDraft('member-b', 'kabanda-a', storage)).toBeNull()
+    expect(readRaidTemplateDraft('member-a', 'kabanda-b', storage)).toBeNull()
+    expect(draftKey('member-a', 'kabanda-a')).not.toBe(draftKey('member-b', 'kabanda-a'))
+  })
+
+  it('fails closed for malformed local data', () => {
+    const storage = memoryStorage()
+    storage.setItem(draftKey('member-a', 'kabanda-a'), '{not json')
+    expect(readRaidTemplateDraft('member-a', 'kabanda-a', storage)).toBeNull()
+
+    storage.setItem(draftKey('member-a', 'kabanda-a'), JSON.stringify({
+      ...createRaidTemplateDraft('member-a', 'kabanda-a'),
+      points: [null],
+    }))
+    expect(readRaidTemplateDraft('member-a', 'kabanda-a', storage)).toBeNull()
+  })
+
+  it('scrubs legacy provider estimates instead of persisting them in the local draft', () => {
+    const storage = memoryStorage()
+    const key = draftKey('member-a', 'kabanda-a')
+    storage.setItem(key, JSON.stringify({
+      ...createRaidTemplateDraft('member-a', 'kabanda-a'),
+      estimate: { status: 'ready', mode: 'bicycle', distanceMeters: 4_200 },
+    }))
+
+    const restored = readRaidTemplateDraft('member-a', 'kabanda-a', storage)
+    expect(restored).not.toHaveProperty('estimate')
+    expect(JSON.parse(storage.getItem(key) ?? '{}')).not.toHaveProperty('estimate')
+  })
+})

--- a/apps/pwa/src/features/raid-plans/editor/draft-store.ts
+++ b/apps/pwa/src/features/raid-plans/editor/draft-store.ts
@@ -4,12 +4,18 @@ const DRAFT_PREFIX = 'kabanda.raid-template-draft.v1'
 
 type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
 
+type StoredRaidTemplateDraft = Partial<Omit<RaidTemplateDraft, 'schemaVersion' | 'scope'>> & {
+  schemaVersion?: 1 | 2
+  scope?: RaidTemplateDraft['scope']
+}
+
 export function createRaidTemplateDraft(identityId: string, kabandaId: string, now = new Date().toISOString()): RaidTemplateDraft {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     clientDraftId: randomId(),
     identityId,
     kabandaId,
+    scope: 'kabanda',
     title: '',
     coverImage: null,
     points: [],
@@ -57,13 +63,14 @@ export function draftKey(identityId: string, kabandaId: string): string {
 
 function parseDraft(value: unknown, identityId: string, kabandaId: string): RaidTemplateDraft | null {
   if (!value || typeof value !== 'object') return null
-  const draft = value as Partial<RaidTemplateDraft>
-  const valid = draft.schemaVersion === 1 &&
+  const draft = value as StoredRaidTemplateDraft
+  const valid = (draft.schemaVersion === 1 || draft.schemaVersion === 2) &&
     draft.identityId === identityId &&
     draft.kabandaId === kabandaId &&
     typeof draft.clientDraftId === 'string' &&
     typeof draft.idempotencyKey === 'string' &&
     typeof draft.title === 'string' &&
+    (draft.scope === undefined || draft.scope === 'kabanda' || draft.scope === 'all_authenticated') &&
     (draft.coverImage === null || typeof draft.coverImage === 'string') &&
     Array.isArray(draft.points) &&
     draft.points.length <= 10 &&
@@ -72,10 +79,11 @@ function parseDraft(value: unknown, identityId: string, kabandaId: string): Raid
     typeof draft.updatedAt === 'string'
   if (!valid) return null
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     clientDraftId: draft.clientDraftId!,
     identityId,
     kabandaId,
+    scope: draft.scope === 'all_authenticated' ? 'all_authenticated' : 'kabanda',
     title: draft.title!,
     coverImage: draft.coverImage!,
     points: draft.points!,

--- a/apps/pwa/src/features/raid-plans/editor/draft-store.ts
+++ b/apps/pwa/src/features/raid-plans/editor/draft-store.ts
@@ -27,15 +27,7 @@ export function readRaidTemplateDraft(
   if (!storage) return null
   try {
     const value: unknown = JSON.parse(storage.getItem(draftKey(identityId, kabandaId)) ?? 'null')
-    const draft = parseDraft(value, identityId, kabandaId)
-    if (draft) {
-      try {
-        storage.setItem(draftKey(identityId, kabandaId), JSON.stringify(draft))
-      } catch {
-        storage.removeItem(draftKey(identityId, kabandaId))
-      }
-    }
-    return draft
+    return parseDraft(value, identityId, kabandaId)
   } catch {
     return null
   }

--- a/apps/pwa/src/features/raid-plans/editor/draft-store.ts
+++ b/apps/pwa/src/features/raid-plans/editor/draft-store.ts
@@ -1,0 +1,120 @@
+import type { RaidTemplateDraft } from '../types'
+
+const DRAFT_PREFIX = 'kabanda.raid-template-draft.v1'
+
+type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
+
+export function createRaidTemplateDraft(identityId: string, kabandaId: string, now = new Date().toISOString()): RaidTemplateDraft {
+  return {
+    schemaVersion: 1,
+    clientDraftId: randomId(),
+    identityId,
+    kabandaId,
+    title: '',
+    coverImage: null,
+    points: [],
+    selectedPointId: null,
+    idempotencyKey: randomId(),
+    updatedAt: now,
+  }
+}
+
+export function readRaidTemplateDraft(
+  identityId: string,
+  kabandaId: string,
+  storage = browserStorage(),
+): RaidTemplateDraft | null {
+  if (!storage) return null
+  try {
+    const value: unknown = JSON.parse(storage.getItem(draftKey(identityId, kabandaId)) ?? 'null')
+    const draft = parseDraft(value, identityId, kabandaId)
+    if (draft) {
+      try {
+        storage.setItem(draftKey(identityId, kabandaId), JSON.stringify(draft))
+      } catch {
+        storage.removeItem(draftKey(identityId, kabandaId))
+      }
+    }
+    return draft
+  } catch {
+    return null
+  }
+}
+
+export function saveRaidTemplateDraft(draft: RaidTemplateDraft, storage = browserStorage()): boolean {
+  if (!storage) return false
+  try {
+    storage.setItem(draftKey(draft.identityId, draft.kabandaId), JSON.stringify(draft))
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function clearRaidTemplateDraft(identityId: string, kabandaId: string, storage = browserStorage()): void {
+  try {
+    storage?.removeItem(draftKey(identityId, kabandaId))
+  } catch {
+    // A failed cleanup must not turn a successful canonical save into an error.
+  }
+}
+
+export function draftKey(identityId: string, kabandaId: string): string {
+  return `${DRAFT_PREFIX}:${identityId}:${kabandaId}`
+}
+
+function parseDraft(value: unknown, identityId: string, kabandaId: string): RaidTemplateDraft | null {
+  if (!value || typeof value !== 'object') return null
+  const draft = value as Partial<RaidTemplateDraft>
+  const valid = draft.schemaVersion === 1 &&
+    draft.identityId === identityId &&
+    draft.kabandaId === kabandaId &&
+    typeof draft.clientDraftId === 'string' &&
+    typeof draft.idempotencyKey === 'string' &&
+    typeof draft.title === 'string' &&
+    (draft.coverImage === null || typeof draft.coverImage === 'string') &&
+    Array.isArray(draft.points) &&
+    draft.points.length <= 10 &&
+    draft.points.every(isDraftPoint) &&
+    (draft.selectedPointId === null || typeof draft.selectedPointId === 'string') &&
+    typeof draft.updatedAt === 'string'
+  if (!valid) return null
+  return {
+    schemaVersion: 1,
+    clientDraftId: draft.clientDraftId!,
+    identityId,
+    kabandaId,
+    title: draft.title!,
+    coverImage: draft.coverImage!,
+    points: draft.points!,
+    selectedPointId: draft.selectedPointId!,
+    idempotencyKey: draft.idempotencyKey!,
+    updatedAt: draft.updatedAt!,
+  }
+}
+
+function browserStorage(): StorageLike | null {
+  try {
+    return typeof window === 'undefined' ? null : window.localStorage
+  } catch {
+    return null
+  }
+}
+
+function randomId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+function isDraftPoint(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false
+  const point = value as Record<string, unknown>
+  return typeof point.clientId === 'string' &&
+    typeof point.name === 'string' &&
+    typeof point.address === 'string' &&
+    typeof point.comment === 'string' &&
+    typeof point.latitude === 'number' && Number.isFinite(point.latitude) &&
+    typeof point.longitude === 'number' && Number.isFinite(point.longitude) &&
+    (point.geocodeStatus === 'pending' || point.geocodeStatus === 'ready' || point.geocodeStatus === 'failed') &&
+    (point.geocodeRequestId === null || typeof point.geocodeRequestId === 'string') &&
+    typeof point.labelsConfirmed === 'boolean'
+}

--- a/apps/pwa/src/features/raid-plans/editor/editor-components.test.tsx
+++ b/apps/pwa/src/features/raid-plans/editor/editor-components.test.tsx
@@ -2,7 +2,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 import type { DraftRaidTemplatePoint } from '../types'
 import { RaidTemplatePointList } from './RaidTemplatePointList'
-import { RaidTemplatePointSheet } from './RaidTemplatePointSheet'
+import { RaidTemplatePointSheet, shouldDismissPointSheet } from './RaidTemplatePointSheet'
 
 const points: DraftRaidTemplatePoint[] = [
   {
@@ -36,13 +36,23 @@ describe('raid template point controls', () => {
       onClose={() => undefined}
       onConfirm={() => undefined}
       onDelete={() => undefined}
+      onHeightChange={() => undefined}
       onRetryGeocode={() => undefined}
       onUpdate={() => undefined}
       point={points[1]!}
       pointNumber={2}
     />)
-    expect(markup).toContain('Адреса © OpenStreetMap contributors')
+    expect(markup).toContain('© OpenStreetMap')
     expect(markup).toContain('https://www.openstreetmap.org/copyright')
-    expect(markup).toContain('Подтвердить название и адрес')
+    expect(markup).toContain('Подтвердить')
+    expect(markup).toContain('rows="1"')
+    expect(markup).not.toContain('Закрыть карточку точки')
+    expect(markup).not.toContain('Сервис адресов предложил подписи')
+  })
+
+  it('dismisses only after a deliberate downward swipe', () => {
+    expect(shouldDismissPointSheet(100, 171)).toBe(false)
+    expect(shouldDismissPointSheet(100, 172)).toBe(true)
+    expect(shouldDismissPointSheet(100, 40)).toBe(false)
   })
 })

--- a/apps/pwa/src/features/raid-plans/editor/editor-components.test.tsx
+++ b/apps/pwa/src/features/raid-plans/editor/editor-components.test.tsx
@@ -1,0 +1,48 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import type { DraftRaidTemplatePoint } from '../types'
+import { RaidTemplatePointList } from './RaidTemplatePointList'
+import { RaidTemplatePointSheet } from './RaidTemplatePointSheet'
+
+const points: DraftRaidTemplatePoint[] = [
+  {
+    clientId: 'first', name: 'Старт', address: 'Пушкинская, 1', comment: '', latitude: 56.8, longitude: 53.2,
+    geocodeStatus: 'ready', geocodeRequestId: null, labelsConfirmed: true,
+  },
+  {
+    clientId: 'second', name: 'Финиш', address: 'Береговая, 2', comment: 'Встречаемся у входа', latitude: 56.9, longitude: 53.3,
+    geocodeStatus: 'ready', geocodeRequestId: null, labelsConfirmed: false,
+  },
+]
+
+describe('raid template point controls', () => {
+  it('keeps drag, move buttons, and edit cards available together', () => {
+    const markup = renderToStaticMarkup(<RaidTemplatePointList
+      onDelete={() => undefined}
+      onMove={() => undefined}
+      onReorder={() => undefined}
+      onSelect={() => undefined}
+      points={points}
+      selectedPointId={null}
+    />)
+    expect(markup).toContain('Перетащить точку 1')
+    expect(markup).toContain('Поднять точку 2 выше')
+    expect(markup).toContain('Опустить точку 1 ниже')
+    expect(markup).toContain('Проверьте')
+  })
+
+  it('shows explicit provider attribution beside editable address labels', () => {
+    const markup = renderToStaticMarkup(<RaidTemplatePointSheet
+      onClose={() => undefined}
+      onConfirm={() => undefined}
+      onDelete={() => undefined}
+      onRetryGeocode={() => undefined}
+      onUpdate={() => undefined}
+      point={points[1]!}
+      pointNumber={2}
+    />)
+    expect(markup).toContain('Адреса © OpenStreetMap contributors')
+    expect(markup).toContain('https://www.openstreetmap.org/copyright')
+    expect(markup).toContain('Подтвердить название и адрес')
+  })
+})

--- a/apps/pwa/src/features/raid-plans/editor/editor-components.test.tsx
+++ b/apps/pwa/src/features/raid-plans/editor/editor-components.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { DraftRaidTemplatePoint } from '../types'
 import { RaidTemplatePointList } from './RaidTemplatePointList'
 import { RaidTemplatePointSheet, shouldDismissPointSheet } from './RaidTemplatePointSheet'
+import { RaidTemplateScopeControl } from './RaidTemplateEditorPage'
 
 const points: DraftRaidTemplatePoint[] = [
   {
@@ -54,5 +55,26 @@ describe('raid template point controls', () => {
     expect(shouldDismissPointSheet(100, 171)).toBe(false)
     expect(shouldDismissPointSheet(100, 172)).toBe(true)
     expect(shouldDismissPointSheet(100, 40)).toBe(false)
+  })
+})
+
+describe('raid template access control', () => {
+  it('defaults to the Kabanda and explains the public disclosure before saving', () => {
+    const privateMarkup = renderToStaticMarkup(<RaidTemplateScopeControl
+      kabandaName="Кабанда Preview"
+      onChange={() => undefined}
+      scope="kabanda"
+    />)
+    const publicMarkup = renderToStaticMarkup(<RaidTemplateScopeControl
+      kabandaName="Кабанда Preview"
+      onChange={() => undefined}
+      scope="all_authenticated"
+    />)
+
+    expect(privateMarkup).toContain('Только для своих')
+    expect(privateMarkup).toContain('Для всех')
+    expect(privateMarkup).toContain('Маршрут увидят только участники вашей Кабанды')
+    expect(privateMarkup).toMatch(/type="radio"[^>]*checked=""/)
+    expect(publicMarkup).toContain('Обложку, комментарии и координаты увидят все участники приложения')
   })
 })

--- a/apps/pwa/src/features/raid-plans/editor/prepare-cover.ts
+++ b/apps/pwa/src/features/raid-plans/editor/prepare-cover.ts
@@ -1,0 +1,51 @@
+const ACCEPTED_COVER_TYPES = ['image/jpeg', 'image/png', 'image/webp']
+const MAX_SOURCE_BYTES = 12 * 1024 * 1024
+const MAX_DATA_URL_LENGTH = 420_000
+
+export async function prepareRaidTemplateCover(file: File): Promise<string> {
+  if (!ACCEPTED_COVER_TYPES.includes(file.type)) throw new Error('Выберите JPEG, PNG или WebP.')
+  if (file.size > MAX_SOURCE_BYTES) throw new Error('Файл больше 12 МБ. Выберите изображение поменьше.')
+
+  const sourceUrl = URL.createObjectURL(file)
+  try {
+    const image = await loadImage(sourceUrl)
+    const ratio = 16 / 9
+    const width = Math.min(1280, image.naturalWidth)
+    const height = Math.max(1, Math.round(width / ratio))
+    const sourceRatio = image.naturalWidth / image.naturalHeight
+    const sourceWidth = sourceRatio > ratio ? image.naturalHeight * ratio : image.naturalWidth
+    const sourceHeight = sourceRatio > ratio ? image.naturalHeight : image.naturalWidth / ratio
+    const canvas = document.createElement('canvas')
+    canvas.width = width
+    canvas.height = height
+    const context = canvas.getContext('2d')
+    if (!context) throw new Error('Не удалось подготовить изображение на этом устройстве.')
+    context.drawImage(
+      image,
+      (image.naturalWidth - sourceWidth) / 2,
+      (image.naturalHeight - sourceHeight) / 2,
+      sourceWidth,
+      sourceHeight,
+      0,
+      0,
+      width,
+      height,
+    )
+    for (const quality of [0.8, 0.68, 0.56, 0.44]) {
+      const dataUrl = canvas.toDataURL('image/jpeg', quality)
+      if (dataUrl.length <= MAX_DATA_URL_LENGTH) return dataUrl
+    }
+    throw new Error('Изображение не удалось сжать. Выберите другое.')
+  } finally {
+    URL.revokeObjectURL(sourceUrl)
+  }
+}
+
+function loadImage(source: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image()
+    image.onload = () => resolve(image)
+    image.onerror = () => reject(new Error('Файл не похож на исправное изображение.'))
+    image.src = source
+  })
+}

--- a/apps/pwa/src/features/raid-plans/editor/raid-template-editor.css
+++ b/apps/pwa/src/features/raid-plans/editor/raid-template-editor.css
@@ -173,9 +173,13 @@
 }
 
 .rt-point-sheet textarea {
-  min-height: 86px;
-  resize: vertical;
+  min-height: 44px;
+  max-height: 112px;
+  resize: none;
+  transition: min-height 160ms ease;
 }
+
+.rt-point-sheet textarea:focus { min-height: 78px; }
 
 .rt-cover {
   position: relative;
@@ -268,6 +272,23 @@
   inset: 0;
   width: 100%;
   height: 100%;
+}
+
+.rt-map--point-editing {
+  position: fixed;
+  z-index: 90;
+  inset: 0;
+  width: 100vw;
+  height: 100dvh;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.rt-map--point-editing .rt-map__instruction,
+.rt-map--point-editing .rt-map__controls {
+  opacity: 0;
+  pointer-events: none;
 }
 
 .rt-map__status {
@@ -536,21 +557,27 @@
   display: grid;
   align-items: end;
   padding-top: max(24px, env(safe-area-inset-top));
-  background: rgb(17 18 20 / 48%);
+  background: transparent;
 }
 
 .rt-point-sheet {
+  --rt-point-sheet-drag: 0px;
   display: grid;
   width: min(100%, 640px);
-  max-height: min(88dvh, 760px);
+  max-height: min(54dvh, 440px);
   overflow-y: auto;
-  gap: 11px;
+  gap: 7px;
   justify-self: center;
-  border-radius: 24px 24px 0 0;
-  padding: 10px 16px calc(18px + env(safe-area-inset-bottom));
+  border: 1px solid rgb(24 24 24 / 8%);
+  border-radius: 20px 20px 0 0;
+  padding: 8px 12px calc(12px + env(safe-area-inset-bottom));
   background: #fff;
-  box-shadow: 0 -20px 50px rgb(12 13 14 / 22%);
+  box-shadow: 0 -14px 38px rgb(12 13 14 / 19%);
+  transform: translateY(var(--rt-point-sheet-drag));
+  transition: transform 160ms ease;
 }
+
+.rt-point-sheet--dragging { transition: none; }
 
 .rt-point-sheet__grabber {
   width: 42px;
@@ -560,38 +587,23 @@
   background: #d4d3d5;
 }
 
-.rt-point-sheet header {
-  display: flex;
-  align-items: start;
-  justify-content: space-between;
-  gap: 14px;
+.rt-point-sheet__handle {
+  display: grid;
+  gap: 5px;
+  padding-bottom: 2px;
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
 }
 
-.rt-point-sheet header span {
-  color: var(--rt-red-dark);
-  font-size: 10px;
-  font-weight: 780;
-  letter-spacing: .04em;
-  text-transform: uppercase;
-}
+.rt-point-sheet__handle:active { cursor: grabbing; }
 
-.rt-point-sheet h2 { margin: 1px 0 0; font-size: 21px; letter-spacing: -.035em; }
-
-.rt-point-sheet__close {
-  width: 44px;
-  height: 44px;
-  flex: 0 0 auto;
-  border: 0;
-  border-radius: 50%;
-  color: #555960;
-  background: #f1f1f2;
-  font-size: 23px;
-}
+.rt-point-sheet h2 { margin: 0; font-size: 17px; letter-spacing: -.025em; }
 
 .rt-point-sheet__hint {
   margin: 0;
   border-radius: 11px;
-  padding: 9px 11px;
+  padding: 6px 9px;
   color: #666970;
   background: #f4f3f2;
   font-size: 10px;
@@ -607,12 +619,21 @@
   text-decoration: underline;
 }
 
-.rt-point-sheet form { display: grid; gap: 10px; }
-.rt-point-sheet form > label span { color: var(--rt-muted); font-weight: 500; }
+.rt-point-sheet form { display: grid; gap: 7px; }
+
+.rt-point-sheet form > label,
+.rt-point-sheet__field-head > label { margin-bottom: -4px; color: #3e4147; font-size: 10px; font-weight: 730; }
+
+.rt-point-sheet__field-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: -4px;
+}
 
 .rt-point-sheet__attribution {
-  width: fit-content;
-  margin-top: -5px;
+  flex: 0 0 auto;
   color: #666970;
   font-size: 9px;
   line-height: 1.3;
@@ -620,14 +641,19 @@
 
 .rt-point-sheet__confirm,
 .rt-point-sheet__delete {
-  min-height: 50px;
-  border-radius: 13px;
+  min-height: 48px;
+  border-radius: 12px;
   font-weight: 760;
 }
 
+.rt-point-sheet__actions { display: grid; grid-template-columns: minmax(0, 1fr) 48px; gap: 8px; }
+
 .rt-point-sheet__confirm { border: 0; color: #fff; background: var(--rt-red); }
 .rt-point-sheet__confirm:disabled { opacity: .45; }
-.rt-point-sheet__delete { border: 1px solid #efc1bd; color: #a62e29; background: #fff; }
+.rt-point-sheet__delete { display: grid; place-items: center; border: 1px solid #efc1bd; color: #a62e29; background: #fff; }
+.rt-point-sheet__delete svg { width: 20px; fill: none; stroke: currentColor; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.8; }
+
+body.rt-point-sheet-open { overflow: hidden; }
 
 .rt-editor-state {
   display: grid;
@@ -652,10 +678,12 @@
   .rt-editor__heading { align-items: start; }
   .rt-editor__local-state { max-width: 130px; white-space: normal; text-align: right; }
   .rt-map { height: max(360px, 54dvh); border-radius: 17px; }
-  .rt-point-card { grid-template-columns: 44px minmax(0, 1fr); }
-  .rt-point-card__drag { min-width: 44px; grid-row: 1; }
-  .rt-point-card__main { grid-row: 1; }
-  .rt-point-card__actions { grid-column: 1 / -1; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .rt-map--point-editing { height: 100dvh; border-radius: 0; }
+  .rt-point-card { grid-template-columns: 44px minmax(0, 1fr) 132px; gap: 3px; }
+  .rt-point-card__drag { min-width: 44px; }
+  .rt-point-card__main { grid-template-columns: 28px minmax(0, 1fr); gap: 6px; padding-inline: 2px; }
+  .rt-point-card__number { width: 28px; height: 28px; }
+  .rt-point-card__actions { grid-template-columns: repeat(3, 44px); gap: 0; }
   .rt-point-card__state { display: none; }
 }
 
@@ -664,8 +692,12 @@
   .rt-editor__heading h1 { font-size: 1.75rem; }
   .rt-map { height: 50dvh; min-height: 330px; }
   .rt-route-summary > span { padding-inline: 10px; }
+  .rt-point-card { grid-template-columns: minmax(0, 1fr) 132px; }
+  .rt-point-card__drag { display: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .rt-point-card { transition: none; }
+  .rt-point-card,
+  .rt-point-sheet,
+  .rt-point-sheet textarea { transition: none; }
 }

--- a/apps/pwa/src/features/raid-plans/editor/raid-template-editor.css
+++ b/apps/pwa/src/features/raid-plans/editor/raid-template-editor.css
@@ -564,7 +564,7 @@
   --rt-point-sheet-drag: 0px;
   display: grid;
   width: min(100%, 640px);
-  max-height: min(54dvh, 440px);
+  max-height: min(65dvh, 440px);
   overflow-y: auto;
   gap: 7px;
   justify-self: center;
@@ -620,6 +620,12 @@
 }
 
 .rt-point-sheet form { display: grid; gap: 7px; }
+
+.rt-point-sheet input,
+.rt-point-sheet textarea {
+  min-height: 44px;
+  padding-block: 8px;
+}
 
 .rt-point-sheet form > label,
 .rt-point-sheet__field-head > label { margin-bottom: -4px; color: #3e4147; font-size: 10px; font-weight: 730; }
@@ -691,6 +697,7 @@ body.rt-point-sheet-open { overflow: hidden; }
   .rt-editor-nav__brand strong { display: none; }
   .rt-editor__heading h1 { font-size: 1.75rem; }
   .rt-map { height: 50dvh; min-height: 330px; }
+  .rt-map--point-editing { height: 100dvh; min-height: 100dvh; }
   .rt-route-summary > span { padding-inline: 10px; }
   .rt-point-card { grid-template-columns: minmax(0, 1fr) 132px; }
   .rt-point-card__drag { display: none; }

--- a/apps/pwa/src/features/raid-plans/editor/raid-template-editor.css
+++ b/apps/pwa/src/features/raid-plans/editor/raid-template-editor.css
@@ -1,0 +1,671 @@
+.rt-editor-shell {
+  --rt-red: #ef332d;
+  --rt-red-dark: #c92722;
+  --rt-ink: #17181b;
+  --rt-muted: #696b72;
+  --rt-line: #e4e2e1;
+  display: grid;
+  width: min(100%, 960px);
+  min-height: 100dvh;
+  gap: 18px;
+  margin: 0 auto;
+  padding: max(14px, env(safe-area-inset-top)) clamp(12px, 3vw, 28px) calc(98px + env(safe-area-inset-bottom));
+  color: var(--rt-ink);
+  font-family: "Manrope Variable", Manrope, ui-sans-serif, system-ui, sans-serif;
+}
+
+.rt-editor-shell *,
+.rt-editor-shell *::before,
+.rt-editor-shell *::after { box-sizing: border-box; }
+
+.rt-editor-shell button,
+.rt-editor-shell input,
+.rt-editor-shell textarea { font: inherit; }
+
+.rt-editor-shell button:focus-visible,
+.rt-editor-shell a:focus-visible,
+.rt-editor-shell input:focus-visible,
+.rt-editor-shell textarea:focus-visible {
+  outline: 3px solid #4d83ff;
+  outline-offset: 2px;
+}
+
+.rt-editor-nav {
+  display: flex;
+  min-height: 42px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.rt-editor-nav > a {
+  display: inline-flex;
+  min-height: 42px;
+  align-items: center;
+  gap: 6px;
+  color: #52565d;
+  font-size: 13px;
+  font-weight: 720;
+  text-decoration: none;
+}
+
+.rt-editor-nav__brand img {
+  width: 30px;
+  height: 30px;
+  object-fit: contain;
+}
+
+.rt-editor-nav__brand strong {
+  color: var(--rt-ink);
+  font-size: 12px;
+  letter-spacing: .08em;
+}
+
+.rt-editor__heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.rt-editor__heading > div { min-width: 0; }
+
+.rt-editor__heading p {
+  overflow: hidden;
+  margin: 0 0 3px;
+  color: var(--rt-red-dark);
+  font-size: 11px;
+  font-weight: 780;
+  letter-spacing: .05em;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.rt-editor__heading h1 {
+  margin: 0;
+  font-size: clamp(1.9rem, 7vw, 2.8rem);
+  font-weight: 790;
+  letter-spacing: -.055em;
+  line-height: 1;
+}
+
+.rt-editor__local-state {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 7px 9px;
+  color: #5f6268;
+  background: #f0f0f1;
+  font-size: 9px;
+  font-weight: 700;
+}
+
+.rt-editor__local-state--failed {
+  color: #8b3a31;
+  background: #fff0ee;
+}
+
+.rt-editor__basics,
+.rt-editor__route {
+  display: grid;
+  gap: 12px;
+}
+
+.rt-editor__basics {
+  border: 1px solid var(--rt-line);
+  border-radius: 20px;
+  padding: clamp(14px, 3vw, 20px);
+  background: #fff;
+  box-shadow: 0 9px 26px rgb(38 32 30 / 6%);
+}
+
+.rt-editor__section-head {
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+}
+
+.rt-editor__section-head > span {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border-radius: 10px;
+  color: #fff;
+  background: var(--rt-red);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.rt-editor__section-head h2 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 780;
+  letter-spacing: -.025em;
+}
+
+.rt-editor__section-head p {
+  margin: 2px 0 0;
+  color: var(--rt-muted);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.rt-editor__basics > label:not(.rt-cover),
+.rt-point-sheet form > label {
+  margin-bottom: -7px;
+  color: #3e4147;
+  font-size: 11px;
+  font-weight: 730;
+}
+
+.rt-editor__basics > input,
+.rt-point-sheet input,
+.rt-point-sheet textarea {
+  width: 100%;
+  min-height: 48px;
+  border: 1px solid #cfd0d3;
+  border-radius: 12px;
+  padding: 10px 12px;
+  color: var(--rt-ink);
+  background: #fff;
+}
+
+.rt-point-sheet textarea {
+  min-height: 86px;
+  resize: vertical;
+}
+
+.rt-cover {
+  position: relative;
+  display: grid;
+  min-height: 132px;
+  overflow: hidden;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 11px;
+  align-content: center;
+  align-items: center;
+  border: 1px dashed #c8c6c5;
+  border-radius: 16px;
+  padding: 14px;
+  background: #f8f7f6;
+  cursor: pointer;
+}
+
+.rt-cover input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  opacity: 0;
+}
+
+.rt-cover:focus-within { outline: 3px solid #4d83ff; outline-offset: 2px; }
+
+.rt-cover__icon {
+  display: grid;
+  width: 48px;
+  height: 48px;
+  place-items: center;
+  border-radius: 15px;
+  color: #fff;
+  background: var(--rt-red);
+  font-size: 25px;
+}
+
+.rt-cover__copy {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.rt-cover__copy strong { font-size: 13px; }
+.rt-cover__copy small { color: var(--rt-muted); font-size: 10px; }
+
+.rt-cover--ready {
+  min-height: 0;
+  aspect-ratio: 16 / 7;
+  align-content: end;
+  color: #fff;
+  border-style: solid;
+  background: #282b2d;
+}
+
+.rt-cover--ready::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+  background: linear-gradient(0deg, rgb(8 10 11 / 80%), transparent 68%);
+}
+
+.rt-cover--ready img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.rt-cover--ready .rt-cover__copy small { color: rgb(255 255 255 / 76%); }
+
+.rt-editor__route { gap: 11px; }
+
+.rt-map {
+  position: relative;
+  height: clamp(360px, 55dvh, 620px);
+  overflow: hidden;
+  border: 1px solid #d8d5d3;
+  border-radius: 20px;
+  background: #e8e6e3;
+  box-shadow: 0 10px 28px rgb(41 36 31 / 9%);
+}
+
+.rt-map__stage {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.rt-map__status {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  gap: 6px;
+  padding: 28px;
+  color: #575a60;
+  background: #efeeec;
+  font-size: 12px;
+  text-align: center;
+}
+
+.rt-map__status strong { color: var(--rt-ink); font-size: 15px; }
+
+.rt-map__status button {
+  min-height: 44px;
+  margin-top: 4px;
+  border: 0;
+  border-radius: 12px;
+  padding: 0 16px;
+  color: #fff;
+  background: var(--rt-red);
+  font-weight: 740;
+}
+
+.rt-map__instruction {
+  position: absolute;
+  z-index: 2;
+  top: 10px;
+  left: 50%;
+  max-width: calc(100% - 90px);
+  transform: translateX(-50%);
+  border-radius: 999px;
+  padding: 8px 12px;
+  color: #25272b;
+  background: rgb(255 255 255 / 94%);
+  box-shadow: 0 5px 18px rgb(24 24 24 / 16%);
+  font-size: 10px;
+  font-weight: 720;
+  text-align: center;
+}
+
+.rt-map__controls {
+  position: absolute;
+  z-index: 2;
+  right: 10px;
+  bottom: 12px;
+  display: grid;
+  overflow: hidden;
+  border: 1px solid rgb(25 25 25 / 10%);
+  border-radius: 13px;
+  background: rgb(255 255 255 / 95%);
+  box-shadow: 0 5px 18px rgb(24 24 24 / 16%);
+}
+
+.rt-map__controls button {
+  display: grid;
+  width: 44px;
+  height: 44px;
+  place-items: center;
+  border: 0;
+  border-bottom: 1px solid #e5e3e2;
+  color: #292b2f;
+  background: transparent;
+  font-size: 21px;
+  font-weight: 600;
+}
+
+.rt-map__controls button:last-child { border-bottom: 0; }
+.rt-map__controls button:disabled { opacity: .4; }
+.rt-map__controls svg { width: 19px; fill: none; stroke: currentColor; stroke-width: 1.8; }
+.rt-map__controls .rt-map__add-point { color: #fff; background: var(--rt-red); }
+
+.rt-route-summary {
+  display: grid;
+  grid-template-columns: minmax(0, .7fr) minmax(0, 1.3fr);
+  overflow: hidden;
+  border: 1px solid var(--rt-line);
+  border-radius: 15px;
+  background: #fff;
+}
+
+.rt-route-summary > span {
+  display: grid;
+  min-width: 0;
+  gap: 1px;
+  padding: 11px 13px;
+}
+
+.rt-route-summary > span + span { border-left: 1px solid var(--rt-line); }
+.rt-route-summary strong { overflow: hidden; font-size: 14px; text-overflow: ellipsis; white-space: nowrap; }
+.rt-route-summary small { overflow: hidden; color: var(--rt-muted); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
+
+.rt-editor__points-empty {
+  display: grid;
+  gap: 3px;
+  border: 1px dashed #d6d3d1;
+  border-radius: 15px;
+  padding: 15px;
+  color: var(--rt-muted);
+  background: #faf9f8;
+  font-size: 11px;
+}
+
+.rt-editor__points-empty strong { color: var(--rt-ink); font-size: 13px; }
+
+.rt-point-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.rt-point-card {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: 44px minmax(0, 1fr) auto;
+  gap: 4px;
+  align-items: stretch;
+  border: 1px solid var(--rt-line);
+  border-radius: 15px;
+  padding: 5px;
+  background: #fff;
+  box-shadow: 0 5px 16px rgb(41 34 31 / 5%);
+  transition: border-color 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+}
+
+.rt-point-card--selected { border-color: #ef7e78; box-shadow: 0 0 0 2px rgb(239 51 45 / 10%); }
+.rt-point-card--dragged { z-index: 3; border-color: var(--rt-red); transform: scale(1.015); box-shadow: 0 12px 26px rgb(45 35 32 / 16%); }
+
+.rt-point-card button { cursor: pointer; }
+
+.rt-point-card__drag {
+  min-width: 44px;
+  border: 0;
+  border-radius: 10px;
+  color: #83858b;
+  background: #f5f4f3;
+  font-size: 20px;
+  touch-action: none;
+  user-select: none;
+}
+
+.rt-point-card__main {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+  gap: 9px;
+  align-items: center;
+  border: 0;
+  padding: 4px 5px;
+  color: inherit;
+  background: transparent;
+  text-align: left;
+}
+
+.rt-point-card__number {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  border-radius: 50%;
+  color: #fff;
+  background: var(--rt-red);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.rt-point-card__copy {
+  display: grid;
+  min-width: 0;
+  gap: 1px;
+}
+
+.rt-point-card__copy strong,
+.rt-point-card__copy small,
+.rt-point-card__copy em {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rt-point-card__copy strong { font-size: 12px; }
+.rt-point-card__copy small { color: var(--rt-muted); font-size: 9px; }
+.rt-point-card__copy em { color: #52565d; font-size: 9px; font-style: normal; }
+
+.rt-point-card__state {
+  border-radius: 999px;
+  padding: 4px 6px;
+  color: #7b5428;
+  background: #fff4df;
+  font-size: 8px;
+  font-weight: 760;
+}
+
+.rt-point-card__state--confirmed { color: #245d39; background: #eaf7ee; }
+
+.rt-point-card__actions {
+  display: grid;
+  grid-template-columns: repeat(3, 44px);
+  gap: 3px;
+}
+
+.rt-point-card__actions button {
+  min-width: 44px;
+  min-height: 44px;
+  border: 0;
+  border-radius: 9px;
+  color: #52555b;
+  background: #f3f2f1;
+  font-size: 15px;
+}
+
+.rt-point-card__actions button:disabled { opacity: .35; cursor: default; }
+.rt-point-card__actions .rt-point-card__delete { color: #a62e29; background: #fff0ee; }
+
+.rt-editor__validation,
+.rt-editor__offline,
+.rt-editor__error {
+  margin: 0;
+  border: 1px solid #efaaa6;
+  border-radius: 13px;
+  padding: 11px 13px;
+  color: #8e2c27;
+  background: #fff1f0;
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.rt-editor__validation ul { margin: 5px 0 0; padding-left: 18px; }
+
+.rt-editor__offline {
+  border-color: #ead5a8;
+  color: #6f5520;
+  background: #fff8e7;
+}
+
+.rt-editor__save {
+  position: sticky;
+  z-index: 15;
+  bottom: max(10px, env(safe-area-inset-bottom));
+  width: 100%;
+  min-height: 56px;
+  border: 0;
+  border-radius: 15px;
+  padding: 0 20px;
+  color: #fff;
+  background: linear-gradient(135deg, #fb4a42, #dd2d28);
+  box-shadow: 0 14px 30px rgb(125 30 26 / 25%);
+  font-weight: 780;
+  cursor: pointer;
+}
+
+.rt-editor__save:disabled { cursor: default; filter: saturate(.5); opacity: .7; }
+
+.rt-point-sheet-backdrop {
+  position: fixed;
+  z-index: 100;
+  inset: 0;
+  display: grid;
+  align-items: end;
+  padding-top: max(24px, env(safe-area-inset-top));
+  background: rgb(17 18 20 / 48%);
+}
+
+.rt-point-sheet {
+  display: grid;
+  width: min(100%, 640px);
+  max-height: min(88dvh, 760px);
+  overflow-y: auto;
+  gap: 11px;
+  justify-self: center;
+  border-radius: 24px 24px 0 0;
+  padding: 10px 16px calc(18px + env(safe-area-inset-bottom));
+  background: #fff;
+  box-shadow: 0 -20px 50px rgb(12 13 14 / 22%);
+}
+
+.rt-point-sheet__grabber {
+  width: 42px;
+  height: 4px;
+  justify-self: center;
+  border-radius: 999px;
+  background: #d4d3d5;
+}
+
+.rt-point-sheet header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.rt-point-sheet header span {
+  color: var(--rt-red-dark);
+  font-size: 10px;
+  font-weight: 780;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.rt-point-sheet h2 { margin: 1px 0 0; font-size: 21px; letter-spacing: -.035em; }
+
+.rt-point-sheet__close {
+  width: 44px;
+  height: 44px;
+  flex: 0 0 auto;
+  border: 0;
+  border-radius: 50%;
+  color: #555960;
+  background: #f1f1f2;
+  font-size: 23px;
+}
+
+.rt-point-sheet__hint {
+  margin: 0;
+  border-radius: 11px;
+  padding: 9px 11px;
+  color: #666970;
+  background: #f4f3f2;
+  font-size: 10px;
+  line-height: 1.45;
+}
+
+.rt-point-sheet__hint button {
+  border: 0;
+  padding: 0;
+  color: var(--rt-red-dark);
+  background: transparent;
+  font-weight: 760;
+  text-decoration: underline;
+}
+
+.rt-point-sheet form { display: grid; gap: 10px; }
+.rt-point-sheet form > label span { color: var(--rt-muted); font-weight: 500; }
+
+.rt-point-sheet__attribution {
+  width: fit-content;
+  margin-top: -5px;
+  color: #666970;
+  font-size: 9px;
+  line-height: 1.3;
+}
+
+.rt-point-sheet__confirm,
+.rt-point-sheet__delete {
+  min-height: 50px;
+  border-radius: 13px;
+  font-weight: 760;
+}
+
+.rt-point-sheet__confirm { border: 0; color: #fff; background: var(--rt-red); }
+.rt-point-sheet__confirm:disabled { opacity: .45; }
+.rt-point-sheet__delete { border: 1px solid #efc1bd; color: #a62e29; background: #fff; }
+
+.rt-editor-state {
+  display: grid;
+  min-height: 220px;
+  place-content: center;
+  justify-items: center;
+  gap: 9px;
+  border: 1px solid var(--rt-line);
+  border-radius: 20px;
+  padding: 24px;
+  background: #fff;
+  text-align: center;
+}
+
+.rt-editor-state h1,
+.rt-editor-state p { margin: 0; }
+.rt-editor-state p { max-width: 440px; color: var(--rt-muted); line-height: 1.5; }
+.rt-editor-state a { color: var(--rt-red-dark); font-weight: 750; }
+
+@media (max-width: 680px) {
+  .rt-editor-shell { gap: 15px; padding-inline: 10px; }
+  .rt-editor__heading { align-items: start; }
+  .rt-editor__local-state { max-width: 130px; white-space: normal; text-align: right; }
+  .rt-map { height: max(360px, 54dvh); border-radius: 17px; }
+  .rt-point-card { grid-template-columns: 44px minmax(0, 1fr); }
+  .rt-point-card__drag { min-width: 44px; grid-row: 1; }
+  .rt-point-card__main { grid-row: 1; }
+  .rt-point-card__actions { grid-column: 1 / -1; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .rt-point-card__state { display: none; }
+}
+
+@media (max-width: 360px) {
+  .rt-editor-nav__brand strong { display: none; }
+  .rt-editor__heading h1 { font-size: 1.75rem; }
+  .rt-map { height: 50dvh; min-height: 330px; }
+  .rt-route-summary > span { padding-inline: 10px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rt-point-card { transition: none; }
+}

--- a/apps/pwa/src/features/raid-plans/editor/raid-template-editor.css
+++ b/apps/pwa/src/features/raid-plans/editor/raid-template-editor.css
@@ -207,6 +207,92 @@
 
 .rt-cover:focus-within { outline: 3px solid #4d83ff; outline-offset: 2px; }
 
+.rt-visibility {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  margin: 0;
+  border: 0;
+  padding: 0;
+}
+
+.rt-visibility legend {
+  margin-bottom: 6px;
+  color: #3e4147;
+  font-size: 11px;
+  font-weight: 730;
+}
+
+.rt-visibility__options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+  border-radius: 14px;
+  padding: 4px;
+  background: #f2f1f0;
+}
+
+.rt-visibility__options label {
+  position: relative;
+  min-width: 0;
+  cursor: pointer;
+}
+
+.rt-visibility__options input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  opacity: 0;
+}
+
+.rt-visibility__options span {
+  display: grid;
+  min-height: 52px;
+  align-content: center;
+  border: 1px solid transparent;
+  border-radius: 11px;
+  padding: 7px 9px;
+  color: #62656a;
+  background: transparent;
+  transition: background 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.rt-visibility__options strong {
+  overflow: hidden;
+  font-size: 11px;
+  font-weight: 780;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rt-visibility__options small {
+  overflow: hidden;
+  margin-top: 2px;
+  font-size: 9px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rt-visibility__options input:checked + span {
+  border-color: rgb(225 50 45 / 14%);
+  color: var(--rt-ink);
+  background: #fff;
+  box-shadow: 0 4px 12px rgb(45 38 35 / 8%);
+}
+
+.rt-visibility__options input:focus-visible + span {
+  outline: 3px solid #4d83ff;
+  outline-offset: 2px;
+}
+
+.rt-visibility > p {
+  margin: 0;
+  color: var(--rt-muted);
+  font-size: 10px;
+  line-height: 1.35;
+}
+
 .rt-cover__icon {
   display: grid;
   width: 48px;

--- a/apps/pwa/src/features/raid-plans/editor/reducer.test.ts
+++ b/apps/pwa/src/features/raid-plans/editor/reducer.test.ts
@@ -4,10 +4,11 @@ import { raidTemplateDraftErrors, raidTemplateDraftReducer } from './reducer'
 
 function draft(points: DraftRaidTemplatePoint[] = []): RaidTemplateDraft {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     clientDraftId: 'draft-1',
     identityId: 'identity-1',
     kabandaId: 'kabanda-1',
+    scope: 'kabanda',
     title: 'Маршрут',
     coverImage: 'data:image/jpeg;base64,cover',
     points,
@@ -32,6 +33,13 @@ function point(id: string, name = id): DraftRaidTemplatePoint {
 }
 
 describe('raid template editor reducer', () => {
+  it('changes route access without touching the route content', () => {
+    const initial = draft([point('a'), point('b')])
+    const updated = raidTemplateDraftReducer(initial, { type: 'set-scope', scope: 'all_authenticated' })
+
+    expect(updated).toMatchObject({ scope: 'all_authenticated', title: initial.title, points: initial.points })
+  })
+
   it('reorders points both by drag target and accessible step buttons', () => {
     const initial = draft([point('a'), point('b'), point('c')])
     const dragged = raidTemplateDraftReducer(initial, { type: 'reorder-point', activeId: 'a', overId: 'c' })

--- a/apps/pwa/src/features/raid-plans/editor/reducer.test.ts
+++ b/apps/pwa/src/features/raid-plans/editor/reducer.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import type { DraftRaidTemplatePoint, RaidTemplateDraft } from '../types'
+import { raidTemplateDraftErrors, raidTemplateDraftReducer } from './reducer'
+
+function draft(points: DraftRaidTemplatePoint[] = []): RaidTemplateDraft {
+  return {
+    schemaVersion: 1,
+    clientDraftId: 'draft-1',
+    identityId: 'identity-1',
+    kabandaId: 'kabanda-1',
+    title: 'Маршрут',
+    coverImage: 'data:image/jpeg;base64,cover',
+    points,
+    selectedPointId: null,
+    idempotencyKey: 'operation-1',
+    updatedAt: '2026-09-01T10:00:00.000Z',
+  }
+}
+
+function point(id: string, name = id): DraftRaidTemplatePoint {
+  return {
+    clientId: id,
+    name,
+    address: `Адрес ${id}`,
+    comment: '',
+    latitude: 56.85,
+    longitude: 53.2,
+    geocodeStatus: 'ready',
+    geocodeRequestId: null,
+    labelsConfirmed: true,
+  }
+}
+
+describe('raid template editor reducer', () => {
+  it('reorders points both by drag target and accessible step buttons', () => {
+    const initial = draft([point('a'), point('b'), point('c')])
+    const dragged = raidTemplateDraftReducer(initial, { type: 'reorder-point', activeId: 'a', overId: 'c' })
+    expect(dragged.points.map(({ clientId }) => clientId)).toEqual(['b', 'c', 'a'])
+
+    const moved = raidTemplateDraftReducer(dragged, { type: 'move-point', pointId: 'a', direction: -1 })
+    expect(moved.points.map(({ clientId }) => clientId)).toEqual(['b', 'a', 'c'])
+  })
+
+  it('ignores a stale reverse-geocode response and requires explicit label confirmation', () => {
+    let current = draft([{ ...point('a', 'Точка 1'), labelsConfirmed: false }])
+    current = raidTemplateDraftReducer(current, { type: 'start-geocode', pointId: 'a', requestId: 'new' })
+    current = raidTemplateDraftReducer(current, {
+      type: 'resolve-geocode', pointId: 'a', requestId: 'old', name: 'Старое', address: 'Старый адрес',
+    })
+    expect(current.points[0]?.name).toBe('Точка 1')
+
+    current = raidTemplateDraftReducer(current, {
+      type: 'resolve-geocode', pointId: 'a', requestId: 'new', name: 'Набережная', address: 'ул. Береговая, 1',
+    })
+    expect(current.points[0]).toMatchObject({
+      name: 'Набережная',
+      address: 'Адрес a',
+      labelsConfirmed: false,
+      geocodeStatus: 'ready',
+    })
+  })
+
+  it('keeps manually edited and confirmed labels when reverse geocoding resolves late', () => {
+    let current = draft([{
+      ...point('a', 'Точка 1'),
+      address: '',
+      geocodeStatus: 'pending',
+      labelsConfirmed: false,
+    }])
+    current = raidTemplateDraftReducer(current, { type: 'start-geocode', pointId: 'a', requestId: 'lookup' })
+    current = raidTemplateDraftReducer(current, {
+      type: 'update-point',
+      pointId: 'a',
+      patch: { name: 'Моя остановка', address: 'Мой адрес', labelsConfirmed: false },
+    })
+    current = raidTemplateDraftReducer(current, { type: 'confirm-point-labels', pointId: 'a' })
+    expect(current.points[0]).toMatchObject({
+      labelsConfirmed: true,
+      geocodeStatus: 'ready',
+      geocodeRequestId: null,
+    })
+    current = raidTemplateDraftReducer(current, {
+      type: 'resolve-geocode',
+      pointId: 'a',
+      requestId: 'lookup',
+      name: 'Ответ геокодера',
+      address: 'Адрес геокодера',
+    })
+
+    expect(current.points[0]).toMatchObject({
+      name: 'Моя остановка',
+      address: 'Мой адрес',
+      labelsConfirmed: true,
+      geocodeStatus: 'ready',
+      geocodeRequestId: null,
+    })
+  })
+
+  it('does not mark a confirmed point as failed even if a matching geocode request remains', () => {
+    const initial = draft([{
+      ...point('a'),
+      geocodeStatus: 'pending',
+      geocodeRequestId: 'lookup',
+    }])
+    const current = raidTemplateDraftReducer(initial, {
+      type: 'fail-geocode', pointId: 'a', requestId: 'lookup',
+    })
+
+    expect(current.points[0]).toMatchObject({
+      labelsConfirmed: true,
+      geocodeStatus: 'ready',
+      geocodeRequestId: null,
+    })
+  })
+
+  it('blocks save until two points have user-confirmed labels', () => {
+    expect(raidTemplateDraftErrors(draft([point('a')]))).toContain('Добавьте хотя бы две точки.')
+    expect(raidTemplateDraftErrors(draft([point('a'), { ...point('b'), labelsConfirmed: false }]))).toContain(
+      'Подтвердите название и адрес каждой точки.',
+    )
+    expect(raidTemplateDraftErrors(draft([point('a'), point('b')]))).toEqual([])
+  })
+})

--- a/apps/pwa/src/features/raid-plans/editor/reducer.ts
+++ b/apps/pwa/src/features/raid-plans/editor/reducer.ts
@@ -7,6 +7,7 @@ import {
 
 export type RaidTemplateDraftAction =
   | { type: 'set-title'; title: string }
+  | { type: 'set-scope'; scope: RaidTemplateDraft['scope'] }
   | { type: 'set-cover'; coverImage: string | null }
   | { type: 'add-point'; point: DraftRaidTemplatePoint }
   | { type: 'select-point'; pointId: string | null }
@@ -25,6 +26,8 @@ export function raidTemplateDraftReducer(draft: RaidTemplateDraft, action: RaidT
   switch (action.type) {
     case 'set-title':
       return { ...draft, title: action.title, updatedAt }
+    case 'set-scope':
+      return { ...draft, scope: action.scope, updatedAt }
     case 'set-cover':
       return { ...draft, coverImage: action.coverImage, updatedAt }
     case 'add-point':

--- a/apps/pwa/src/features/raid-plans/editor/reducer.ts
+++ b/apps/pwa/src/features/raid-plans/editor/reducer.ts
@@ -1,0 +1,138 @@
+import {
+  RAID_TEMPLATE_MAX_POINTS,
+  RAID_TEMPLATE_MIN_POINTS,
+  type DraftRaidTemplatePoint,
+  type RaidTemplateDraft,
+} from '../types'
+
+export type RaidTemplateDraftAction =
+  | { type: 'set-title'; title: string }
+  | { type: 'set-cover'; coverImage: string | null }
+  | { type: 'add-point'; point: DraftRaidTemplatePoint }
+  | { type: 'select-point'; pointId: string | null }
+  | { type: 'update-point'; pointId: string; patch: Partial<Pick<DraftRaidTemplatePoint, 'name' | 'address' | 'comment' | 'geocodeStatus' | 'geocodeRequestId' | 'labelsConfirmed'>> }
+  | { type: 'confirm-point-labels'; pointId: string }
+  | { type: 'start-geocode'; pointId: string; requestId: string }
+  | { type: 'resolve-geocode'; pointId: string; requestId: string; name: string; address: string }
+  | { type: 'fail-geocode'; pointId: string; requestId: string }
+  | { type: 'move-point'; pointId: string; direction: -1 | 1 }
+  | { type: 'reorder-point'; activeId: string; overId: string }
+  | { type: 'delete-point'; pointId: string }
+  | { type: 'replace'; draft: RaidTemplateDraft }
+
+export function raidTemplateDraftReducer(draft: RaidTemplateDraft, action: RaidTemplateDraftAction): RaidTemplateDraft {
+  const updatedAt = new Date().toISOString()
+  switch (action.type) {
+    case 'set-title':
+      return { ...draft, title: action.title, updatedAt }
+    case 'set-cover':
+      return { ...draft, coverImage: action.coverImage, updatedAt }
+    case 'add-point':
+      if (draft.points.length >= RAID_TEMPLATE_MAX_POINTS) return draft
+      return {
+        ...draft,
+        points: [...draft.points, action.point],
+        selectedPointId: action.point.clientId,
+        updatedAt,
+      }
+    case 'select-point':
+      return { ...draft, selectedPointId: action.pointId }
+    case 'update-point':
+      return {
+        ...draft,
+        points: draft.points.map((point) => point.clientId === action.pointId ? { ...point, ...action.patch } : point),
+        updatedAt,
+      }
+    case 'confirm-point-labels':
+      return {
+        ...draft,
+        points: draft.points.map((point) => point.clientId === action.pointId
+          ? { ...point, labelsConfirmed: true, geocodeStatus: 'ready', geocodeRequestId: null }
+          : point),
+        updatedAt,
+      }
+    case 'start-geocode':
+      return {
+        ...draft,
+        points: draft.points.map((point) => point.clientId === action.pointId
+          ? { ...point, geocodeStatus: 'pending', geocodeRequestId: action.requestId }
+          : point),
+        updatedAt,
+      }
+    case 'resolve-geocode':
+      return {
+        ...draft,
+        points: draft.points.map((point) => {
+          if (point.clientId !== action.pointId || point.geocodeRequestId !== action.requestId) return point
+          if (point.labelsConfirmed) {
+            return { ...point, geocodeStatus: 'ready', geocodeRequestId: null }
+          }
+          return {
+            ...point,
+            name: isFallbackPointName(point.name) && action.name ? action.name : point.name,
+            address: point.address.trim() || action.address,
+            geocodeStatus: 'ready',
+            geocodeRequestId: null,
+          }
+        }),
+        updatedAt,
+      }
+    case 'fail-geocode':
+      return {
+        ...draft,
+        points: draft.points.map((point) => {
+          if (point.clientId !== action.pointId || point.geocodeRequestId !== action.requestId) return point
+          if (point.labelsConfirmed) return { ...point, geocodeStatus: 'ready', geocodeRequestId: null }
+          return { ...point, geocodeStatus: 'failed', geocodeRequestId: null }
+        }),
+        updatedAt,
+      }
+    case 'move-point': {
+      const from = draft.points.findIndex((point) => point.clientId === action.pointId)
+      if (from < 0) return draft
+      const to = from + action.direction
+      if (to < 0 || to >= draft.points.length) return draft
+      return { ...draft, points: moveItem(draft.points, from, to), updatedAt }
+    }
+    case 'reorder-point': {
+      const from = draft.points.findIndex((point) => point.clientId === action.activeId)
+      const to = draft.points.findIndex((point) => point.clientId === action.overId)
+      if (from < 0 || to < 0 || from === to) return draft
+      return { ...draft, points: moveItem(draft.points, from, to), updatedAt }
+    }
+    case 'delete-point': {
+      const points = draft.points.filter((point) => point.clientId !== action.pointId)
+      return {
+        ...draft,
+        points,
+        selectedPointId: draft.selectedPointId === action.pointId ? null : draft.selectedPointId,
+        updatedAt,
+      }
+    }
+    case 'replace':
+      return action.draft
+  }
+}
+
+export function raidTemplateDraftErrors(draft: RaidTemplateDraft): string[] {
+  const errors: string[] = []
+  if (!draft.title.trim()) errors.push('Добавьте название маршрута.')
+  if (!draft.coverImage) errors.push('Добавьте обложку маршрута.')
+  if (draft.points.length < RAID_TEMPLATE_MIN_POINTS) errors.push('Добавьте хотя бы две точки.')
+  if (draft.points.length > RAID_TEMPLATE_MAX_POINTS) errors.push(`Можно добавить не больше ${RAID_TEMPLATE_MAX_POINTS} точек.`)
+  if (draft.points.some((point) => !point.name.trim() || !point.address.trim())) errors.push('Проверьте название и адрес каждой точки.')
+  if (draft.points.some((point) => !point.labelsConfirmed)) errors.push('Подтвердите название и адрес каждой точки.')
+  return errors
+}
+
+function moveItem<T>(items: readonly T[], from: number, to: number): T[] {
+  const next = [...items]
+  const [item] = next.splice(from, 1)
+  if (item === undefined) return next
+  next.splice(to, 0, item)
+  return next
+}
+
+function isFallbackPointName(value: string): boolean {
+  return /^Точка \d+$/.test(value.trim())
+}

--- a/apps/pwa/src/features/raid-plans/editor/route-estimate.test.ts
+++ b/apps/pwa/src/features/raid-plans/editor/route-estimate.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { formatPlanDistance, geodesicRouteDistance } from './route-estimate'
+
+describe('raid template distance fallback', () => {
+  it('sums ordered straight-line segments for an honest editor fallback', () => {
+    const points = [
+      { latitude: 0, longitude: 0 },
+      { latitude: 0, longitude: 0.001 },
+      { latitude: 0, longitude: 0.002 },
+    ]
+    const distance = geodesicRouteDistance(points)
+    expect(distance).toBeGreaterThan(220)
+    expect(distance).toBeLessThan(224)
+    expect(formatPlanDistance(distance)).toBe('222 м')
+  })
+})

--- a/apps/pwa/src/features/raid-plans/editor/route-estimate.ts
+++ b/apps/pwa/src/features/raid-plans/editor/route-estimate.ts
@@ -1,0 +1,36 @@
+import type { DraftRaidTemplatePoint } from '../types'
+
+const EARTH_RADIUS_METERS = 6_371_000
+
+export function geodesicRouteDistance(points: readonly Pick<DraftRaidTemplatePoint, 'latitude' | 'longitude'>[]): number {
+  let total = 0
+  for (let index = 1; index < points.length; index += 1) {
+    const previous = points[index - 1]
+    const current = points[index]
+    if (!previous || !current) continue
+    total += distanceMeters(previous, current)
+  }
+  return Math.max(0, Math.round(total))
+}
+
+export function formatPlanDistance(distanceMeters: number): string {
+  if (distanceMeters < 1_000) return `${Math.max(0, Math.round(distanceMeters))} м`
+  return `${(distanceMeters / 1_000).toLocaleString('ru-RU', { maximumFractionDigits: 1 })} км`
+}
+
+function distanceMeters(
+  left: { latitude: number; longitude: number },
+  right: { latitude: number; longitude: number },
+): number {
+  const leftLatitude = radians(left.latitude)
+  const rightLatitude = radians(right.latitude)
+  const latitudeDelta = radians(right.latitude - left.latitude)
+  const longitudeDelta = radians(right.longitude - left.longitude)
+  const a = Math.sin(latitudeDelta / 2) ** 2 +
+    Math.cos(leftLatitude) * Math.cos(rightLatitude) * Math.sin(longitudeDelta / 2) ** 2
+  return 2 * EARTH_RADIUS_METERS * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+}
+
+function radians(value: number): number {
+  return value * Math.PI / 180
+}

--- a/apps/pwa/src/features/raid-plans/types.ts
+++ b/apps/pwa/src/features/raid-plans/types.ts
@@ -34,8 +34,7 @@ export interface RaidTemplateCover {
 export interface RaidTemplateSummary {
   id: string
   kabandaId: string
-  scope: 'kabanda'
-  createdByUserId: string
+  scope: 'kabanda' | 'all_authenticated'
   title: string
   version: number
   cover: RaidTemplateCover
@@ -75,10 +74,11 @@ export type DraftRouteEstimate =
   | { status: 'degraded'; distanceMeters: number; failureCode: RaidTemplateFailureCode }
 
 export interface RaidTemplateDraft {
-  schemaVersion: 1
+  schemaVersion: 2
   clientDraftId: string
   identityId: string
   kabandaId: string
+  scope: 'kabanda' | 'all_authenticated'
   title: string
   coverImage: string | null
   points: DraftRaidTemplatePoint[]

--- a/apps/pwa/src/features/raid-plans/types.ts
+++ b/apps/pwa/src/features/raid-plans/types.ts
@@ -1,0 +1,88 @@
+import type {
+  CreateRaidTemplate as ContractCreateRaidTemplate,
+  RaidTemplatePointInput as ContractRaidTemplatePointInput,
+} from '@kabanda/contracts'
+
+export const RAID_TEMPLATE_MIN_POINTS = 2
+export const RAID_TEMPLATE_MAX_POINTS = 10
+
+export type RaidTemplateFailureCode =
+  | 'api_key_rejected'
+  | 'provider_unavailable'
+  | 'no_route'
+  | 'unknown'
+
+export interface RaidTemplateEstimate {
+  method: 'straight_segments'
+  distanceMeters: number
+}
+
+export type RaidTemplatePointInput = ContractRaidTemplatePointInput
+
+export interface RaidTemplatePoint extends RaidTemplatePointInput {
+  id: string
+  position: number
+}
+
+export interface RaidTemplateCover {
+  url: string
+  sha256: string
+  width: number
+  height: number
+}
+
+export interface RaidTemplateSummary {
+  id: string
+  kabandaId: string
+  scope: 'kabanda'
+  createdByUserId: string
+  title: string
+  version: number
+  cover: RaidTemplateCover
+  pointCount: number
+  estimate: RaidTemplateEstimate
+  createdAt: string
+  updatedAt: string
+}
+
+export interface RaidTemplate extends RaidTemplateSummary {
+  points: RaidTemplatePoint[]
+}
+
+export type CreateRaidTemplateInput = ContractCreateRaidTemplate
+
+export interface CreateRaidTemplateResponse {
+  receipt: {
+    operationId: string
+    command: 'create-raid-template'
+    resultingVersion: 1
+    serverAt: string
+  }
+  template: RaidTemplate
+}
+
+export interface DraftRaidTemplatePoint extends RaidTemplatePointInput {
+  clientId: string
+  geocodeStatus: 'pending' | 'ready' | 'failed'
+  geocodeRequestId: string | null
+  labelsConfirmed: boolean
+}
+
+export type DraftRouteEstimate =
+  | { status: 'idle' }
+  | { status: 'calculating'; fallbackDistanceMeters: number | null }
+  | { status: 'ready'; distanceMeters: number }
+  | { status: 'degraded'; distanceMeters: number; failureCode: RaidTemplateFailureCode }
+
+export interface RaidTemplateDraft {
+  schemaVersion: 1
+  clientDraftId: string
+  identityId: string
+  kabandaId: string
+  title: string
+  coverImage: string | null
+  points: DraftRaidTemplatePoint[]
+  selectedPointId: string | null
+  idempotencyKey: string
+  updatedAt: string
+}

--- a/apps/pwa/src/features/raid-plans/yandex-adapter.test.ts
+++ b/apps/pwa/src/features/raid-plans/yandex-adapter.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest'
+import type {
+  YandexEvent,
+  YandexEventHandler,
+  YandexMap,
+  YandexMapsRuntime,
+} from '../kabandas/yandex-maps'
+import {
+  attachBicycleRoute,
+  attachNumberedWaypointPlacemark,
+  normalizeYandexRouteFailure,
+  straightLineDistanceMeters,
+  type BicycleRouteState,
+} from './yandex-adapter'
+
+describe('straightLineDistanceMeters', () => {
+  it('returns zero until a route has at least two points', () => {
+    expect(straightLineDistanceMeters([])).toBe(0)
+    expect(straightLineDistanceMeters([{ latitude: 56.85, longitude: 53.2 }])).toBe(0)
+  })
+
+  it('sums geodesic distances between consecutive points', () => {
+    const oneDegreeAtEquatorMeters = straightLineDistanceMeters([
+      { latitude: 0, longitude: 0 },
+      { latitude: 0, longitude: 1 },
+    ])
+    const twoSegmentsMeters = straightLineDistanceMeters([
+      { latitude: 0, longitude: 0 },
+      { latitude: 0, longitude: 1 },
+      { latitude: 0, longitude: 2 },
+    ])
+
+    expect(oneDegreeAtEquatorMeters).toBeCloseTo(111_194.93, 1)
+    expect(twoSegmentsMeters).toBeCloseTo(oneDegreeAtEquatorMeters * 2, 6)
+  })
+})
+
+describe('normalizeYandexRouteFailure', () => {
+  it('normalizes invalid-key and authorization failures', () => {
+    expect(normalizeYandexRouteFailure(new Error('Invalid api key'))).toBe('api_key_rejected')
+    expect(normalizeYandexRouteFailure({ status: 403 })).toBe('api_key_rejected')
+  })
+
+  it('keeps provider failures distinct from no-route and unknown failures', () => {
+    expect(normalizeYandexRouteFailure({ message: 'Route not found' })).toBe('no_route')
+    expect(normalizeYandexRouteFailure({ status: 503 })).toBe('provider_unavailable')
+    expect(normalizeYandexRouteFailure({ message: 'Counter total limit exceeded' })).toBe('provider_unavailable')
+    expect(normalizeYandexRouteFailure({ message: 'Unexpected response shape' })).toBe('unknown')
+  })
+})
+
+describe('attachNumberedWaypointPlacemark', () => {
+  it('selects the existing point without bubbling a second map click', () => {
+    const eventHandlers = new Map<string, YandexEventHandler>()
+    const placemark = {
+      events: {
+        add: (name: string, handler: YandexEventHandler) => eventHandlers.set(name, handler),
+        remove: (name: string) => eventHandlers.delete(name),
+      },
+    }
+    const runtime = {
+      Placemark: class {
+        constructor() {
+          return placemark
+        }
+      },
+    } as unknown as YandexMapsRuntime
+    const map = {
+      geoObjects: {
+        add: vi.fn(),
+        remove: vi.fn(),
+      },
+    } as unknown as YandexMap
+    const onSelect = vi.fn()
+    const stopPropagation = vi.fn()
+
+    const dispose = attachNumberedWaypointPlacemark(
+      runtime,
+      map,
+      { latitude: 56.85, longitude: 53.2 },
+      1,
+      { onSelect },
+    )
+    const clickEvent: YandexEvent = {
+      get: <Value,>() => undefined as Value,
+      stopPropagation,
+    }
+    eventHandlers.get('click')?.(clickEvent)
+
+    expect(stopPropagation).toHaveBeenCalledOnce()
+    expect(onSelect).toHaveBeenCalledOnce()
+    expect(stopPropagation.mock.invocationCallOrder[0]).toBeLessThan(onSelect.mock.invocationCallOrder[0]!)
+
+    dispose()
+    expect(map.geoObjects.remove).toHaveBeenCalledWith(placemark)
+  })
+})
+
+describe('attachBicycleRoute', () => {
+  it('uses the lat-lon bicycle contract and contains provider failure events', () => {
+    const eventHandlers = new Map<string, YandexEventHandler>()
+    let modelInput: unknown
+    const route = {
+      model: {
+        events: {
+          add: (name: string, handler: YandexEventHandler) => eventHandlers.set(name, handler),
+          remove: (name: string) => eventHandlers.delete(name),
+        },
+      },
+      getActiveRoute: () => null,
+    }
+    const runtime = {
+      multiRouter: {
+        MultiRoute: class {
+          constructor(input: unknown) {
+            modelInput = input
+            return route
+          }
+        },
+      },
+    } as unknown as YandexMapsRuntime
+    const map = {
+      geoObjects: {
+        add: vi.fn(),
+        remove: vi.fn(),
+      },
+    } as unknown as YandexMap
+    const states: BicycleRouteState[] = []
+
+    const dispose = attachBicycleRoute(runtime, map, [
+      { latitude: 56.85, longitude: 53.2 },
+      { latitude: 56.86, longitude: 53.21 },
+    ], (state) => states.push(state))
+
+    expect(modelInput).toEqual({
+      referencePoints: [[56.85, 53.2], [56.86, 53.21]],
+      params: {
+        routingMode: 'bicycle',
+        reverseGeocoding: false,
+        results: 1,
+      },
+    })
+    expect(states[0]).toMatchObject({ status: 'calculating' })
+
+    const failureEvent: YandexEvent = {
+      get: <Value,>() => new Error('Invalid api key') as unknown as Value,
+    }
+    expect(() => eventHandlers.get('requestfail')?.(failureEvent)).not.toThrow()
+    expect(states.at(-1)).toMatchObject({
+      status: 'failed',
+      code: 'api_key_rejected',
+    })
+
+    dispose()
+    expect(map.geoObjects.remove).toHaveBeenCalledWith(route)
+  })
+})

--- a/apps/pwa/src/features/raid-plans/yandex-adapter.ts
+++ b/apps/pwa/src/features/raid-plans/yandex-adapter.ts
@@ -1,0 +1,263 @@
+import {
+  loadYandexMaps,
+  type YandexCoordinates,
+  type YandexEvent,
+  type YandexEventHandler,
+  type YandexMap,
+  type YandexMapsRuntime,
+  type YandexMultiRoute,
+  type YandexPlacemark,
+} from '../kabandas/yandex-maps'
+import type { RaidTemplateFailureCode } from './types'
+
+const EARTH_RADIUS_METERS = 6_371_000
+
+export type RaidPlanGeoPoint = Readonly<{
+  latitude: number
+  longitude: number
+}>
+
+export type BicycleRouteState =
+  | {
+      status: 'calculating'
+      fallbackDistanceMeters: number
+    }
+  | {
+      status: 'ready'
+      distanceMeters: number
+      fallbackDistanceMeters: number
+    }
+  | {
+      status: 'failed'
+      code: RaidTemplateFailureCode
+      fallbackDistanceMeters: number
+    }
+
+export type DisposeYandexAttachment = () => undefined
+
+export type NumberedWaypointPlacemarkOptions = {
+  selected?: boolean
+  onSelect?: () => void
+}
+
+export function loadRaidPlanYandex(apiKey: string) {
+  return loadYandexMaps(apiKey)
+}
+
+export function toYandexCoordinates(point: RaidPlanGeoPoint): YandexCoordinates {
+  return [point.latitude, point.longitude]
+}
+
+export function fromYandexCoordinates(coordinates: YandexCoordinates): RaidPlanGeoPoint {
+  return {
+    latitude: coordinates[0],
+    longitude: coordinates[1],
+  }
+}
+
+export function attachRaidPlanMapClick(
+  map: YandexMap,
+  onPoint: (point: RaidPlanGeoPoint) => void,
+): DisposeYandexAttachment {
+  const handleClick: YandexEventHandler = (event) => {
+    const coordinates = event.get<YandexCoordinates | undefined>('coords')
+    if (!coordinates || !coordinates.every(Number.isFinite)) return
+    onPoint(fromYandexCoordinates(coordinates))
+  }
+
+  map.events.add('click', handleClick)
+  return () => {
+    map.events.remove?.('click', handleClick)
+    return undefined
+  }
+}
+
+export function attachNumberedWaypointPlacemark(
+  runtime: YandexMapsRuntime,
+  map: YandexMap,
+  point: RaidPlanGeoPoint,
+  number: number,
+  options: NumberedWaypointPlacemarkOptions = {},
+): DisposeYandexAttachment {
+  const placemark: YandexPlacemark = new runtime.Placemark(toYandexCoordinates(point), {
+    iconContent: String(number),
+  }, {
+    preset: options.selected ? 'islands#redStretchyIcon' : 'islands#blueStretchyIcon',
+    hasBalloon: false,
+    openBalloonOnClick: false,
+  })
+
+  const handleSelect: YandexEventHandler | null = options.onSelect
+    ? (event) => {
+        event.stopPropagation?.()
+        options.onSelect?.()
+      }
+    : null
+  if (handleSelect) placemark.events.add('click', handleSelect)
+
+  map.geoObjects.add(placemark)
+  return () => {
+    if (handleSelect) placemark.events.remove?.('click', handleSelect)
+    map.geoObjects.remove(placemark)
+    return undefined
+  }
+}
+
+const toRadians = (degrees: number) => degrees * Math.PI / 180
+
+function pointDistanceMeters(from: RaidPlanGeoPoint, to: RaidPlanGeoPoint) {
+  const latitudeDelta = toRadians(to.latitude - from.latitude)
+  const longitudeDelta = toRadians(to.longitude - from.longitude)
+  const fromLatitude = toRadians(from.latitude)
+  const toLatitude = toRadians(to.latitude)
+  const haversine = Math.sin(latitudeDelta / 2) ** 2 +
+    Math.cos(fromLatitude) * Math.cos(toLatitude) * Math.sin(longitudeDelta / 2) ** 2
+  const safeHaversine = Math.min(1, Math.max(0, haversine))
+
+  return EARTH_RADIUS_METERS * 2 * Math.atan2(
+    Math.sqrt(safeHaversine),
+    Math.sqrt(1 - safeHaversine),
+  )
+}
+
+export function straightLineDistanceMeters(points: readonly RaidPlanGeoPoint[]) {
+  let distanceMeters = 0
+  for (let index = 1; index < points.length; index += 1) {
+    distanceMeters += pointDistanceMeters(points[index - 1]!, points[index]!)
+  }
+  return distanceMeters
+}
+
+function errorDetails(error: unknown) {
+  if (typeof error === 'string') return { message: error, status: null }
+  if (!error || typeof error !== 'object') return { message: '', status: null }
+
+  const record = error as Record<string, unknown>
+  const messageParts = [
+    error instanceof Error ? error.message : null,
+    record.message,
+    record.description,
+    record.code,
+    record.statusText,
+  ]
+    .filter((value): value is string => typeof value === 'string')
+  const statusCandidate = record.status ?? record.statusCode
+  const status = typeof statusCandidate === 'number'
+    ? statusCandidate
+    : typeof statusCandidate === 'string' && /^\d{3}$/.test(statusCandidate)
+      ? Number(statusCandidate)
+      : null
+
+  return { message: messageParts.join(' '), status }
+}
+
+export function normalizeYandexRouteFailure(error: unknown): RaidTemplateFailureCode {
+  const { message, status } = errorDetails(error)
+  const normalized = message.toLocaleLowerCase('en-US')
+
+  if (
+    status === 401 ||
+    status === 403 ||
+    /\b40[13]\b|api[\s_-]*key|invalid key|key not found|unauthori[sz]ed|forbidden|referer/.test(normalized)
+  ) return 'api_key_rejected'
+
+  if (/no route|route not found|cannot build|could not build|маршрут не найден/.test(normalized)) {
+    return 'no_route'
+  }
+
+  if (
+    status === 429 ||
+    (status !== null && status >= 500) ||
+    /\b429\b|\b5\d\d\b|quota|limit exceeded|too many requests|network|failed to fetch|timeout|timed out|unavailable/.test(normalized)
+  ) return 'provider_unavailable'
+
+  return 'unknown'
+}
+
+function routeDistanceMeters(route: YandexMultiRoute) {
+  const activeRoute = route.getActiveRoute()
+  if (!activeRoute) return null
+
+  const distance = activeRoute.properties.get<unknown>('distance')
+  if (typeof distance === 'number' && Number.isFinite(distance) && distance >= 0) return distance
+  if (!distance || typeof distance !== 'object') return null
+
+  const value = (distance as Record<string, unknown>).value
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null
+}
+
+export function attachBicycleRoute(
+  runtime: YandexMapsRuntime,
+  map: YandexMap,
+  points: readonly RaidPlanGeoPoint[],
+  onState: (state: BicycleRouteState) => void,
+): DisposeYandexAttachment {
+  if (points.length < 2) return () => undefined
+
+  const fallbackDistanceMeters = straightLineDistanceMeters(points)
+  let disposed = false
+  let route: YandexMultiRoute | null = null
+  let handleSuccess: YandexEventHandler | null = null
+  let handleFailure: YandexEventHandler | null = null
+
+  const emit = (state: BicycleRouteState) => {
+    if (!disposed) onState(state)
+  }
+
+  const dispose: DisposeYandexAttachment = () => {
+    if (disposed) return undefined
+    disposed = true
+    if (!route) return undefined
+    if (handleSuccess) route.model.events.remove?.('requestsuccess', handleSuccess)
+    if (handleFailure) route.model.events.remove?.('requestfail', handleFailure)
+    map.geoObjects.remove(route)
+    return undefined
+  }
+
+  emit({ status: 'calculating', fallbackDistanceMeters })
+
+  try {
+    route = new runtime.multiRouter.MultiRoute({
+      referencePoints: points.map(toYandexCoordinates),
+      params: {
+        routingMode: 'bicycle',
+        reverseGeocoding: false,
+        results: 1,
+      },
+    }, {
+      boundsAutoApply: true,
+    })
+
+    handleSuccess = () => {
+      if (!route) return
+      const distanceMeters = routeDistanceMeters(route)
+      if (distanceMeters === null) {
+        emit({ status: 'failed', code: 'no_route', fallbackDistanceMeters })
+        return
+      }
+      emit({ status: 'ready', distanceMeters, fallbackDistanceMeters })
+    }
+    handleFailure = (event: YandexEvent) => {
+      emit({
+        status: 'failed',
+        code: normalizeYandexRouteFailure(event.get('error')),
+        fallbackDistanceMeters,
+      })
+    }
+
+    route.model.events.add('requestsuccess', handleSuccess)
+    route.model.events.add('requestfail', handleFailure)
+    map.geoObjects.add(route)
+  } catch (error) {
+    if (route && handleSuccess) route.model.events.remove?.('requestsuccess', handleSuccess)
+    if (route && handleFailure) route.model.events.remove?.('requestfail', handleFailure)
+    route = null
+    emit({
+      status: 'failed',
+      code: normalizeYandexRouteFailure(error),
+      fallbackDistanceMeters,
+    })
+  }
+
+  return dispose
+}

--- a/apps/pwa/src/features/raids/ProductionRaidsHub.test.tsx
+++ b/apps/pwa/src/features/raids/ProductionRaidsHub.test.tsx
@@ -1,7 +1,8 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 import type { KabandaSummary } from '../kabandas/types'
-import { InvitationRaidRow, ProductionCreateTemplateAction, ProductionRaidsHub } from './ProductionRaidsHub'
+import type { RaidHistoryItem } from '../results/types'
+import { InvitationRaidRow, ProductionCreateActions, ProductionHistory, ProductionRaidsHub } from './ProductionRaidsHub'
 import type { RaidProjection } from './types'
 
 const kabanda: KabandaSummary = {
@@ -15,25 +16,51 @@ const kabanda: KabandaSummary = {
 }
 
 describe('ProductionRaidsHub shell', () => {
-  it('starts in an explicit loading state without exposing a create mutation', () => {
+  it('starts in an explicit loading state without exposing create mutations', () => {
     const markup = renderToStaticMarkup(<ProductionRaidsHub identityId="owner-id" kabanda={kabanda} />)
 
     expect(markup).toContain('data-testid="production-raids-hub"')
     expect(markup).toContain('aria-busy="true"')
+    expect(markup).not.toContain('data-testid="production-new-raid"')
     expect(markup).not.toContain('data-testid="production-new-template"')
     expect(markup).not.toContain('Северное кольцо')
     expect(markup).not.toContain('Центр на закате')
   })
 
-  it('offers the route-template action to any member only when mutations are enabled', () => {
-    const markup = renderToStaticMarkup(
-      <ProductionCreateTemplateAction enabled kabandaId={kabanda.id} />,
-    )
+  it.each(['owner', 'member'] as const)('offers distinct raid and route actions to an active %s when mutations are enabled', (role) => {
+    const membership = { ...kabanda, role }
+    const markup = renderToStaticMarkup(<ProductionCreateActions enabled kabandaId={membership.id} />)
 
+    expect(markup).toContain('aria-label="Создание рейда и маршрута"')
+    expect(markup).toContain('data-testid="production-new-raid"')
+    expect(markup).toContain('href="/app?createRaid=kabanda-real-id"')
+    expect(markup).toContain('Новый рейд')
     expect(markup).toContain('data-testid="production-new-template"')
     expect(markup).toContain('href="/app?createRaidTemplate=kabanda-real-id"')
     expect(markup).toContain('Новый маршрут')
-    expect(renderToStaticMarkup(<ProductionCreateTemplateAction enabled={false} kabandaId={kabanda.id} />)).toBe('')
+  })
+
+  it('hides both create mutations from a read-only resource state', () => {
+    expect(renderToStaticMarkup(<ProductionCreateActions enabled={false} kabandaId={kabanda.id} />)).toBe('')
+  })
+
+  it('keeps both create actions alongside a nonempty raid history', () => {
+    const completed: RaidHistoryItem = {
+      raidId: 'completed-raid',
+      title: 'Завершённый рейд',
+      completedAt: '2026-08-31T10:00:00+04:00',
+      partial: false,
+      team: { durationSeconds: 600, distanceMeters: 2_000, uniquePoints: 3, photos: 1 },
+      personal: { durationSeconds: 300, distanceMeters: 1_000, uniquePoints: 2, photos: 1 },
+    }
+    const markup = renderToStaticMarkup(<>
+      <ProductionCreateActions enabled kabandaId={kabanda.id} />
+      <ProductionHistory coverImage="/cover.jpg" history={[completed]} />
+    </>)
+
+    expect(markup).toContain('Завершённый рейд')
+    expect(markup).toContain('href="/app?createRaid=kabanda-real-id"')
+    expect(markup).toContain('href="/app?createRaidTemplate=kabanda-real-id"')
   })
 
   it('renders a canonical invitation with accessible accept and decline actions', () => {

--- a/apps/pwa/src/features/raids/ProductionRaidsHub.test.tsx
+++ b/apps/pwa/src/features/raids/ProductionRaidsHub.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 import type { KabandaSummary } from '../kabandas/types'
-import { InvitationRaidRow, ProductionCreateRaidAction, ProductionRaidsHub } from './ProductionRaidsHub'
+import { InvitationRaidRow, ProductionCreateTemplateAction, ProductionRaidsHub } from './ProductionRaidsHub'
 import type { RaidProjection } from './types'
 
 const kabanda: KabandaSummary = {
@@ -20,19 +20,20 @@ describe('ProductionRaidsHub shell', () => {
 
     expect(markup).toContain('data-testid="production-raids-hub"')
     expect(markup).toContain('aria-busy="true"')
-    expect(markup).not.toContain('data-testid="production-new-raid"')
+    expect(markup).not.toContain('data-testid="production-new-template"')
     expect(markup).not.toContain('Северное кольцо')
     expect(markup).not.toContain('Центр на закате')
   })
 
-  it('offers the canonical create action to any member only when mutations are enabled', () => {
+  it('offers the route-template action to any member only when mutations are enabled', () => {
     const markup = renderToStaticMarkup(
-      <ProductionCreateRaidAction enabled kabandaId={kabanda.id} />,
+      <ProductionCreateTemplateAction enabled kabandaId={kabanda.id} />,
     )
 
-    expect(markup).toContain('data-testid="production-new-raid"')
-    expect(markup).toContain('href="/app?createRaid=kabanda-real-id"')
-    expect(renderToStaticMarkup(<ProductionCreateRaidAction enabled={false} kabandaId={kabanda.id} />)).toBe('')
+    expect(markup).toContain('data-testid="production-new-template"')
+    expect(markup).toContain('href="/app?createRaidTemplate=kabanda-real-id"')
+    expect(markup).toContain('Новый маршрут')
+    expect(renderToStaticMarkup(<ProductionCreateTemplateAction enabled={false} kabandaId={kabanda.id} />)).toBe('')
   })
 
   it('renders a canonical invitation with accessible accept and decline actions', () => {

--- a/apps/pwa/src/features/raids/ProductionRaidsHub.tsx
+++ b/apps/pwa/src/features/raids/ProductionRaidsHub.tsx
@@ -22,6 +22,7 @@ import {
 } from './production-model'
 import { isStaleConflict, selectPrimaryAction } from './state'
 import type { RaidProjection } from './types'
+import { RaidTemplateCatalog } from '../raid-plans/RaidTemplateCatalog'
 import '../raids-design/raids-design.css'
 import './production-raids.css'
 
@@ -249,7 +250,7 @@ export function ProductionRaidsHub({
     <section className="prd-raids" data-testid="production-raids-hub" aria-busy={resourceState === 'loading'} aria-label="Рейды Кабанды">
       <header className="rdp-heading prd-raids__heading">
         <h1>Рейды</h1>
-        <ProductionCreateRaidAction enabled={canMutate} kabandaId={kabanda.id} />
+        <ProductionCreateTemplateAction enabled={canMutate} kabandaId={kabanda.id} />
       </header>
 
       {resourceState === 'stale' && staleAt && (
@@ -312,30 +313,21 @@ export function ProductionRaidsHub({
 
           <ProductionHistory coverImage={coverImage} createRaidHref={canMutate ? createRaidHref : null} history={history} />
 
-          <section className="rdp-section prd-routes-empty" aria-labelledby="production-routes-heading" data-testid="production-route-catalog-empty">
-            <h2 id="production-routes-heading">Доступные маршруты</h2>
-            <RaidEmptyState
-              detail="Здесь появятся готовые маршруты Кабанды. Пока новый рейд создаётся без шаблона."
-              eyebrow="Скоро"
-              icon="route"
-              image={appPath('brand/kabanda-login-riders.jpg')}
-              title="Каталог маршрутов готовится"
-            />
-          </section>
+          <RaidTemplateCatalog kabandaId={kabanda.id} />
         </>
       )}
     </section>
   )
 }
 
-export function ProductionCreateRaidAction({ enabled, kabandaId }: { enabled: boolean; kabandaId: string }) {
+export function ProductionCreateTemplateAction({ enabled, kabandaId }: { enabled: boolean; kabandaId: string }) {
   if (!enabled) return null
   return <a
     className="rdp-new prd-raids__new"
-    data-testid="production-new-raid"
-    href={`${appPath('app')}?createRaid=${encodeURIComponent(kabandaId)}`}
+    data-testid="production-new-template"
+    href={`${appPath('app')}?createRaidTemplate=${encodeURIComponent(kabandaId)}`}
   >
-    <span aria-hidden="true">＋</span> Новый рейд
+    <span aria-hidden="true">＋</span> Новый маршрут
   </a>
 }
 

--- a/apps/pwa/src/features/raids/ProductionRaidsHub.tsx
+++ b/apps/pwa/src/features/raids/ProductionRaidsHub.tsx
@@ -242,7 +242,6 @@ export function ProductionRaidsHub({
   )
   const staleAt = newestDate(actionableStaleAt, historyStaleAt)
   const coverImage = kabanda.coverImage ?? appPath('brand/kabanda-team-cover.jpg')
-  const createRaidHref = `${appPath('app')}?createRaid=${encodeURIComponent(kabanda.id)}`
   const resourcePolicy = productionResourcePolicy(resourceState, online)
   const canMutate = resourcePolicy.canMutate
 
@@ -250,7 +249,7 @@ export function ProductionRaidsHub({
     <section className="prd-raids" data-testid="production-raids-hub" aria-busy={resourceState === 'loading'} aria-label="Рейды Кабанды">
       <header className="rdp-heading prd-raids__heading">
         <h1>Рейды</h1>
-        <ProductionCreateTemplateAction enabled={canMutate} kabandaId={kabanda.id} />
+        <ProductionCreateActions enabled={canMutate} kabandaId={kabanda.id} />
       </header>
 
       {resourceState === 'stale' && staleAt && (
@@ -311,7 +310,7 @@ export function ProductionRaidsHub({
             </section>
           )}
 
-          <ProductionHistory coverImage={coverImage} createRaidHref={canMutate ? createRaidHref : null} history={history} />
+          <ProductionHistory coverImage={coverImage} history={history} />
 
           <RaidTemplateCatalog kabandaId={kabanda.id} />
         </>
@@ -320,15 +319,24 @@ export function ProductionRaidsHub({
   )
 }
 
-export function ProductionCreateTemplateAction({ enabled, kabandaId }: { enabled: boolean; kabandaId: string }) {
+export function ProductionCreateActions({ enabled, kabandaId }: { enabled: boolean; kabandaId: string }) {
   if (!enabled) return null
-  return <a
-    className="rdp-new prd-raids__new"
-    data-testid="production-new-template"
-    href={`${appPath('app')}?createRaidTemplate=${encodeURIComponent(kabandaId)}`}
-  >
-    <span aria-hidden="true">＋</span> Новый маршрут
-  </a>
+  return <nav aria-label="Создание рейда и маршрута" className="prd-raids__create-actions">
+    <a
+      className="rdp-new prd-raids__new"
+      data-testid="production-new-raid"
+      href={`${appPath('app')}?createRaid=${encodeURIComponent(kabandaId)}`}
+    >
+      <span aria-hidden="true">＋</span> Новый рейд
+    </a>
+    <a
+      className="rdp-new prd-raids__new prd-raids__new--template"
+      data-testid="production-new-template"
+      href={`${appPath('app')}?createRaidTemplate=${encodeURIComponent(kabandaId)}`}
+    >
+      <Icon name="route" size={18} /> Новый маршрут
+    </a>
+  </nav>
 }
 
 function ProductionResourceError({
@@ -462,7 +470,7 @@ function UpcomingRaidRow({ identityId, raid }: { identityId: string; raid: RaidP
   </a>
 }
 
-function ProductionHistory({ coverImage, createRaidHref, history }: { coverImage: string; createRaidHref: string | null; history: RaidHistoryItem[] }) {
+export function ProductionHistory({ coverImage, history }: { coverImage: string; history: RaidHistoryItem[] }) {
   const [filter, setFilter] = useState<ProductionHistoryFilter>('all')
   const visibleHistory = filterProductionHistory(history, filter)
 
@@ -470,8 +478,6 @@ function ProductionHistory({ coverImage, createRaidHref, history }: { coverImage
     <h2 id="production-history-heading">История</h2>
     {history.length === 0 ? (
       <RaidEmptyState
-        actionHref={createRaidHref ?? undefined}
-        actionLabel="Создать первый рейд"
         detail="После завершения здесь появятся только реальные километры, точки и фотографии команды."
         eyebrow="Всё впереди"
         icon="flag"

--- a/apps/pwa/src/features/raids/RaidApp.tsx
+++ b/apps/pwa/src/features/raids/RaidApp.tsx
@@ -59,6 +59,7 @@ import { ActiveRaidPanel } from './recording/ActiveRaidPanel'
 import { FinalizationPanel } from '../results/FinalizationPanel'
 import { ResultPanel } from '../results/ResultPanel'
 import { leaveRaid } from '../results/api'
+import { RaidTemplateEditorRoute } from '../raid-plans/editor/RaidTemplateEditorPage'
 import './raids.css'
 
 type RaidIdentity = { id: string }
@@ -136,6 +137,7 @@ export function RaidApp({ route }: { route: Exclude<RaidRoute, { kind: 'home' }>
   if (session.status === 'unavailable') return <RaidShell><EmptyState title="Не удалось проверить вход" detail="Соединение недоступно, а сохранённой identity на этом устройстве нет. Попробуйте ещё раз онлайн." /></RaidShell>
   if (route.kind === 'invalid') return <RaidShell><EmptyState title="Ссылка на рейд некорректна" detail="Откройте рейд с главной страницы КАБАНДЫ." /></RaidShell>
   if (session.source === 'cached' && route.kind !== 'raid') return <RaidShell><EmptyState title="Доступна только сохранённая копия" detail="Создание рейда требует подтверждённой онлайн-сессии." /></RaidShell>
+  if (route.kind === 'create-template') return <RaidTemplateEditorRoute identityId={session.identity.id} kabandaId={route.kabandaId} />
   if (route.kind === 'create') return <CreateRaidPage identityId={session.identity.id} kabandaId={route.kabandaId} />
   return <RaidDetailPage
     key={raidDetailRemountKey(session.identity.id, route.raidId)}

--- a/apps/pwa/src/features/raids/production-raids.css
+++ b/apps/pwa/src/features/raids/production-raids.css
@@ -34,9 +34,27 @@
   font-size: clamp(2rem, 5vw, 2.65rem);
 }
 
+.prd-raids__create-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: end;
+  gap: 8px;
+}
+
 .prd-raids__new {
-  min-height: 46px;
+  min-height: 44px;
+  padding-inline: 13px;
+  font-size: .88rem;
   text-decoration: none;
+}
+
+.prd-raids__new svg { flex: 0 0 auto; }
+
+.prd-raids__new--template {
+  border: 1px solid #dedcdf;
+  color: #34363b;
+  background: #fff;
+  box-shadow: 0 5px 14px rgb(32 30 29 / 8%);
 }
 
 .prd-raids > .rdp-section,
@@ -567,9 +585,10 @@
 @media (max-width: 620px) {
   .prd-raids { gap: 16px; }
 
-  .prd-raids__heading { min-height: 46px; }
+  .prd-raids__heading { min-height: 46px; flex-wrap: wrap; gap: 10px; }
   .prd-raids__heading h1 { font-size: 2rem; }
-  .prd-raids__new { min-height: 44px; padding-inline: 12px; font-size: .88rem; }
+  .prd-raids__create-actions { display: grid; width: 100%; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .prd-raids__new { min-width: 0; min-height: 44px; justify-content: center; padding-inline: 8px; font-size: .82rem; }
   .prd-raids__new span { font-size: 21px; }
 
   .prd-current-raid { padding: 11px; }
@@ -592,7 +611,7 @@
 
 @media (max-width: 350px) {
   .prd-raids__heading { flex-wrap: wrap; }
-  .prd-raids__heading h1 { flex: 1 1 90px; }
+  .prd-raids__heading h1 { flex: 1 1 100%; }
   .prd-current-raid .rdp-active__metrics svg { display: none; }
   .prd-raids .rdp-row__badge { display: none; }
   .prd-invitation__description { margin-left: 0; }

--- a/apps/pwa/src/features/raids/production-raids.css
+++ b/apps/pwa/src/features/raids/production-raids.css
@@ -208,6 +208,118 @@
   font-weight: 760;
 }
 
+.prd-template-catalog {
+  display: grid;
+  gap: 11px;
+}
+
+.prd-template-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.prd-template-card {
+  display: grid;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid #e2dfde;
+  border-radius: 16px;
+  background: #fff;
+  box-shadow: 0 7px 20px rgb(43 32 31 / 7%);
+}
+
+.prd-template-card > img {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  background: #ecebea;
+}
+
+.prd-template-card > div {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+  padding: 10px 11px 11px;
+}
+
+.prd-template-card h3 {
+  overflow: hidden;
+  margin: 0;
+  color: var(--rdp-ink);
+  font-size: 13px;
+  font-weight: 760;
+  letter-spacing: -.015em;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.prd-template-card p {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: 0;
+  color: #4f535a;
+  font-size: 11px;
+  font-weight: 680;
+}
+
+.prd-template-card small {
+  overflow: hidden;
+  color: var(--rdp-muted);
+  font-size: 9px;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.prd-template-empty,
+.prd-template-error {
+  display: flex;
+  min-height: 74px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px dashed #d7d3d1;
+  border-radius: 15px;
+  padding: 13px 14px;
+  color: var(--rdp-muted);
+  background: #faf9f8;
+  font-size: 11px;
+}
+
+.prd-template-empty {
+  display: grid;
+  justify-content: stretch;
+  gap: 3px;
+}
+
+.prd-template-empty strong {
+  color: var(--rdp-ink);
+  font-size: 13px;
+}
+
+.prd-template-error button {
+  min-height: 40px;
+  flex: 0 0 auto;
+  border: 1px solid #dedde0;
+  border-radius: 10px;
+  padding: 0 12px;
+  color: var(--rdp-ink);
+  background: #fff;
+  font: inherit;
+  font-weight: 720;
+}
+
+.prd-template-grid--loading i {
+  aspect-ratio: 16 / 10;
+  border-radius: 16px;
+  background: linear-gradient(100deg, #ecebea 20%, #f7f6f5 38%, #ecebea 58%);
+  background-size: 220% 100%;
+  animation: rdp-shimmer 1.25s linear infinite;
+}
+
 .prd-invitations__offline {
   margin: 0;
   border-radius: 11px;
@@ -489,5 +601,6 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .prd-raids__loading i { animation: none; }
+  .prd-raids__loading i,
+  .prd-template-grid--loading i { animation: none; }
 }

--- a/apps/pwa/src/features/raids/routing.test.ts
+++ b/apps/pwa/src/features/raids/routing.test.ts
@@ -16,9 +16,17 @@ describe('raid deep-link routing', () => {
     })
   })
 
+  it('opens the route constructor without creating an operational raid', () => {
+    expect(parseRaidRoute('?createRaidTemplate=33333333-3333-4333-8333-333333333333')).toEqual({
+      kind: 'create-template',
+      kabandaId: '33333333-3333-4333-8333-333333333333',
+    })
+  })
+
   it('rejects malformed locators before an API lookup', () => {
     expect(parseRaidRoute('?raid=../../private')).toEqual({ kind: 'invalid' })
     expect(parseRaidRoute('?createRaid=not-a-uuid')).toEqual({ kind: 'invalid' })
+    expect(parseRaidRoute('?createRaidTemplate=not-a-uuid')).toEqual({ kind: 'invalid' })
     expect(parseRaidRoute('?kabanda=22222222-2222-4222-8222-222222222222')).toEqual({ kind: 'home' })
   })
 })

--- a/apps/pwa/src/features/raids/routing.ts
+++ b/apps/pwa/src/features/raids/routing.ts
@@ -1,6 +1,7 @@
 export type RaidRoute =
   | { kind: 'home' }
   | { kind: 'create'; kabandaId: string }
+  | { kind: 'create-template'; kabandaId: string }
   | { kind: 'raid'; raidId: string }
   | { kind: 'invalid' }
 
@@ -9,8 +10,10 @@ const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}
 export function parseRaidRoute(search: string): RaidRoute {
   const params = new URLSearchParams(search)
   const raidId = params.get('raid')
+  const templateKabandaId = params.get('createRaidTemplate')
   const kabandaId = params.get('createRaid')
   if (raidId) return uuidPattern.test(raidId) ? { kind: 'raid', raidId } : { kind: 'invalid' }
+  if (templateKabandaId) return uuidPattern.test(templateKabandaId) ? { kind: 'create-template', kabandaId: templateKabandaId } : { kind: 'invalid' }
   if (kabandaId) return uuidPattern.test(kabandaId) ? { kind: 'create', kabandaId } : { kind: 'invalid' }
   return { kind: 'home' }
 }

--- a/infra/postgres/migrations/0011_raid_templates.sql
+++ b/infra/postgres/migrations/0011_raid_templates.sql
@@ -1,0 +1,105 @@
+CREATE TABLE raid_templates (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  kabanda_id uuid NOT NULL REFERENCES kabandas(id) ON DELETE RESTRICT,
+  scope text NOT NULL DEFAULT 'kabanda' CHECK (scope = 'kabanda'),
+  created_by_user_id uuid NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  title text NOT NULL CHECK (char_length(title) BETWEEN 1 AND 120),
+  version integer NOT NULL DEFAULT 1 CHECK (version > 0),
+  point_count smallint NOT NULL CHECK (point_count BETWEEN 2 AND 10),
+  cover_bytes bytea NOT NULL,
+  cover_content_type text NOT NULL CHECK (cover_content_type = 'image/jpeg'),
+  cover_size_bytes integer NOT NULL CHECK (cover_size_bytes BETWEEN 1 AND 3145728),
+  cover_width integer NOT NULL CHECK (cover_width BETWEEN 1 AND 2048),
+  cover_height integer NOT NULL CHECK (cover_height BETWEEN 1 AND 2048),
+  cover_sha256 char(64) NOT NULL CHECK (cover_sha256 ~ '^[a-f0-9]{64}$'),
+  distance_method text NOT NULL CHECK (distance_method = 'straight_segments'),
+  estimated_distance_meters integer NOT NULL CHECK (estimated_distance_meters >= 0),
+  archived_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (cover_size_bytes = octet_length(cover_bytes))
+);
+
+CREATE INDEX raid_templates_kabanda_catalog_idx
+  ON raid_templates (kabanda_id, updated_at DESC, id DESC)
+  WHERE archived_at IS NULL;
+
+CREATE INDEX raid_templates_creator_idx
+  ON raid_templates (created_by_user_id, kabanda_id, updated_at DESC);
+
+CREATE TABLE raid_template_points (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  template_id uuid NOT NULL REFERENCES raid_templates(id) ON DELETE CASCADE,
+  position smallint NOT NULL CHECK (position BETWEEN 0 AND 9),
+  name text NOT NULL CHECK (char_length(name) BETWEEN 1 AND 160),
+  address text NOT NULL CHECK (char_length(address) BETWEEN 1 AND 300),
+  comment text NOT NULL DEFAULT '' CHECK (char_length(comment) <= 500),
+  location geography(Point, 4326) NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (template_id, position),
+  CHECK (
+    ST_Y(location::geometry) BETWEEN -90 AND 90
+    AND ST_X(location::geometry) BETWEEN -180 AND 180
+  )
+);
+
+CREATE INDEX raid_template_points_location_idx ON raid_template_points USING gist (location);
+
+CREATE TABLE raid_template_receipts (
+  actor_user_id uuid NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  operation_id text NOT NULL CHECK (char_length(operation_id) BETWEEN 8 AND 100),
+  template_id uuid NOT NULL REFERENCES raid_templates(id) ON DELETE RESTRICT,
+  command text NOT NULL CHECK (command = 'create-raid-template'),
+  request_fingerprint char(64) NOT NULL CHECK (request_fingerprint ~ '^[a-f0-9]{64}$'),
+  resulting_version integer NOT NULL CHECK (resulting_version > 0),
+  response_json jsonb NOT NULL CHECK (octet_length(response_json::text) <= 65536),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (actor_user_id, operation_id),
+  UNIQUE (template_id, resulting_version)
+);
+
+CREATE FUNCTION enforce_raid_template_point_count() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+  target_template_id uuid;
+  target_template_ids uuid[];
+  expected_count integer;
+  actual_count integer;
+BEGIN
+  IF TG_TABLE_NAME = 'raid_templates' THEN
+    target_template_ids := ARRAY[NEW.id];
+  ELSIF TG_OP = 'DELETE' THEN
+    target_template_ids := ARRAY[OLD.template_id];
+  ELSIF TG_OP = 'UPDATE' AND OLD.template_id IS DISTINCT FROM NEW.template_id THEN
+    target_template_ids := ARRAY[OLD.template_id, NEW.template_id];
+  ELSE
+    target_template_ids := ARRAY[NEW.template_id];
+  END IF;
+
+  FOREACH target_template_id IN ARRAY target_template_ids LOOP
+    SELECT point_count INTO expected_count FROM raid_templates WHERE id = target_template_id;
+    IF NOT FOUND THEN
+      CONTINUE;
+    END IF;
+
+    SELECT count(*) INTO actual_count FROM raid_template_points
+      WHERE template_id = target_template_id;
+    IF actual_count <> expected_count THEN
+      RAISE EXCEPTION 'raid template point count mismatch: expected %, found %',
+        expected_count, actual_count
+        USING ERRCODE = '23514';
+    END IF;
+  END LOOP;
+  RETURN NULL;
+END;
+$$;
+
+CREATE CONSTRAINT TRIGGER raid_templates_point_count_matches
+  AFTER INSERT OR UPDATE OF point_count ON raid_templates
+  DEFERRABLE INITIALLY DEFERRED
+  FOR EACH ROW EXECUTE FUNCTION enforce_raid_template_point_count();
+
+CREATE CONSTRAINT TRIGGER raid_template_points_count_matches
+  AFTER INSERT OR UPDATE OR DELETE ON raid_template_points
+  DEFERRABLE INITIALLY DEFERRED
+  FOR EACH ROW EXECUTE FUNCTION enforce_raid_template_point_count();

--- a/infra/postgres/migrations/0012_raid_template_visibility.sql
+++ b/infra/postgres/migrations/0012_raid_template_visibility.sql
@@ -1,0 +1,10 @@
+ALTER TABLE raid_templates
+  DROP CONSTRAINT raid_templates_scope_check;
+
+ALTER TABLE raid_templates
+  ADD CONSTRAINT raid_templates_scope_check
+  CHECK (scope IN ('kabanda', 'all_authenticated'));
+
+CREATE INDEX raid_templates_public_catalog_idx
+  ON raid_templates (updated_at DESC, id DESC)
+  WHERE scope = 'all_authenticated' AND archived_at IS NULL;

--- a/infra/stand/kabanda.env.example
+++ b/infra/stand/kabanda.env.example
@@ -4,10 +4,11 @@ API_PORT=3098
 API_BUILD_ID=replace-with-exact-git-sha
 APP_ORIGIN=https://replace-after-quick-tunnel.trycloudflare.com
 APP_BASE_PATH=/
+NOMINATIM_BASE_URL=https://nominatim.openstreetmap.org
 VITE_YANDEX_MAPS_API_KEY=replace-with-referer-restricted-browser-key
 PWA_DIST_DIR=/opt/kabanda/current/apps/pwa/dist
 TRUST_PROXY_ADDRESS=127.0.0.1
-EXPECTED_MIGRATION=0010_kabanda_cover.sql
+EXPECTED_MIGRATION=0011_raid_templates.sql
 ALPHA_ACCESS_MODE=enforced
 ALPHA_ACCESS_SECRET=replace-with-a-distinct-random-secret-at-least-32-characters
 # Required only when importing a manifest with field_verified points.

--- a/infra/stand/kabanda.env.example
+++ b/infra/stand/kabanda.env.example
@@ -8,7 +8,7 @@ NOMINATIM_BASE_URL=https://nominatim.openstreetmap.org
 VITE_YANDEX_MAPS_API_KEY=replace-with-referer-restricted-browser-key
 PWA_DIST_DIR=/opt/kabanda/current/apps/pwa/dist
 TRUST_PROXY_ADDRESS=127.0.0.1
-EXPECTED_MIGRATION=0011_raid_templates.sql
+EXPECTED_MIGRATION=0012_raid_template_visibility.sql
 ALPHA_ACCESS_MODE=enforced
 ALPHA_ACCESS_SECRET=replace-with-a-distinct-random-secret-at-least-32-characters
 # Required only when importing a manifest with field_verified points.

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -172,6 +172,7 @@ export const raidTemplatePointInputSchema = z.object({
 }).strict()
 
 export const createRaidTemplateSchema = z.object({
+  scope: z.enum(['kabanda', 'all_authenticated']).default('kabanda'),
   title: z.string().trim().min(1).max(120),
   coverImage: z
     .string()

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -163,6 +163,34 @@ export const recordPointVisitSchema = z.object({
   idempotencyKey: idempotencyKeySchema,
 })
 
+export const raidTemplatePointInputSchema = z.object({
+  name: z.string().trim().min(1).max(160),
+  address: z.string().trim().min(1).max(300),
+  comment: z.string().trim().max(500).default(''),
+  latitude: z.number().min(-90).max(90),
+  longitude: z.number().min(-180).max(180),
+}).strict()
+
+export const createRaidTemplateSchema = z.object({
+  title: z.string().trim().min(1).max(120),
+  coverImage: z
+    .string()
+    .max(420_000)
+    .regex(/^data:image\/jpeg;base64,[A-Za-z0-9+/]+={0,2}$/),
+  points: z.array(raidTemplatePointInputSchema).min(2).max(10),
+}).strict()
+
+export const reverseGeocodeQuerySchema = z.object({
+  latitude: z.coerce.number().min(56.7).max(57),
+  longitude: z.coerce.number().min(53).max(53.4),
+}).strict()
+
+export const reverseGeocodeResultSchema = z.object({
+  name: z.string().max(160),
+  address: z.string().max(300),
+  source: z.literal('openstreetmap'),
+}).strict()
+
 export const apiErrorSchema = z.object({
   error: z.object({
     code: z.string(),
@@ -177,3 +205,7 @@ export type RequestMagicLink = z.infer<typeof requestMagicLinkSchema>
 export type UpdateProfile = z.infer<typeof updateProfileSchema>
 export type CreateKabanda = z.infer<typeof createKabandaSchema>
 export type UpdateKabanda = z.infer<typeof updateKabandaSchema>
+export type RaidTemplatePointInput = z.infer<typeof raidTemplatePointInputSchema>
+export type CreateRaidTemplate = z.infer<typeof createRaidTemplateSchema>
+export type ReverseGeocodeQuery = z.infer<typeof reverseGeocodeQuerySchema>
+export type ReverseGeocodeResult = z.infer<typeof reverseGeocodeResultSchema>


### PR DESCRIPTION
Закрывает #60.

## Что сделано
- любой активный участник Кабанды может открыть конструктор маршрута;
- обязательные название и обложка;
- точки на Яндекс.Карте, адресные подсказки OpenStreetMap и ручное подтверждение;
- комментарии, изменение порядка касанием и доступными кнопками;
- временная велооценка Яндекса с честным fallback, в БД сохраняется только серверный расчёт по прямым отрезкам;
- маршрут-шаблон отделён от запуска operational raid;
- каталог маршрутов на экране «Рейды».

## Проверки
- `corepack pnpm check`;
- миграция `0011_raid_templates.sql` на изолированной PostGIS;
- `raid-templates.postgres.test.ts`: 4/4;
- независимое code/security review: APPROVE.