### PR TITLE
feat: raid presence and active map check-ins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ NOMINATIM_BASE_URL=https://nominatim.openstreetmap.org
 # Production same-origin stand only; leave unset for split local Vite dev.
 # PWA_DIST_DIR=/absolute/path/to/apps/pwa/dist
 # TRUST_PROXY_ADDRESS=127.0.0.1
-EXPECTED_MIGRATION=0012_raid_template_visibility.sql
+EXPECTED_MIGRATION=0013_raid_presence.sql
 ALPHA_ACCESS_MODE=disabled
 # Required with ALPHA_ACCESS_MODE=enforced; generate a distinct random value of at least 32 characters.
 # ALPHA_ACCESS_SECRET=

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -17,7 +17,7 @@ const environmentSchema = z.object({
   NOMINATIM_BASE_URL: z.url().default('https://nominatim.openstreetmap.org'),
   PWA_DIST_DIR: z.string().min(1).optional(),
   TRUST_PROXY_ADDRESS: z.string().min(1).optional(),
-  EXPECTED_MIGRATION: z.string().regex(/^\d{4}_[a-z0-9_]+\.sql$/).default('0012_raid_template_visibility.sql'),
+  EXPECTED_MIGRATION: z.string().regex(/^\d{4}_[a-z0-9_]+\.sql$/).default('0013_raid_presence.sql'),
   DATABASE_URL: z
     .string()
     .min(1)

--- a/apps/api/src/raid-routes.ts
+++ b/apps/api/src/raid-routes.ts
@@ -208,6 +208,15 @@ export async function registerRaidRoutes(
     return { raid: await dependencies.raids.getRaid(user.id, raidId) }
   })
 
+  app.get('/api/raids/:raidId/route/track', async (request, reply) => {
+    const user = await currentUser(request, dependencies)
+    if (!user) return authRequired(reply)
+    const raidId = resourceIdSchema.parse((request.params as { raidId: string }).raidId)
+    return reply
+      .header('Cache-Control', 'private, no-store')
+      .send({ track: await dependencies.raids.getRouteTrack(user.id, raidId) })
+  })
+
   app.get('/api/raids/:raidId/result', async (request, reply) => {
     const user = await currentUser(request, dependencies)
     if (!user) return authRequired(reply)

--- a/apps/api/src/raid-routes.ts
+++ b/apps/api/src/raid-routes.ts
@@ -76,6 +76,13 @@ const nearbySchema = z.object({
   longitude: z.coerce.number().min(53).max(53.4),
   limit: z.coerce.number().int().min(1).max(5).default(5),
 })
+const presenceSchema = z.object({
+  latitude: z.coerce.number().min(56.7).max(57),
+  longitude: z.coerce.number().min(53).max(53.4),
+  capturedAt: z.iso.datetime({ offset: true }),
+  accuracyMeters: z.coerce.number().min(0).max(50),
+})
+const manualPresenceSchema = z.object({ present: z.boolean() })
 const presentParticipantIdsSchema = z.array(z.uuid()).max(20).default([])
 const checkinSchema = z.object({
   pointSnapshotId: z.uuid(),
@@ -215,6 +222,60 @@ export async function registerRaidRoutes(
     return reply
       .header('Cache-Control', 'private, no-store')
       .send({ track: await dependencies.raids.getRouteTrack(user.id, raidId) })
+  })
+
+  app.get('/api/raids/:raidId/map-points', async (request, reply) => {
+    const user = await currentUser(request, dependencies)
+    if (!user) return authRequired(reply)
+    const raidId = resourceIdSchema.parse((request.params as { raidId: string }).raidId)
+    return reply
+      .header('Cache-Control', 'private, no-store')
+      .send(await dependencies.raids.getMapPoints(user.id, raidId))
+  })
+
+  app.get('/api/raids/:raidId/presence', async (request, reply) => {
+    const user = await currentUser(request, dependencies)
+    if (!user) return authRequired(reply)
+    const raidId = resourceIdSchema.parse((request.params as { raidId: string }).raidId)
+    return reply
+      .header('Cache-Control', 'private, no-store')
+      .send(await dependencies.raids.getPresenceRoster(user.id, raidId))
+  })
+
+  app.get('/api/raids/:raidId/check-ins/presence', async (request, reply) => {
+    const user = await currentUser(request, dependencies)
+    if (!user) return authRequired(reply)
+    const raidId = resourceIdSchema.parse((request.params as { raidId: string }).raidId)
+    const pointSnapshotId = resourceIdSchema.parse(
+      (request.query as { pointSnapshotId?: string }).pointSnapshotId,
+    )
+    return reply
+      .header('Cache-Control', 'private, no-store')
+      .send(await dependencies.raids.getPointPresence(user.id, raidId, pointSnapshotId))
+  })
+
+  app.put('/api/raids/:raidId/presence/me', async (request, reply) => {
+    const user = await currentUser(request, dependencies)
+    if (!user) return authRequired(reply)
+    const raidId = resourceIdSchema.parse((request.params as { raidId: string }).raidId)
+    return reply
+      .header('Cache-Control', 'private, no-store')
+      .send(await dependencies.raids.reportPresence(user.id, raidId, presenceSchema.parse(request.body)))
+  })
+
+  app.put('/api/raids/:raidId/presence/:participantId/manual', async (request, reply) => {
+    const user = await currentUser(request, dependencies)
+    if (!user) return authRequired(reply)
+    const { raidId, participantId } = request.params as { raidId: string; participantId: string }
+    const input = manualPresenceSchema.parse(request.body)
+    return reply
+      .header('Cache-Control', 'private, no-store')
+      .send(await dependencies.raids.setManualPresence(
+        user.id,
+        resourceIdSchema.parse(raidId),
+        resourceIdSchema.parse(participantId),
+        input.present,
+      ))
   })
 
   app.get('/api/raids/:raidId/result', async (request, reply) => {

--- a/apps/api/src/raids.ts
+++ b/apps/api/src/raids.ts
@@ -132,6 +132,49 @@ export type RouteTrackProjection = {
   serverAt: string
 }
 
+export type RaidMapPointProjection = {
+  id: string
+  sourcePointId: string
+  name: string
+  latitude: number
+  longitude: number
+  position: number
+  visitedByMe: boolean
+  visitedByTeam: boolean
+}
+
+export type RaidPresenceEvidence = {
+  latitude: number
+  longitude: number
+  capturedAt: string
+  accuracyMeters: number
+}
+
+export type RaidPresenceRoster = {
+  radiusMeters: 50
+  maxAgeSeconds: 30
+  allReady: boolean
+  participants: Array<{
+    id: string
+    displayName: string
+    avatarUrl: string | null
+    status: 'nearby' | 'manual' | 'waiting'
+    observedAt: string | null
+  }>
+  serverAt: string
+}
+
+export type RaidPointPresenceRoster = {
+  pointSnapshotId: string
+  radiusMeters: 50
+  participants: Array<{
+    id: string
+    status: 'nearby' | 'waiting'
+    observedAt: string | null
+  }>
+  serverAt: string
+}
+
 export type RouteStatusProjection = {
   status: RouteStatusCode
   navigatorUserId: string | null
@@ -489,6 +532,11 @@ export interface RaidService {
     operationId: string,
   ): Promise<RouteBatchResponse>
   getRouteTrack(actorUserId: string, raidId: string): Promise<RouteTrackProjection>
+  getMapPoints(actorUserId: string, raidId: string): Promise<{ points: RaidMapPointProjection[] }>
+  reportPresence(actorUserId: string, raidId: string, evidence: RaidPresenceEvidence): Promise<RaidPresenceRoster>
+  getPresenceRoster(actorUserId: string, raidId: string): Promise<RaidPresenceRoster>
+  setManualPresence(actorUserId: string, raidId: string, participantId: string, present: boolean): Promise<RaidPresenceRoster>
+  getPointPresence(actorUserId: string, raidId: string, pointSnapshotId: string): Promise<RaidPointPresenceRoster>
   getRaid(actorUserId: string, raidId: string): Promise<RaidProjection>
   getCurrent(actorUserId: string): Promise<RaidProjection | null>
   listActionable(actorUserId: string, kabandaId: string): Promise<RaidProjection[]>
@@ -1058,12 +1106,249 @@ export class DatabaseRaidService implements RaidService {
     }
   }
 
+  async getMapPoints(
+    actorUserId: string,
+    raidId: string,
+  ): Promise<{ points: RaidMapPointProjection[] }> {
+    const client = await this.pool.connect()
+    try {
+      const access = await client.query<{
+        state: RaidState
+        role: 'owner' | 'member'
+        participant_state: RaidParticipantState | null
+      }>(
+        `SELECT r.state, m.role, p.state AS participant_state FROM raids r
+         JOIN kabandas k ON k.id = r.kabanda_id AND k.archived_at IS NULL
+         JOIN kabanda_memberships m
+           ON m.kabanda_id = r.kabanda_id AND m.user_id = $2 AND m.removed_at IS NULL
+         LEFT JOIN raid_participants p ON p.raid_id = r.id AND p.user_id = $2
+         WHERE r.id = $1`,
+        [raidId, actorUserId],
+      )
+      const visibility = access.rows[0]
+      const mayReadLive = visibility?.role === 'owner' || visibility?.participant_state === 'active'
+      const mayReadCompleted = visibility?.state === 'completed'
+      if (!visibility || (!mayReadLive && !mayReadCompleted)) throw this.notFound()
+
+      const result = await client.query<{
+        id: string
+        source_point_id: string
+        name: string
+        latitude: number
+        longitude: number
+        position: number
+        visited_by_me: boolean
+        visited_by_team: boolean
+      }>(
+        `SELECT s.id, s.source_point_id, s.name,
+           ST_Y(s.location::geometry) AS latitude,
+           ST_X(s.location::geometry) AS longitude,
+           s.position,
+           EXISTS (SELECT 1 FROM raid_point_credits c
+             WHERE c.raid_id = s.raid_id AND c.point_snapshot_id = s.id
+               AND c.user_id = $2) AS visited_by_me,
+           EXISTS (SELECT 1 FROM raid_point_credits c
+             WHERE c.raid_id = s.raid_id AND c.point_snapshot_id = s.id) AS visited_by_team
+         FROM raid_point_snapshots s
+         WHERE s.raid_id = $1
+         ORDER BY s.position, s.id
+         LIMIT 500`,
+        [raidId, actorUserId],
+      )
+      return {
+        points: result.rows.map((row) => ({
+          id: row.id,
+          sourcePointId: row.source_point_id,
+          name: row.name,
+          latitude: Number(row.latitude),
+          longitude: Number(row.longitude),
+          position: Number(row.position),
+          visitedByMe: row.visited_by_me,
+          visitedByTeam: row.visited_by_team,
+        })),
+      }
+    } finally {
+      client.release()
+    }
+  }
+
+  async reportPresence(
+    actorUserId: string,
+    raidId: string,
+    evidence: RaidPresenceEvidence,
+  ): Promise<RaidPresenceRoster> {
+    return transaction(this.pool, async (client) => {
+      const raid = await this.lockRaid(client, actorUserId, raidId)
+      const mayReportInLobby = raid.state === 'lobby' && ['accepted', 'ready'].includes(raid.participant_state ?? '')
+      const mayReportInRaid = raid.state === 'active' && raid.participant_state === 'active'
+      if (!mayReportInLobby && !mayReportInRaid) {
+        throw this.forbiddenCommand()
+      }
+      const capturedAt = new Date(evidence.capturedAt)
+      const ageMs = Date.now() - capturedAt.getTime()
+      if (!Number.isFinite(capturedAt.getTime()) || ageMs > 30_000 || ageMs < -10_000) {
+        throw new RaidError('PRESENCE_LOCATION_STALE', 409, 'Нужна свежая геолокация')
+      }
+      await client.query(
+        `INSERT INTO raid_presence_reports
+          (raid_id, user_id, location, captured_at, accuracy_meters, expires_at, updated_at)
+         VALUES ($1, $2, ST_SetSRID(ST_MakePoint($4, $3), 4326)::geography,
+           $5, $6, clock_timestamp() + interval '30 seconds', clock_timestamp())
+         ON CONFLICT (raid_id, user_id) DO UPDATE SET
+           location = excluded.location,
+           captured_at = excluded.captured_at,
+           accuracy_meters = excluded.accuracy_meters,
+           expires_at = excluded.expires_at,
+           updated_at = excluded.updated_at`,
+        [raid.id, actorUserId, evidence.latitude, evidence.longitude, capturedAt, evidence.accuracyMeters],
+      )
+      return this.projectPresenceRoster(client, raid)
+    })
+  }
+
+  async getPresenceRoster(actorUserId: string, raidId: string): Promise<RaidPresenceRoster> {
+    return transaction(this.pool, async (client) => {
+      const raid = await this.lockRaid(client, actorUserId, raidId)
+      if (raid.state !== 'lobby') throw this.forbiddenCommand()
+      return this.projectPresenceRoster(client, raid)
+    })
+  }
+
+  async setManualPresence(
+    actorUserId: string,
+    raidId: string,
+    participantId: string,
+    present: boolean,
+  ): Promise<RaidPresenceRoster> {
+    return transaction(this.pool, async (client) => {
+      const raid = await this.lockRaid(client, actorUserId, raidId)
+      this.requireOrganizer(raid, actorUserId)
+      if (raid.state !== 'lobby') throw this.forbiddenCommand()
+      if (participantId === actorUserId) throw this.forbiddenCommand()
+      const result = await client.query(
+        `UPDATE raid_participants SET
+           presence_override_at = CASE WHEN $4 THEN clock_timestamp() ELSE NULL END,
+           presence_override_by = CASE WHEN $4 THEN $2 ELSE NULL END,
+           updated_at = clock_timestamp()
+         WHERE raid_id = $1 AND user_id = $3 AND state IN ('accepted', 'ready')`,
+        [raid.id, actorUserId, participantId, present],
+      )
+      if (!result.rowCount) throw this.notFound()
+      return this.projectPresenceRoster(client, raid)
+    })
+  }
+
+  async getPointPresence(
+    actorUserId: string,
+    raidId: string,
+    pointSnapshotId: string,
+  ): Promise<RaidPointPresenceRoster> {
+    return transaction(this.pool, async (client) => {
+      const raid = await this.lockRaid(client, actorUserId, raidId)
+      this.requireOrganizer(raid, actorUserId)
+      if (raid.state !== 'active') throw this.forbiddenCommand()
+      const point = await client.query<{ id: string }>(
+        'SELECT id FROM raid_point_snapshots WHERE id = $1 AND raid_id = $2',
+        [pointSnapshotId, raid.id],
+      )
+      if (!point.rowCount) throw this.notFound()
+      const result = await client.query<{
+        id: string
+        status: 'nearby' | 'waiting'
+        observed_at: Date | null
+        server_at: Date
+      }>(
+        `SELECT p.user_id AS id,
+           CASE WHEN report.expires_at > clock_timestamp()
+             AND report.accuracy_meters <= 50
+             AND ST_DWithin(report.location, snapshot.location, 50)
+             THEN 'nearby' ELSE 'waiting' END AS status,
+           CASE WHEN report.expires_at > clock_timestamp()
+             AND report.accuracy_meters <= 50
+             AND ST_DWithin(report.location, snapshot.location, 50)
+             THEN report.captured_at ELSE NULL END AS observed_at,
+           clock_timestamp() AS server_at
+         FROM raid_participants p
+         CROSS JOIN raid_point_snapshots snapshot
+         LEFT JOIN raid_presence_reports report
+           ON report.raid_id = p.raid_id AND report.user_id = p.user_id
+         WHERE p.raid_id = $1 AND p.state = 'active'
+           AND snapshot.id = $2 AND snapshot.raid_id = p.raid_id
+         ORDER BY p.invited_at, p.user_id`,
+        [raid.id, pointSnapshotId],
+      )
+      return {
+        pointSnapshotId,
+        radiusMeters: 50,
+        participants: result.rows.map((row) => ({
+          id: row.id,
+          status: row.status,
+          observedAt: row.observed_at?.toISOString() ?? null,
+        })),
+        serverAt: result.rows[0]?.server_at.toISOString() ?? new Date().toISOString(),
+      }
+    })
+  }
+
+  private async projectPresenceRoster(
+    client: PoolClient,
+    raid: RaidRow,
+  ): Promise<RaidPresenceRoster> {
+    const result = await client.query<{
+      id: string
+      display_name: string
+      avatar_url: string | null
+      status: 'nearby' | 'manual' | 'waiting'
+      observed_at: Date | null
+      server_at: Date
+    }>(
+      `WITH organizer AS (
+         SELECT location FROM raid_presence_reports
+         WHERE raid_id = $1 AND user_id = $2 AND expires_at > clock_timestamp()
+           AND accuracy_meters <= 50
+       )
+       SELECT u.id,
+         coalesce(u.display_name, u.username::text, split_part(u.email::text, '@', 1)) AS display_name,
+         u.avatar_url,
+         CASE
+           WHEN p.presence_override_at IS NOT NULL THEN 'manual'
+           WHEN own.expires_at > clock_timestamp() AND own.accuracy_meters <= 50
+             AND EXISTS (SELECT 1 FROM organizer o WHERE ST_DWithin(own.location, o.location, 50))
+             THEN 'nearby'
+           ELSE 'waiting'
+         END AS status,
+         CASE WHEN p.presence_override_at IS NOT NULL THEN p.presence_override_at
+           WHEN own.expires_at > clock_timestamp() THEN own.captured_at ELSE NULL END AS observed_at,
+         clock_timestamp() AS server_at
+       FROM raid_participants p
+       JOIN users u ON u.id = p.user_id
+       LEFT JOIN raid_presence_reports own ON own.raid_id = p.raid_id AND own.user_id = p.user_id
+       WHERE p.raid_id = $1 AND p.state IN ('accepted', 'ready')
+       ORDER BY p.invited_at, p.user_id`,
+      [raid.id, raid.organizer_user_id],
+    )
+    const participants = result.rows.map((row) => ({
+      id: row.id,
+      displayName: row.display_name,
+      avatarUrl: row.avatar_url,
+      status: row.status,
+      observedAt: row.observed_at?.toISOString() ?? null,
+    }))
+    return {
+      radiusMeters: 50,
+      maxAgeSeconds: 30,
+      allReady: participants.length > 0 && participants.every(({ status }) => status !== 'waiting'),
+      participants,
+      serverAt: result.rows[0]?.server_at.toISOString() ?? new Date().toISOString(),
+    }
+  }
+
   async nearbyCheckins(
     actorUserId: string,
     raidId: string,
     input: NearbyCheckinInput,
   ): Promise<{
-    policy: { version: 'v1'; radiusMeters: 75; maxAgeSeconds: 60; maxAccuracyMeters: 50 }
+    policy: { version: 'v1'; radiusMeters: 50; maxAgeSeconds: 60; maxAccuracyMeters: 50 }
     points: Array<{
       pointSnapshotId: string
       sourcePointId: string
@@ -1100,12 +1385,12 @@ export class DatabaseRaidService implements RaidService {
              WHERE c.raid_id = s.raid_id AND c.point_snapshot_id = s.id) AS credited_by_team
          FROM raid_point_snapshots s
          CROSS JOIN (SELECT ST_SetSRID(ST_MakePoint($4, $3), 4326)::geography AS location) q
-         WHERE s.raid_id = $1 AND ST_DWithin(s.location, q.location, 75)
+         WHERE s.raid_id = $1 AND ST_DWithin(s.location, q.location, 50)
          ORDER BY distance_meters, s.position, s.id LIMIT $5`,
         [raid.id, actorUserId, input.latitude, input.longitude, input.limit],
       )
       return {
-        policy: { version: 'v1', radiusMeters: 75, maxAgeSeconds: 60, maxAccuracyMeters: 50 },
+        policy: { version: 'v1', radiusMeters: 50, maxAgeSeconds: 60, maxAccuracyMeters: 50 },
         points: result.rows.map((row) => ({
           pointSnapshotId: row.id,
           sourcePointId: row.source_point_id,
@@ -1167,7 +1452,7 @@ export class DatabaseRaidService implements RaidService {
       let reason: CheckinResponse['reason'] = null
       if (ageMs > 60_000 || ageMs < -30_000) reason = 'location_expired'
       else if (input.evidence.accuracyMeters > 50) reason = 'accuracy_insufficient'
-      else if (distanceMeters > 75) reason = 'too_far'
+      else if (distanceMeters > 50) reason = 'too_far'
       const accepted = reason === null
       const attemptResult = await client.query<{ id: string }>(
         `INSERT INTO raid_checkin_attempts
@@ -2405,6 +2690,10 @@ export class DatabaseRaidService implements RaidService {
           [raid.id, raid.navigator_user_id, raid.kabanda_id],
         )
         if (!navigator.rowCount) throw this.forbiddenCommand()
+        const presence = await this.projectPresenceRoster(client, raid)
+        if (!presence.allReady) {
+          throw new RaidError('RAID_PARTICIPANTS_NOT_PRESENT', 409, 'Подтвердите, что вся стая на месте')
+        }
         const snapshots = await client.query(
           `INSERT INTO raid_point_snapshots
             (raid_id, source_point_id, collection_id, name, location, position)
@@ -2446,6 +2735,7 @@ export class DatabaseRaidService implements RaidService {
         await this.openActivityWindow(client, raid.id, nextVersion)
         if (!raid.navigator_user_id) throw this.forbiddenCommand()
         await this.createUnclaimedLease(client, raid.id, raid.navigator_user_id)
+        await client.query('DELETE FROM raid_presence_reports WHERE raid_id = $1', [raid.id])
         return
       }
       case 'pause':
@@ -2468,6 +2758,7 @@ export class DatabaseRaidService implements RaidService {
         await client.query(`UPDATE raids SET state = 'cancelled', cancelled_at = now() WHERE id = $1`, [
           raid.id,
         ])
+        await client.query('DELETE FROM raid_presence_reports WHERE raid_id = $1', [raid.id])
         return
     }
   }

--- a/apps/api/src/raids.ts
+++ b/apps/api/src/raids.ts
@@ -118,6 +118,20 @@ export type RouteBatchInput = {
   samples: RouteSampleInput[]
 }
 
+export type RouteTrackPoint = {
+  latitude: number
+  longitude: number
+  capturedAt: string
+}
+
+export type RouteTrackProjection = {
+  segments: RouteTrackPoint[][]
+  pointCount: number
+  truncated: boolean
+  updatedAt: string | null
+  serverAt: string
+}
+
 export type RouteStatusProjection = {
   status: RouteStatusCode
   navigatorUserId: string | null
@@ -474,6 +488,7 @@ export interface RaidService {
     input: RouteBatchInput,
     operationId: string,
   ): Promise<RouteBatchResponse>
+  getRouteTrack(actorUserId: string, raidId: string): Promise<RouteTrackProjection>
   getRaid(actorUserId: string, raidId: string): Promise<RaidProjection>
   getCurrent(actorUserId: string): Promise<RaidProjection | null>
   listActionable(actorUserId: string, kabandaId: string): Promise<RaidProjection[]>
@@ -942,6 +957,105 @@ export class DatabaseRaidService implements RaidService {
       })
       return response
     })
+  }
+
+  async getRouteTrack(actorUserId: string, raidId: string): Promise<RouteTrackProjection> {
+    const client = await this.pool.connect()
+    try {
+      const access = await client.query<{
+        state: RaidState
+        role: 'owner' | 'member'
+        participant_state: RaidParticipantState | null
+      }>(
+        `SELECT r.state, m.role, p.state AS participant_state FROM raids r
+         JOIN kabandas k ON k.id = r.kabanda_id AND k.archived_at IS NULL
+         JOIN kabanda_memberships m
+           ON m.kabanda_id = r.kabanda_id AND m.user_id = $2 AND m.removed_at IS NULL
+         LEFT JOIN raid_participants p ON p.raid_id = r.id AND p.user_id = $2
+         WHERE r.id = $1`,
+        [raidId, actorUserId],
+      )
+      const visibility = access.rows[0]
+      const mayReadActiveTrack = visibility?.role === 'owner' || visibility?.participant_state === 'active'
+      const mayReadCompletedTrack = visibility?.state === 'completed'
+      if (!visibility || (!mayReadActiveTrack && !mayReadCompletedTrack)) throw this.notFound()
+
+      const result = await client.query<{
+        lease_id: string
+        generation: number
+        sequence: string | number
+        captured_at: Date
+        latitude: number
+        longitude: number
+        continues_previous: boolean
+        server_at: Date
+      }>(
+        `WITH ordered AS (
+           SELECT s.lease_id, l.generation, s.sequence, s.captured_at, s.geom, s.accuracy_m,
+             r.state,
+             lag(s.sequence) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_sequence,
+             lag(s.captured_at) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_at,
+             lag(s.geom) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_geom,
+             lag(s.accuracy_m) OVER (PARTITION BY s.lease_id ORDER BY s.sequence) AS previous_accuracy,
+             c.max_sequence AS final_sequence
+           FROM raid_route_samples s
+           JOIN raid_navigator_leases l ON l.id = s.lease_id AND l.raid_id = s.raid_id
+           JOIN raids r ON r.id = s.raid_id
+           LEFT JOIN raid_route_finalization_cutoffs c
+             ON c.raid_id = s.raid_id AND c.lease_id = s.lease_id
+           WHERE s.raid_id = $1
+         )
+         SELECT lease_id, generation, sequence, captured_at,
+           ST_Y(geom::geometry) AS latitude,
+           ST_X(geom::geometry) AS longitude,
+           (previous_geom IS NOT NULL
+             AND sequence = previous_sequence + 1
+             AND previous_accuracy <= 50
+             AND extract(epoch FROM (captured_at - previous_at)) BETWEEN 0 AND 120
+             AND ST_Distance(geom, previous_geom) <= 2000
+             AND ST_Distance(geom, previous_geom) /
+               greatest(extract(epoch FROM (captured_at - previous_at)), 0.001) <= 50
+             AND EXISTS (SELECT 1 FROM raid_activity_windows w
+               WHERE w.raid_id = $1 AND previous_at >= w.opened_at
+                 AND captured_at <= coalesce(w.closed_at, clock_timestamp()))) AS continues_previous,
+           clock_timestamp() AS server_at
+         FROM ordered
+         WHERE accuracy_m <= 50
+           AND (state IN ('active', 'paused') OR sequence <= final_sequence)
+           AND EXISTS (SELECT 1 FROM raid_activity_windows w
+             WHERE w.raid_id = $1 AND captured_at >= w.opened_at
+               AND captured_at <= coalesce(w.closed_at, clock_timestamp()))
+         ORDER BY generation, sequence
+         LIMIT 10001`,
+        [raidId],
+      )
+      const rows = result.rows.slice(0, 10_000)
+      const segments: RouteTrackPoint[][] = []
+      let current: RouteTrackPoint[] = []
+      let previousLeaseId: string | null = null
+      for (const row of rows) {
+        const point: RouteTrackPoint = {
+          latitude: Number(row.latitude),
+          longitude: Number(row.longitude),
+          capturedAt: row.captured_at.toISOString(),
+        }
+        if (!row.continues_previous || row.lease_id !== previousLeaseId) {
+          current = []
+          segments.push(current)
+        }
+        current.push(point)
+        previousLeaseId = row.lease_id
+      }
+      return {
+        segments,
+        pointCount: rows.length,
+        truncated: result.rows.length > rows.length,
+        updatedAt: rows.at(-1)?.captured_at.toISOString() ?? null,
+        serverAt: result.rows[0]?.server_at.toISOString() ?? new Date().toISOString(),
+      }
+    } finally {
+      client.release()
+    }
   }
 
   async nearbyCheckins(

--- a/apps/api/src/raids.ts
+++ b/apps/api/src/raids.ts
@@ -1185,21 +1185,29 @@ export class DatabaseRaidService implements RaidService {
         throw this.forbiddenCommand()
       }
       const capturedAt = new Date(evidence.capturedAt)
-      const ageMs = Date.now() - capturedAt.getTime()
-      if (!Number.isFinite(capturedAt.getTime()) || ageMs > 30_000 || ageMs < -10_000) {
+      if (!Number.isFinite(capturedAt.getTime())) {
+        throw new RaidError('PRESENCE_LOCATION_STALE', 409, 'Нужна свежая геолокация')
+      }
+      const freshness = await client.query<{ fresh: boolean }>(
+        `SELECT $1::timestamptz >= clock_timestamp() - interval '30 seconds'
+           AND $1::timestamptz <= clock_timestamp() + interval '10 seconds' AS fresh`,
+        [capturedAt],
+      )
+      if (!freshness.rows[0]?.fresh) {
         throw new RaidError('PRESENCE_LOCATION_STALE', 409, 'Нужна свежая геолокация')
       }
       await client.query(
         `INSERT INTO raid_presence_reports
           (raid_id, user_id, location, captured_at, accuracy_meters, expires_at, updated_at)
          VALUES ($1, $2, ST_SetSRID(ST_MakePoint($4, $3), 4326)::geography,
-           $5, $6, clock_timestamp() + interval '30 seconds', clock_timestamp())
+           $5, $6, $5::timestamptz + interval '30 seconds', clock_timestamp())
          ON CONFLICT (raid_id, user_id) DO UPDATE SET
            location = excluded.location,
            captured_at = excluded.captured_at,
            accuracy_meters = excluded.accuracy_meters,
            expires_at = excluded.expires_at,
-           updated_at = excluded.updated_at`,
+           updated_at = excluded.updated_at
+         WHERE excluded.captured_at > raid_presence_reports.captured_at`,
         [raid.id, actorUserId, evidence.latitude, evidence.longitude, capturedAt, evidence.accuracyMeters],
       )
       return this.projectPresenceRoster(client, raid)

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -87,6 +87,7 @@ function createRaids(overrides: Partial<RaidService> = {}): RaidService {
     acquireNavigatorLease: vi.fn(),
     recoverNavigatorLease: vi.fn(),
     submitRouteBatch: vi.fn(),
+    getRouteTrack: vi.fn().mockResolvedValue({ segments: [], pointCount: 0, truncated: false, updatedAt: null, serverAt: '2026-08-28T12:00:00.000Z' }),
     getRaid: vi.fn(),
     getCurrent: vi.fn().mockResolvedValue(null),
     listActionable: vi.fn().mockResolvedValue([]),
@@ -1107,6 +1108,34 @@ describe('API foundation', () => {
     )
     expect(JSON.stringify(response.json())).not.toContain('56.85')
     expect(JSON.stringify(response.json())).not.toContain('53.2')
+  })
+
+  it('returns the private no-store route track to an authenticated viewer', async () => {
+    const track = {
+      segments: [[
+        { latitude: 56.85, longitude: 53.2, capturedAt: '2026-08-28T12:00:00.000Z' },
+        { latitude: 56.851, longitude: 53.201, capturedAt: '2026-08-28T12:00:05.000Z' },
+      ]],
+      pointCount: 2,
+      truncated: false,
+      updatedAt: '2026-08-28T12:00:05.000Z',
+      serverAt: '2026-08-28T12:00:06.000Z',
+    }
+    const getRouteTrack = vi.fn().mockResolvedValue(track)
+    const app = await createTestApp(
+      createAuth({ getUser: vi.fn().mockResolvedValue(user) }),
+      createKabandas(),
+      createRaids({ getRouteTrack }),
+    )
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/raids/81297402-898c-48d6-bc78-c74b6b38205c/route/track',
+      headers: { cookie: 'kabanda_session=session' },
+    })
+    expect(response.statusCode).toBe(200)
+    expect(response.headers['cache-control']).toBe('private, no-store')
+    expect(response.json()).toEqual({ track })
+    expect(getRouteTrack).toHaveBeenCalledWith(user.id, '81297402-898c-48d6-bc78-c74b6b38205c')
   })
 
   it('registers the canonical route lease acquire endpoint', async () => {

--- a/apps/api/test/app.test.ts
+++ b/apps/api/test/app.test.ts
@@ -88,6 +88,11 @@ function createRaids(overrides: Partial<RaidService> = {}): RaidService {
     recoverNavigatorLease: vi.fn(),
     submitRouteBatch: vi.fn(),
     getRouteTrack: vi.fn().mockResolvedValue({ segments: [], pointCount: 0, truncated: false, updatedAt: null, serverAt: '2026-08-28T12:00:00.000Z' }),
+    getMapPoints: vi.fn().mockResolvedValue({ points: [] }),
+    reportPresence: vi.fn().mockResolvedValue({ radiusMeters: 50, maxAgeSeconds: 30, allReady: false, participants: [], serverAt: '2026-08-28T12:00:00.000Z' }),
+    getPresenceRoster: vi.fn().mockResolvedValue({ radiusMeters: 50, maxAgeSeconds: 30, allReady: false, participants: [], serverAt: '2026-08-28T12:00:00.000Z' }),
+    setManualPresence: vi.fn().mockResolvedValue({ radiusMeters: 50, maxAgeSeconds: 30, allReady: false, participants: [], serverAt: '2026-08-28T12:00:00.000Z' }),
+    getPointPresence: vi.fn().mockResolvedValue({ pointSnapshotId: '00000000-0000-4000-8000-000000000001', radiusMeters: 50, participants: [], serverAt: '2026-08-28T12:00:00.000Z' }),
     getRaid: vi.fn(),
     getCurrent: vi.fn().mockResolvedValue(null),
     listActionable: vi.fn().mockResolvedValue([]),
@@ -1138,6 +1143,96 @@ describe('API foundation', () => {
     expect(getRouteTrack).toHaveBeenCalledWith(user.id, '81297402-898c-48d6-bc78-c74b6b38205c')
   })
 
+  it('returns private raid map points to an authenticated viewer', async () => {
+    const points = [{
+      id: '9ad92175-8a47-4131-86ad-10ed765f8168',
+      sourcePointId: '631eb45d-dc73-4f21-aad2-ee179b6a17fd',
+      name: 'Точка у старта',
+      latitude: 56.85,
+      longitude: 53.2,
+      position: 0,
+      visitedByMe: false,
+      visitedByTeam: false,
+    }]
+    const getMapPoints = vi.fn().mockResolvedValue({ points })
+    const app = await createTestApp(
+      createAuth({ getUser: vi.fn().mockResolvedValue(user) }),
+      createKabandas(),
+      createRaids({ getMapPoints }),
+    )
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/raids/81297402-898c-48d6-bc78-c74b6b38205c/map-points',
+      headers: { cookie: 'kabanda_session=session' },
+    })
+    expect(response.statusCode).toBe(200)
+    expect(response.headers['cache-control']).toBe('private, no-store')
+    expect(response.json()).toEqual({ points })
+    expect(getMapPoints).toHaveBeenCalledWith(user.id, '81297402-898c-48d6-bc78-c74b6b38205c')
+  })
+
+  it('accepts fresh pre-start presence without returning coordinates', async () => {
+    const roster = {
+      radiusMeters: 50,
+      maxAgeSeconds: 30,
+      allReady: true,
+      participants: [{ id: user.id, displayName: 'Павел', avatarUrl: null, status: 'nearby', observedAt: '2026-08-28T12:00:00.000Z' }],
+      serverAt: '2026-08-28T12:00:01.000Z',
+    }
+    const reportPresence = vi.fn().mockResolvedValue(roster)
+    const app = await createTestApp(
+      createAuth({ getUser: vi.fn().mockResolvedValue(user) }),
+      createKabandas(),
+      createRaids({ reportPresence }),
+    )
+    const evidence = {
+      latitude: 56.85,
+      longitude: 53.2,
+      capturedAt: '2026-08-28T12:00:00.000Z',
+      accuracyMeters: 8,
+    }
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/api/raids/81297402-898c-48d6-bc78-c74b6b38205c/presence/me',
+      headers: { origin: testOrigin, cookie: 'kabanda_session=session' },
+      payload: evidence,
+    })
+    expect(response.statusCode).toBe(200)
+    expect(response.headers['cache-control']).toBe('private, no-store')
+    expect(response.json()).toEqual(roster)
+    expect(JSON.stringify(response.json())).not.toContain('56.85')
+    expect(JSON.stringify(response.json())).not.toContain('53.2')
+    expect(reportPresence).toHaveBeenCalledWith(user.id, '81297402-898c-48d6-bc78-c74b6b38205c', evidence)
+  })
+
+  it('returns point proximity statuses to the raid organizer without coordinates', async () => {
+    const pointSnapshotId = '9ad92175-8a47-4131-86ad-10ed765f8168'
+    const roster = {
+      pointSnapshotId,
+      radiusMeters: 50,
+      participants: [{ id: user.id, status: 'nearby', observedAt: '2026-08-28T12:00:00.000Z' }],
+      serverAt: '2026-08-28T12:00:01.000Z',
+    }
+    const getPointPresence = vi.fn().mockResolvedValue(roster)
+    const app = await createTestApp(
+      createAuth({ getUser: vi.fn().mockResolvedValue(user) }),
+      createKabandas(),
+      createRaids({ getPointPresence }),
+    )
+    const raidId = '81297402-898c-48d6-bc78-c74b6b38205c'
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/raids/${raidId}/check-ins/presence?pointSnapshotId=${pointSnapshotId}`,
+      headers: { cookie: 'kabanda_session=session' },
+    })
+    expect(response.statusCode).toBe(200)
+    expect(response.headers['cache-control']).toBe('private, no-store')
+    expect(response.json()).toEqual(roster)
+    expect(JSON.stringify(response.json())).not.toContain('56.85')
+    expect(JSON.stringify(response.json())).not.toContain('53.2')
+    expect(getPointPresence).toHaveBeenCalledWith(user.id, raidId, pointSnapshotId)
+  })
+
   it('registers the canonical route lease acquire endpoint', async () => {
     const acquireNavigatorLease = vi.fn().mockResolvedValue({
       receipt: {
@@ -1179,7 +1274,7 @@ describe('API foundation', () => {
 
   it('registers bounded nearby and actor-owned pending inbox routes', async () => {
     const nearbyCheckins = vi.fn().mockResolvedValue({
-      policy: { version: 'v1', radiusMeters: 75, maxAgeSeconds: 60, maxAccuracyMeters: 50 },
+      policy: { version: 'v1', radiusMeters: 50, maxAgeSeconds: 60, maxAccuracyMeters: 50 },
       points: [],
     })
     const listPendingClaims = vi.fn().mockResolvedValue({ claims: [] })

--- a/apps/api/test/kabandas.postgres.test.ts
+++ b/apps/api/test/kabandas.postgres.test.ts
@@ -686,6 +686,55 @@ describePostgres('Kabandas and points PostgreSQL invariants', () => {
     )).rows[0]?.count)).toBe(0)
   })
 
+  it('expires presence from capture time and ignores an older in-flight report', async () => {
+    const { ownerId, kabanda } = await ownerAndKabanda('presence-ordering')
+    const ready = await readyRaid(ownerId, kabanda.id, 'presence-ordering')
+    const freshCapturedAt = new Date()
+    await raidService!.reportPresence(ownerId, ready.raid.id, {
+      latitude: 56.85,
+      longitude: 53.2,
+      capturedAt: freshCapturedAt.toISOString(),
+      accuracyMeters: 8,
+    })
+    await raidService!.reportPresence(ownerId, ready.raid.id, {
+      latitude: 57,
+      longitude: 54,
+      capturedAt: new Date(freshCapturedAt.getTime() - 5_000).toISOString(),
+      accuracyMeters: 8,
+    })
+    const stored = await pool!.query<{
+      captured_at: Date
+      expiry_seconds: number
+      longitude: number
+    }>(
+      `SELECT captured_at,
+         extract(epoch FROM expires_at - captured_at) AS expiry_seconds,
+         ST_X(location::geometry) AS longitude
+       FROM raid_presence_reports WHERE raid_id = $1 AND user_id = $2`,
+      [ready.raid.id, ownerId],
+    )
+    expect(stored.rows[0]?.captured_at.toISOString()).toBe(freshCapturedAt.toISOString())
+    expect(Number(stored.rows[0]?.expiry_seconds)).toBe(30)
+    expect(Number(stored.rows[0]?.longitude)).toBe(53.2)
+
+    await pool!.query('DELETE FROM raid_presence_reports WHERE raid_id = $1', [ready.raid.id])
+    const almostExpiredAt = new Date(Date.now() - 20_000)
+    await raidService!.reportPresence(ownerId, ready.raid.id, {
+      latitude: 56.85,
+      longitude: 53.2,
+      capturedAt: almostExpiredAt.toISOString(),
+      accuracyMeters: 8,
+    })
+    const remaining = await pool!.query<{ remaining_seconds: number }>(
+      `SELECT extract(epoch FROM expires_at - clock_timestamp()) AS remaining_seconds
+       FROM raid_presence_reports WHERE raid_id = $1 AND user_id = $2`,
+      [ready.raid.id, ownerId],
+    )
+    expect(Number(stored.rows[0]?.expiry_seconds)).toBe(30)
+    expect(Number(remaining.rows[0]?.remaining_seconds)).toBeGreaterThan(5)
+    expect(Number(remaining.rows[0]?.remaining_seconds)).toBeLessThan(15)
+  })
+
   it('creates a future scheduled raid as planned and opens its lobby', async () => {
     const { ownerId, kabanda } = await ownerAndKabanda('raid-planned')
     const scheduledAt = '2099-08-28T12:00:00.000Z'

--- a/apps/api/test/kabandas.postgres.test.ts
+++ b/apps/api/test/kabandas.postgres.test.ts
@@ -986,7 +986,7 @@ describePostgres('Kabandas and points PostgreSQL invariants', () => {
         completed.organizerId,
       ),
     ).resolves.toBeUndefined()
-  })
+  }, 10_000)
 
   it('does not report a member-organized active raid as current for an unjoined owner', async () => {
     const { ownerId, organizerId, kabanda, started } =

--- a/apps/api/test/kabandas.postgres.test.ts
+++ b/apps/api/test/kabandas.postgres.test.ts
@@ -119,6 +119,12 @@ async function readyRaid(ownerId: string, kabandaId: string, suffix: string) {
     { expectedVersion: 3 },
     `ready-${suffix}`,
   )
+  await raidService!.reportPresence(ownerId, raidId, {
+    latitude: 56.85,
+    longitude: 53.2,
+    capturedAt: new Date().toISOString(),
+    accuracyMeters: 8,
+  })
   return raidService!.reportReadiness(
     ownerId,
     raidId,
@@ -208,6 +214,20 @@ async function activeMemberOrganizerRaid(suffix: string, ownerJoins = true) {
     { expectedVersion: ready.raid.version, ...readiness() },
     `member-organizer-readiness-${suffix}`,
   )
+  await raidService!.reportPresence(organizerId, created.raid.id, {
+    latitude: 56.85,
+    longitude: 53.2,
+    capturedAt: new Date().toISOString(),
+    accuracyMeters: 8,
+  })
+  if (ownerJoins) {
+    await raidService!.reportPresence(ownerId, created.raid.id, {
+      latitude: 56.8501,
+      longitude: 53.2001,
+      capturedAt: new Date().toISOString(),
+      accuracyMeters: 8,
+    })
+  }
   const started = await raidService!.command(
     organizerId,
     created.raid.id,
@@ -633,6 +653,37 @@ describePostgres('Kabandas and points PostgreSQL invariants', () => {
     )
     expect(cancelled.raid).toMatchObject({ state: 'cancelled', version: 8 })
     await expect(raidService!.getCurrent(ownerId)).resolves.toBeNull()
+  })
+
+  it('blocks start until every accepted participant is nearby or manually confirmed', async () => {
+    const { ownerId, kabanda } = await ownerAndKabanda('presence-gate')
+    const ready = await readyRaid(ownerId, kabanda.id, 'presence-gate')
+    await pool!.query('DELETE FROM raid_presence_reports WHERE raid_id = $1', [ready.raid.id])
+    await expect(raidService!.command(
+      ownerId,
+      ready.raid.id,
+      'start',
+      { expectedVersion: ready.raid.version },
+      'presence-gate-blocked',
+    )).rejects.toMatchObject({ code: 'RAID_PARTICIPANTS_NOT_PRESENT' })
+    const present = await raidService!.reportPresence(ownerId, ready.raid.id, {
+      latitude: 56.85,
+      longitude: 53.2,
+      capturedAt: new Date().toISOString(),
+      accuracyMeters: 8,
+    })
+    expect(present).toMatchObject({ allReady: true, participants: [{ id: ownerId, status: 'nearby' }] })
+    await expect(raidService!.command(
+      ownerId,
+      ready.raid.id,
+      'start',
+      { expectedVersion: ready.raid.version },
+      'presence-gate-started',
+    )).resolves.toMatchObject({ raid: { state: 'active' } })
+    expect(Number((await pool!.query(
+      'SELECT count(*) FROM raid_presence_reports WHERE raid_id = $1',
+      [ready.raid.id],
+    )).rows[0]?.count)).toBe(0)
   })
 
   it('creates a future scheduled raid as planned and opens its lobby', async () => {
@@ -1530,6 +1581,18 @@ describePostgres('Kabandas and points PostgreSQL invariants', () => {
       { expectedVersion: 5, ...readiness() },
       'handoff-route-readiness',
     )
+    await raidService!.reportPresence(ownerId, created.raid.id, {
+      latitude: 56.85,
+      longitude: 53.2,
+      capturedAt: new Date().toISOString(),
+      accuracyMeters: 8,
+    })
+    await raidService!.reportPresence(memberId, created.raid.id, {
+      latitude: 56.8501,
+      longitude: 53.2001,
+      capturedAt: new Date().toISOString(),
+      accuracyMeters: 8,
+    })
     const started = await raidService!.command(
       ownerId,
       created.raid.id,

--- a/apps/api/test/kabandas.postgres.test.ts
+++ b/apps/api/test/kabandas.postgres.test.ts
@@ -1295,6 +1295,17 @@ describePostgres('Kabandas and points PostgreSQL invariants', () => {
       'route-batch-fill-gap',
     )
     expect(filled.routeStatus.missingSequenceCount).toBe(0)
+    const track = await raidService!.getRouteTrack(ownerId, acquired.raid.id)
+    expect(track).toMatchObject({ pointCount: 3, truncated: false })
+    expect(track.segments.flat().map(({ latitude, longitude }) => [latitude, longitude])).toEqual([
+      [56.8501, 53.2001],
+      [56.8502, 53.2002],
+      [56.85, 53.2],
+    ])
+    const outsider = await ownerAndKabanda('route-track-outsider')
+    await expect(raidService!.getRouteTrack(outsider.ownerId, acquired.raid.id)).rejects.toMatchObject({
+      code: 'RAID_NOT_FOUND',
+    })
     await expect(
       raidService!.submitRouteBatch(
         ownerId,

--- a/apps/pwa/src/features/checkins/CheckInPanel.tsx
+++ b/apps/pwa/src/features/checkins/CheckInPanel.tsx
@@ -396,6 +396,7 @@ export function CheckInPanel({
         <div><p className="kb-kicker">Точка рейда</p><h2>{manualResponse ? 'Нужна ручная проверка' : 'Кто сейчас здесь?'}</h2></div>
         {local?.unsynced ? <span className="checkin-pending">Локально: {local.unsynced}</span> : null}
       </div>
+      {presentation === 'map-sheet' && local?.unsynced ? <span className="checkin-pending">Локально: {local.unsynced}</span> : null}
       {presentation !== 'map-sheet' && <p className="kb-muted">{serverTailOnly ? 'В finalizing доступны только уже созданные server-side подтверждения.' : 'Для каждой попытки берём отдельную координату. Маршрут навигатора не используется как evidence.'}</p>}
 
       {pendingClaim && <div className="kb-notice"><strong>Вас отметил участник рейда.</strong><p>Подтвердите только своё присутствие или отклоните claim.</p></div>}

--- a/apps/pwa/src/features/checkins/CheckInPanel.tsx
+++ b/apps/pwa/src/features/checkins/CheckInPanel.tsx
@@ -21,6 +21,7 @@ import {
   checkInAttentionState,
   participantSelectionAfterPresenceRefresh,
   participantSelectionKey,
+  participantSelectionScopeKey,
   selectCheckInPrimary,
 } from './state'
 import {
@@ -93,7 +94,7 @@ export function CheckInPanel({
   const senderTabId = useRef(tabId()).current
   const actionKeys = useRef(new Map<string, string>())
   const manualParticipantChoices = useRef(new Map<string, boolean>())
-  const restoredManualAttemptKey = useRef<string | null>(null)
+  const initializedParticipantScopeKey = useRef<string | null>(null)
   const replaying = useRef(false)
   const replayRequested = useRef(false)
   const { setUnsyncedCheckInWork } = useRecordingRuntime()
@@ -107,7 +108,11 @@ export function CheckInPanel({
   ) ?? null
   const manualResponse = manualAttempt?.response as CheckInResponse | null
   const manualAttemptOperationId = manualAttempt?.operationId ?? null
-  const manualAttemptRestoreKey = manualAttempt ? `${identityId}:${manualAttempt.operationId}` : null
+  const participantScopeKey = participantSelectionScopeKey(
+    identityId,
+    selectedPointId,
+    manualAttemptOperationId,
+  )
   const reservedFallback = manualAttempt?.fallbackSubmission ?? null
   const fallbackMedia = local?.media.find((draft) =>
     draft.status === 'accepted' && draft.purpose === 'fallback' &&
@@ -137,13 +142,6 @@ export function CheckInPanel({
   }, [nearbyPoints])
 
   useEffect(() => {
-    setSelectedParticipants([identityId])
-    setNearbyParticipantIds([])
-    setAttestedParticipantKey(null)
-    manualParticipantChoices.current.clear()
-  }, [identityId, selectedPointId])
-
-  useEffect(() => {
     for (const participantId of manualParticipantChoices.current.keys()) {
       if (!activeParticipantIds.has(participantId)) manualParticipantChoices.current.delete(participantId)
     }
@@ -152,24 +150,15 @@ export function CheckInPanel({
   }, [activeParticipantIds, identityId])
 
   useEffect(() => {
-    if (!manualAttempt) {
-      const hadManualAttempt = restoredManualAttemptKey.current !== null
-      restoredManualAttemptKey.current = null
-      if (hadManualAttempt) {
-        manualParticipantChoices.current.clear()
-        setSelectedParticipants([identityId])
-      }
-      return
-    }
-    if (restoredManualAttemptKey.current === manualAttemptRestoreKey) return
-    restoredManualAttemptKey.current = manualAttemptRestoreKey
+    if (initializedParticipantScopeKey.current === participantScopeKey) return
+    initializedParticipantScopeKey.current = participantScopeKey
     manualParticipantChoices.current.clear()
-    setSelectedParticipants(activeParticipantSelection(
-      identityId,
-      manualAttempt.presentParticipantIds,
-      activeParticipantIds,
-    ))
-  }, [activeParticipantIds, identityId, manualAttempt, manualAttemptRestoreKey])
+    setNearbyParticipantIds([])
+    setAttestedParticipantKey(null)
+    setSelectedParticipants(manualAttempt
+      ? activeParticipantSelection(identityId, manualAttempt.presentParticipantIds, activeParticipantIds)
+      : [identityId])
+  }, [activeParticipantIds, identityId, manualAttempt, participantScopeKey])
 
   useEffect(() => {
     if (!viewerIsOrganizer || raid.state !== 'active' || !selectedPointId || !navigator.onLine) return

--- a/apps/pwa/src/features/checkins/CheckInPanel.tsx
+++ b/apps/pwa/src/features/checkins/CheckInPanel.tsx
@@ -84,7 +84,7 @@ export function CheckInPanel({
   const [verifierId, setVerifierId] = useState('')
   const senderTabId = useRef(tabId()).current
   const actionKeys = useRef(new Map<string, string>())
-  const autoSuggestedParticipants = useRef(new Set<string>())
+  const manualParticipantChoices = useRef(new Map<string, boolean>())
   const replaying = useRef(false)
   const replayRequested = useRef(false)
   const { setUnsyncedCheckInWork } = useRecordingRuntime()
@@ -116,7 +116,7 @@ export function CheckInPanel({
     setSelectedParticipants([identityId])
     setNearbyParticipantIds([])
     setOrganizerAttestation(false)
-    autoSuggestedParticipants.current.clear()
+    manualParticipantChoices.current.clear()
   }, [identityId, selectedPointId])
 
   useEffect(() => {
@@ -130,11 +130,13 @@ export function CheckInPanel({
           .filter(({ status }) => status === 'nearby')
           .map(({ id }) => id)
         setNearbyParticipantIds(nearbyIds)
-        const additions = nearbyIds.filter((id) => !autoSuggestedParticipants.current.has(id))
-        for (const id of additions) autoSuggestedParticipants.current.add(id)
-        if (additions.length > 0) {
-          setSelectedParticipants((current) => Array.from(new Set([...current, ...additions])))
-        }
+        const manualIds = Array.from(manualParticipantChoices.current)
+          .filter(([, selected]) => selected)
+          .map(([id]) => id)
+        const suggestedIds = nearbyIds.filter(
+          (id) => id !== identityId && !manualParticipantChoices.current.has(id),
+        )
+        setSelectedParticipants(Array.from(new Set([identityId, ...manualIds, ...suggestedIds])))
       } catch {
         // Manual participant selection remains available when live presence cannot refresh.
       }
@@ -365,9 +367,11 @@ export function CheckInPanel({
   }
 
   const toggleParticipant = (participantId: string) => {
-    setSelectedParticipants((current) => current.includes(participantId)
-      ? current.filter((id) => id !== participantId)
-      : [...current, participantId])
+    setSelectedParticipants((current) => {
+      const selected = !current.includes(participantId)
+      manualParticipantChoices.current.set(participantId, selected)
+      return selected ? [...current, participantId] : current.filter((id) => id !== participantId)
+    })
   }
 
   const selectedPrimaryKind = selectCheckInPrimary({

--- a/apps/pwa/src/features/checkins/CheckInPanel.tsx
+++ b/apps/pwa/src/features/checkins/CheckInPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ApiError } from '../../lib/http'
+import { getRaidPointPresence } from '../raids/api'
 import type { RaidParticipant, RaidProjection } from '../raids/types'
 import { useRecordingRuntime } from '../raids/recording/runtime'
 import {
@@ -54,16 +55,23 @@ export function CheckInPanel({
   staleProjection,
   onCanonicalRefresh,
   serverTailOnly = false,
+  nearbyPoints,
+  presentation = 'card',
+  onPendingChange,
 }: {
   identityId: string
   raid: RaidProjection
   staleProjection: boolean
   onCanonicalRefresh: () => Promise<unknown>
   serverTailOnly?: boolean
+  nearbyPoints?: NearbyPoint[]
+  presentation?: 'card' | 'map-sheet'
+  onPendingChange?: (count: number) => void
 }) {
   const [nearby, setNearby] = useState<NearbyPoint[]>([])
   const [selectedPointId, setSelectedPointId] = useState('')
   const [selectedParticipants, setSelectedParticipants] = useState<string[]>([identityId])
+  const [nearbyParticipantIds, setNearbyParticipantIds] = useState<string[]>([])
   const [organizerAttestation, setOrganizerAttestation] = useState(false)
   const [claims, setClaims] = useState<CheckInClaim[]>([])
   const [fallbacks, setFallbacks] = useState<CheckInFallback[]>([])
@@ -76,10 +84,10 @@ export function CheckInPanel({
   const [verifierId, setVerifierId] = useState('')
   const senderTabId = useRef(tabId()).current
   const actionKeys = useRef(new Map<string, string>())
+  const autoSuggestedParticipants = useRef(new Set<string>())
   const replaying = useRef(false)
   const { setUnsyncedCheckInWork } = useRecordingRuntime()
-  const viewerIsNavigator = raid.navigatorUserId === identityId
-  const viewerIsOwner = raid.organizerUserId === identityId
+  const viewerIsOrganizer = raid.organizerUserId === identityId
   const participants = useMemo(() => activeParticipants(raid), [raid])
   const pendingClaim = claims[0] ?? null
   const pendingFallback = fallbacks[0] ?? null
@@ -93,6 +101,54 @@ export function CheckInPanel({
     draft.attemptId === manualResponse?.attemptId && draft.mediaId,
   ) ?? null
   const canMutate = raid.state === 'active' && !staleProjection
+  const effectiveNearby = nearbyPoints ?? nearby
+
+  useEffect(() => {
+    if (!nearbyPoints) return
+    const eligible = nearbyPoints.filter(({ creditedByTeam }) => !creditedByTeam)
+    setSelectedPointId((current) => eligible.some(({ pointSnapshotId }) => pointSnapshotId === current)
+      ? current
+      : eligible[0]?.pointSnapshotId ?? '')
+  }, [nearbyPoints])
+
+  useEffect(() => {
+    setSelectedParticipants([identityId])
+    setNearbyParticipantIds([])
+    setOrganizerAttestation(false)
+    autoSuggestedParticipants.current.clear()
+  }, [identityId, selectedPointId])
+
+  useEffect(() => {
+    if (!viewerIsOrganizer || raid.state !== 'active' || !selectedPointId || !navigator.onLine) return
+    let active = true
+    const refresh = async () => {
+      try {
+        const response = await getRaidPointPresence(raid.id, selectedPointId)
+        if (!active) return
+        const nearbyIds = response.participants
+          .filter(({ status }) => status === 'nearby')
+          .map(({ id }) => id)
+        setNearbyParticipantIds(nearbyIds)
+        const additions = nearbyIds.filter((id) => !autoSuggestedParticipants.current.has(id))
+        for (const id of additions) autoSuggestedParticipants.current.add(id)
+        if (additions.length > 0) {
+          setSelectedParticipants((current) => Array.from(new Set([...current, ...additions])))
+        }
+      } catch {
+        // Manual participant selection remains available when live presence cannot refresh.
+      }
+    }
+    void refresh()
+    const timer = window.setInterval(() => void refresh(), 5_000)
+    return () => {
+      active = false
+      window.clearInterval(timer)
+    }
+  }, [raid.id, raid.state, selectedPointId, viewerIsOrganizer])
+
+  useEffect(() => {
+    onPendingChange?.(local?.unsynced ?? 0)
+  }, [local?.unsynced, onPendingChange])
 
   const refreshLocal = useCallback(async () => {
     const next = await getCheckInLocalState(identityId, raid.id)
@@ -187,7 +243,7 @@ export function CheckInPanel({
         pointSnapshotId: selectedPointId,
         evidence,
         presentParticipantIds: Array.from(new Set([identityId, ...selectedParticipants])),
-        organizerAttestation: viewerIsOwner && organizerAttestation,
+        organizerAttestation: viewerIsOrganizer && organizerAttestation,
       })
       if (!record) throw new Error('IDENTITY_CHANGED')
       await refreshLocal()
@@ -315,7 +371,7 @@ export function CheckInPanel({
       (reservedFallback?.input.verifierUserId ?? verifierId) &&
       (reservedFallback?.input.verifierUserId ?? verifierId) !== identityId,
     ),
-    viewerIsNavigator,
+    viewerCanCoordinate: viewerIsOrganizer,
     hasSelectedPoint: Boolean(selectedPointId),
   })
   const primaryKind = serverTailOnly && selectedPrimaryKind !== 'claim' && selectedPrimaryKind !== 'verify_fallback'
@@ -329,40 +385,40 @@ export function CheckInPanel({
         ? { label: 'Отправить на ручную проверку', action: submitFallback }
         : primaryKind === 'check_in'
           ? { label: 'Отметиться у точки', action: submit }
-          : primaryKind === 'locate'
+            : primaryKind === 'locate' && presentation !== 'map-sheet'
             ? { label: 'Найти точку рядом', action: locate }
             : null
-  const primaryRequiresOnline = Boolean(pendingClaim || pendingFallback || manualResponse || (viewerIsNavigator && !selectedPointId))
+  const primaryRequiresOnline = Boolean(pendingClaim || pendingFallback || manualResponse || (viewerIsOrganizer && !selectedPointId))
 
   return (
-    <section className="kb-card checkin-panel">
+    <section className={`${presentation === 'map-sheet' ? 'checkin-panel checkin-panel--map' : 'kb-card checkin-panel'}`}>
       <div className="kb-section-head">
         <div><p className="kb-kicker">Точка рейда</p><h2>{manualResponse ? 'Нужна ручная проверка' : 'Кто сейчас здесь?'}</h2></div>
         {local?.unsynced ? <span className="checkin-pending">Локально: {local.unsynced}</span> : null}
       </div>
-      <p className="kb-muted">{serverTailOnly ? 'В finalizing доступны только уже созданные server-side подтверждения.' : 'Для каждой попытки берём отдельную координату. Маршрут навигатора не используется как evidence.'}</p>
+      {presentation !== 'map-sheet' && <p className="kb-muted">{serverTailOnly ? 'В finalizing доступны только уже созданные server-side подтверждения.' : 'Для каждой попытки берём отдельную координату. Маршрут навигатора не используется как evidence.'}</p>}
 
       {pendingClaim && <div className="kb-notice"><strong>Вас отметил участник рейда.</strong><p>Подтвердите только своё присутствие или отклоните claim.</p></div>}
       {pendingFallback && <div className="kb-notice"><strong>Вас выбрали verifier.</strong><p>Подтверждение будет отдельным от автора попытки.</p></div>}
 
-      {!manualResponse && nearby.length > 0 && (
-        <fieldset className="checkin-points"><legend>Eligible точки рядом</legend>{nearby.map((point) => (
+      {!manualResponse && effectiveNearby.length > 0 && (
+        <fieldset className="checkin-points"><legend>{presentation === 'map-sheet' ? 'Точка рядом' : 'Eligible точки рядом'}</legend>{effectiveNearby.filter(({ creditedByTeam }) => presentation !== 'map-sheet' || !creditedByTeam).map((point) => (
           <label key={point.pointSnapshotId}><input type="radio" name="nearby-point" checked={selectedPointId === point.pointSnapshotId} onChange={() => setSelectedPointId(point.pointSnapshotId)} /><span><strong>{point.name}</strong><small>{Math.round(point.distanceMeters)} м · {point.creditedByTeam ? 'команда уже была' : 'новая для команды'}</small></span></label>
         ))}</fieldset>
       )}
 
-      {(selectedPointId || manualResponse) && viewerIsNavigator && (
+      {(selectedPointId || manualResponse) && viewerIsOrganizer && (
         <fieldset className="checkin-participants"><legend>Кто остановился у точки</legend>{participants.map((participant) => (
-          <label key={participant.id}><input type="checkbox" disabled={participant.id === identityId} checked={participant.id === identityId || selectedParticipants.includes(participant.id)} onChange={() => toggleParticipant(participant.id)} /><span>{participant.displayName}{participant.id === identityId ? ' · вы' : ''}</span></label>
-        ))}</fieldset>
+          <label key={participant.id}><input type="checkbox" disabled={participant.id === identityId} checked={participant.id === identityId || selectedParticipants.includes(participant.id)} onChange={() => toggleParticipant(participant.id)} /><span>{participant.displayName}{participant.id === identityId ? ' · вы' : nearbyParticipantIds.includes(participant.id) ? ' · рядом автоматически' : ''}</span></label>
+        ))}<small>Тех, чья свежая геопозиция попала в радиус 50 м, приложение отметило само. Остальных организатор может добавить вручную.</small></fieldset>
       )}
 
-      {!viewerIsOwner && selectedParticipants.some((id) => id !== identityId) && !manualResponse && (
+      {!viewerIsOrganizer && selectedParticipants.some((id) => id !== identityId) && !manualResponse && (
         <p className="kb-muted">Выбранные участники получат личный claim. Credit появится только после их подтверждения.</p>
       )}
 
-      {viewerIsOwner && selectedParticipants.some((id) => id !== identityId) && !manualResponse && (
-        <label className="checkin-attestation"><input type="checkbox" checked={organizerAttestation} onChange={(event) => setOrganizerAttestation(event.target.checked)} /><span><strong>Подтверждаю как вожак</strong><small>Без этого выбранные участники получат personal claim, но не credit.</small></span></label>
+      {viewerIsOrganizer && selectedParticipants.some((id) => id !== identityId) && !manualResponse && (
+        <label className="checkin-attestation"><input type="checkbox" checked={organizerAttestation} onChange={(event) => setOrganizerAttestation(event.target.checked)} /><span><strong>Подтверждаю как организатор</strong><small>Отмеченные участники получат посещение этой точки.</small></span></label>
       )}
 
       {manualResponse && (

--- a/apps/pwa/src/features/checkins/CheckInPanel.tsx
+++ b/apps/pwa/src/features/checkins/CheckInPanel.tsx
@@ -73,7 +73,7 @@ export function CheckInPanel({
   nearbyPoints?: NearbyPoint[]
   presentation?: 'card' | 'map-sheet'
   onPendingChange?: (count: number) => void
-  onAttentionChange?: (state: { count: number; key: string }) => void
+  onAttentionChange?: (state: { count: number; key: string; actionKey: string }) => void
 }) {
   const [nearby, setNearby] = useState<NearbyPoint[]>([])
   const [selectedPointId, setSelectedPointId] = useState('')
@@ -199,7 +199,7 @@ export function CheckInPanel({
 
   useEffect(() => {
     onAttentionChange?.(attention)
-  }, [attention.count, attention.key, onAttentionChange])
+  }, [attention.actionKey, attention.count, attention.key, onAttentionChange])
 
   const refreshLocal = useCallback(async () => {
     const next = await getCheckInLocalState(identityId, raid.id)

--- a/apps/pwa/src/features/checkins/CheckInPanel.tsx
+++ b/apps/pwa/src/features/checkins/CheckInPanel.tsx
@@ -19,6 +19,7 @@ import { loadCheckInExtras } from './refresh'
 import {
   activeParticipantSelection,
   checkInAttentionState,
+  participantSelectionAfterPresenceRefresh,
   participantSelectionKey,
   selectCheckInPrimary,
 } from './state'
@@ -92,6 +93,7 @@ export function CheckInPanel({
   const senderTabId = useRef(tabId()).current
   const actionKeys = useRef(new Map<string, string>())
   const manualParticipantChoices = useRef(new Map<string, boolean>())
+  const restoredManualAttemptKey = useRef<string | null>(null)
   const replaying = useRef(false)
   const replayRequested = useRef(false)
   const { setUnsyncedCheckInWork } = useRecordingRuntime()
@@ -104,6 +106,8 @@ export function CheckInPanel({
     ({ fallbackSubmission }) => fallbackSubmission?.status !== 'submitted',
   ) ?? null
   const manualResponse = manualAttempt?.response as CheckInResponse | null
+  const manualAttemptOperationId = manualAttempt?.operationId ?? null
+  const manualAttemptRestoreKey = manualAttempt ? `${identityId}:${manualAttempt.operationId}` : null
   const reservedFallback = manualAttempt?.fallbackSubmission ?? null
   const fallbackMedia = local?.media.find((draft) =>
     draft.status === 'accepted' && draft.purpose === 'fallback' &&
@@ -148,13 +152,24 @@ export function CheckInPanel({
   }, [activeParticipantIds, identityId])
 
   useEffect(() => {
-    if (!manualAttempt) return
+    if (!manualAttempt) {
+      const hadManualAttempt = restoredManualAttemptKey.current !== null
+      restoredManualAttemptKey.current = null
+      if (hadManualAttempt) {
+        manualParticipantChoices.current.clear()
+        setSelectedParticipants([identityId])
+      }
+      return
+    }
+    if (restoredManualAttemptKey.current === manualAttemptRestoreKey) return
+    restoredManualAttemptKey.current = manualAttemptRestoreKey
+    manualParticipantChoices.current.clear()
     setSelectedParticipants(activeParticipantSelection(
       identityId,
       manualAttempt.presentParticipantIds,
       activeParticipantIds,
     ))
-  }, [activeParticipantIds, identityId, manualAttempt])
+  }, [activeParticipantIds, identityId, manualAttempt, manualAttemptRestoreKey])
 
   useEffect(() => {
     if (!viewerIsOrganizer || raid.state !== 'active' || !selectedPointId || !navigator.onLine) return
@@ -167,13 +182,14 @@ export function CheckInPanel({
           .filter(({ id, status }) => status === 'nearby' && activeParticipantIds.has(id))
           .map(({ id }) => id)
         setNearbyParticipantIds(nearbyIds)
-        const manualIds = Array.from(manualParticipantChoices.current)
-          .filter(([, selected]) => selected)
-          .map(([id]) => id)
-        const suggestedIds = nearbyIds.filter(
-          (id) => id !== identityId && !manualParticipantChoices.current.has(id),
-        )
-        setSelectedParticipants(Array.from(new Set([identityId, ...manualIds, ...suggestedIds])))
+        setSelectedParticipants((current) => participantSelectionAfterPresenceRefresh({
+          identityId,
+          selectedParticipantIds: current,
+          nearbyParticipantIds: nearbyIds,
+          manualParticipantChoices: manualParticipantChoices.current,
+          activeParticipantIds,
+          freezeSuggestions: Boolean(manualAttemptOperationId),
+        }))
       } catch {
         // Manual participant selection remains available when live presence cannot refresh.
       }
@@ -184,7 +200,15 @@ export function CheckInPanel({
       active = false
       window.clearInterval(timer)
     }
-  }, [activeParticipantIds, identityId, raid.id, raid.state, selectedPointId, viewerIsOrganizer])
+  }, [
+    activeParticipantIds,
+    identityId,
+    manualAttemptOperationId,
+    raid.id,
+    raid.state,
+    selectedPointId,
+    viewerIsOrganizer,
+  ])
 
   useEffect(() => {
     onPendingChange?.(local?.unsynced ?? 0)

--- a/apps/pwa/src/features/checkins/CheckInPanel.tsx
+++ b/apps/pwa/src/features/checkins/CheckInPanel.tsx
@@ -86,6 +86,7 @@ export function CheckInPanel({
   const actionKeys = useRef(new Map<string, string>())
   const autoSuggestedParticipants = useRef(new Set<string>())
   const replaying = useRef(false)
+  const replayRequested = useRef(false)
   const { setUnsyncedCheckInWork } = useRecordingRuntime()
   const viewerIsOrganizer = raid.organizerUserId === identityId
   const participants = useMemo(() => activeParticipants(raid), [raid])
@@ -170,25 +171,32 @@ export function CheckInPanel({
   }, [raid.id])
 
   const flush = useCallback(async () => {
-    if (replaying.current || !canMutate || !navigator.onLine) return
+    if (!canMutate || !navigator.onLine) return
+    if (replaying.current) {
+      replayRequested.current = true
+      return
+    }
     replaying.current = true
     try {
-      for (let index = 0; index < 4; index += 1) {
-        const result = await replayOneCheckInOrMedia({
-          identityId,
-          raidId: raid.id,
-          holderTabId: senderTabId,
-          online: navigator.onLine,
-        })
-        if (result.kind === 'idle' || result.kind === 'retryable' || result.kind === 'fence_lost') break
-        if (result.kind === 'terminal') {
-          setMessage(`Сервер отклонил локальную операцию: ${result.code}.`)
-          break
+      do {
+        replayRequested.current = false
+        for (let index = 0; index < 4; index += 1) {
+          const result = await replayOneCheckInOrMedia({
+            identityId,
+            raidId: raid.id,
+            holderTabId: senderTabId,
+            online: navigator.onLine,
+          })
+          if (result.kind === 'idle' || result.kind === 'retryable' || result.kind === 'fence_lost') break
+          if (result.kind === 'terminal') {
+            setMessage(`Сервер отклонил локальную операцию: ${result.code}.`)
+            break
+          }
         }
-      }
-      await refreshLocal()
-      await refreshCanonicalExtras().catch(() => undefined)
-      await onCanonicalRefresh()
+        await refreshLocal()
+        await refreshCanonicalExtras().catch(() => undefined)
+        await onCanonicalRefresh()
+      } while (replayRequested.current && canMutate && navigator.onLine)
     } finally {
       replaying.current = false
     }

--- a/apps/pwa/src/features/checkins/CheckInPanel.tsx
+++ b/apps/pwa/src/features/checkins/CheckInPanel.tsx
@@ -16,7 +16,12 @@ import {
 import { getOneShotCoordinate, hasQuotaForMedia, sha256Hex, validateMediaFile } from './platform'
 import { replayOneCheckInOrMedia } from './replay'
 import { loadCheckInExtras } from './refresh'
-import { selectCheckInPrimary } from './state'
+import {
+  activeParticipantSelection,
+  checkInAttentionState,
+  participantSelectionKey,
+  selectCheckInPrimary,
+} from './state'
 import {
   enqueueCheckIn,
   getCheckInLocalState,
@@ -58,6 +63,7 @@ export function CheckInPanel({
   nearbyPoints,
   presentation = 'card',
   onPendingChange,
+  onAttentionChange,
 }: {
   identityId: string
   raid: RaidProjection
@@ -67,12 +73,13 @@ export function CheckInPanel({
   nearbyPoints?: NearbyPoint[]
   presentation?: 'card' | 'map-sheet'
   onPendingChange?: (count: number) => void
+  onAttentionChange?: (state: { count: number; key: string }) => void
 }) {
   const [nearby, setNearby] = useState<NearbyPoint[]>([])
   const [selectedPointId, setSelectedPointId] = useState('')
   const [selectedParticipants, setSelectedParticipants] = useState<string[]>([identityId])
   const [nearbyParticipantIds, setNearbyParticipantIds] = useState<string[]>([])
-  const [organizerAttestation, setOrganizerAttestation] = useState(false)
+  const [attestedParticipantKey, setAttestedParticipantKey] = useState<string | null>(null)
   const [claims, setClaims] = useState<CheckInClaim[]>([])
   const [fallbacks, setFallbacks] = useState<CheckInFallback[]>([])
   const [media, setMedia] = useState<RaidMedia[]>([])
@@ -90,6 +97,7 @@ export function CheckInPanel({
   const { setUnsyncedCheckInWork } = useRecordingRuntime()
   const viewerIsOrganizer = raid.organizerUserId === identityId
   const participants = useMemo(() => activeParticipants(raid), [raid])
+  const activeParticipantIds = useMemo(() => new Set(participants.map(({ id }) => id)), [participants])
   const pendingClaim = claims[0] ?? null
   const pendingFallback = fallbacks[0] ?? null
   const manualAttempt = local?.needsAction.find(
@@ -103,6 +111,18 @@ export function CheckInPanel({
   ) ?? null
   const canMutate = raid.state === 'active' && !staleProjection
   const effectiveNearby = nearbyPoints ?? nearby
+  const validSelectedParticipants = activeParticipantSelection(
+    identityId,
+    selectedParticipants,
+    activeParticipantIds,
+  )
+  const selectedParticipantKey = participantSelectionKey(validSelectedParticipants)
+  const organizerAttestation = attestedParticipantKey === selectedParticipantKey &&
+    validSelectedParticipants.some((id) => id !== identityId)
+
+  useEffect(() => {
+    setAttestedParticipantKey(null)
+  }, [selectedParticipantKey])
 
   useEffect(() => {
     if (!nearbyPoints) return
@@ -115,9 +135,26 @@ export function CheckInPanel({
   useEffect(() => {
     setSelectedParticipants([identityId])
     setNearbyParticipantIds([])
-    setOrganizerAttestation(false)
+    setAttestedParticipantKey(null)
     manualParticipantChoices.current.clear()
   }, [identityId, selectedPointId])
+
+  useEffect(() => {
+    for (const participantId of manualParticipantChoices.current.keys()) {
+      if (!activeParticipantIds.has(participantId)) manualParticipantChoices.current.delete(participantId)
+    }
+    setNearbyParticipantIds((current) => current.filter((id) => activeParticipantIds.has(id)))
+    setSelectedParticipants((current) => activeParticipantSelection(identityId, current, activeParticipantIds))
+  }, [activeParticipantIds, identityId])
+
+  useEffect(() => {
+    if (!manualAttempt) return
+    setSelectedParticipants(activeParticipantSelection(
+      identityId,
+      manualAttempt.presentParticipantIds,
+      activeParticipantIds,
+    ))
+  }, [activeParticipantIds, identityId, manualAttempt])
 
   useEffect(() => {
     if (!viewerIsOrganizer || raid.state !== 'active' || !selectedPointId || !navigator.onLine) return
@@ -127,7 +164,7 @@ export function CheckInPanel({
         const response = await getRaidPointPresence(raid.id, selectedPointId)
         if (!active) return
         const nearbyIds = response.participants
-          .filter(({ status }) => status === 'nearby')
+          .filter(({ id, status }) => status === 'nearby' && activeParticipantIds.has(id))
           .map(({ id }) => id)
         setNearbyParticipantIds(nearbyIds)
         const manualIds = Array.from(manualParticipantChoices.current)
@@ -147,11 +184,22 @@ export function CheckInPanel({
       active = false
       window.clearInterval(timer)
     }
-  }, [raid.id, raid.state, selectedPointId, viewerIsOrganizer])
+  }, [activeParticipantIds, identityId, raid.id, raid.state, selectedPointId, viewerIsOrganizer])
 
   useEffect(() => {
     onPendingChange?.(local?.unsynced ?? 0)
   }, [local?.unsynced, onPendingChange])
+
+  const attention = checkInAttentionState({
+    claimIds: claims.map(({ id }) => id),
+    fallbackIds: fallbacks.map(({ id }) => id),
+    manualOperationId: manualAttempt?.operationId ?? null,
+    unsynced: local?.unsynced ?? 0,
+  })
+
+  useEffect(() => {
+    onAttentionChange?.(attention)
+  }, [attention.count, attention.key, onAttentionChange])
 
   const refreshLocal = useCallback(async () => {
     const next = await getCheckInLocalState(identityId, raid.id)
@@ -207,6 +255,9 @@ export function CheckInPanel({
   useEffect(() => {
     void refreshLocal().then(() => void flush())
     void refreshCanonicalExtras().catch(() => undefined)
+    const refreshTimer = window.setInterval(() => {
+      void refreshCanonicalExtras().catch(() => undefined)
+    }, 5_000)
     const resume = () => {
       if (document.visibilityState === 'visible') {
         void refreshLocal().then(() => void flush())
@@ -219,6 +270,7 @@ export function CheckInPanel({
     document.addEventListener('visibilitychange', resume)
     return () => {
       setUnsyncedCheckInWork(0)
+      window.clearInterval(refreshTimer)
       window.removeEventListener('online', resume)
       window.removeEventListener('focus', resume)
       window.removeEventListener('pageshow', resume)
@@ -252,7 +304,7 @@ export function CheckInPanel({
       const record = await enqueueCheckIn(identityId, raid.kabandaId, raid.id, {
         pointSnapshotId: selectedPointId,
         evidence,
-        presentParticipantIds: Array.from(new Set([identityId, ...selectedParticipants])),
+        presentParticipantIds: validSelectedParticipants,
         organizerAttestation: viewerIsOrganizer && organizerAttestation,
       })
       if (!record) throw new Error('IDENTITY_CHANGED')
@@ -345,7 +397,7 @@ export function CheckInPanel({
         attemptId: manualResponse.attemptId,
         mediaId: fallbackMedia.mediaId,
         verifierUserId: selectedVerifierId,
-        presentParticipantIds: Array.from(new Set([identityId, ...selectedParticipants])),
+        presentParticipantIds: validSelectedParticipants,
         reason: fallbackReason.trim().slice(0, 240),
       })
       if (!submission) throw new Error('FALLBACK_ATTEMPT_MISSING')
@@ -422,16 +474,16 @@ export function CheckInPanel({
 
       {(selectedPointId || manualResponse) && viewerIsOrganizer && (
         <fieldset className="checkin-participants"><legend>Кто остановился у точки</legend>{participants.map((participant) => (
-          <label key={participant.id}><input type="checkbox" disabled={participant.id === identityId} checked={participant.id === identityId || selectedParticipants.includes(participant.id)} onChange={() => toggleParticipant(participant.id)} /><span>{participant.displayName}{participant.id === identityId ? ' · вы' : nearbyParticipantIds.includes(participant.id) ? ' · рядом автоматически' : ''}</span></label>
+          <label key={participant.id}><input type="checkbox" disabled={participant.id === identityId} checked={participant.id === identityId || validSelectedParticipants.includes(participant.id)} onChange={() => toggleParticipant(participant.id)} /><span>{participant.displayName}{participant.id === identityId ? ' · вы' : nearbyParticipantIds.includes(participant.id) ? ' · рядом автоматически' : ''}</span></label>
         ))}<small>Тех, чья свежая геопозиция попала в радиус 50 м, приложение отметило само. Остальных организатор может добавить вручную.</small></fieldset>
       )}
 
-      {!viewerIsOrganizer && selectedParticipants.some((id) => id !== identityId) && !manualResponse && (
+      {!viewerIsOrganizer && validSelectedParticipants.some((id) => id !== identityId) && !manualResponse && (
         <p className="kb-muted">Выбранные участники получат личный claim. Credit появится только после их подтверждения.</p>
       )}
 
-      {viewerIsOrganizer && selectedParticipants.some((id) => id !== identityId) && !manualResponse && (
-        <label className="checkin-attestation"><input type="checkbox" checked={organizerAttestation} onChange={(event) => setOrganizerAttestation(event.target.checked)} /><span><strong>Подтверждаю как организатор</strong><small>Отмеченные участники получат посещение этой точки.</small></span></label>
+      {viewerIsOrganizer && validSelectedParticipants.some((id) => id !== identityId) && !manualResponse && (
+        <label className="checkin-attestation"><input type="checkbox" checked={organizerAttestation} onChange={(event) => setAttestedParticipantKey(event.target.checked ? selectedParticipantKey : null)} /><span><strong>Подтверждаю как организатор</strong><small>Подтверждение действует только для этого состава. При изменении списка его нужно поставить заново.</small></span></label>
       )}
 
       {manualResponse && (

--- a/apps/pwa/src/features/checkins/state.test.ts
+++ b/apps/pwa/src/features/checkins/state.test.ts
@@ -59,6 +59,16 @@ describe('check-in attention outside point proximity', () => {
     })).toEqual({
       count: 3,
       key: 'claim:claim-a|fallback:fallback-b|manual:operation-c',
+      actionKey: 'claim:claim-a|fallback:fallback-b|manual:operation-c',
     })
+  })
+
+  it('keeps offline work visible without reopening a sheet the user collapsed', () => {
+    expect(checkInAttentionState({
+      claimIds: [],
+      fallbackIds: [],
+      manualOperationId: null,
+      unsynced: 2,
+    })).toEqual({ count: 2, key: 'unsynced:2', actionKey: '' })
   })
 })

--- a/apps/pwa/src/features/checkins/state.test.ts
+++ b/apps/pwa/src/features/checkins/state.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   activeParticipantSelection,
   checkInAttentionState,
+  participantSelectionAfterPresenceRefresh,
   participantSelectionKey,
   selectCheckInPrimary,
 } from './state'
@@ -46,6 +47,46 @@ describe('organizer participant attestation', () => {
       ['organizer', 'still-here', 'departed'],
       new Set(['organizer', 'still-here']),
     )).toEqual(['organizer', 'still-here'])
+  })
+
+  it('freezes a manual fallback participant set across later presence refreshes', () => {
+    expect(participantSelectionAfterPresenceRefresh({
+      identityId: 'organizer',
+      selectedParticipantIds: ['organizer', 'original-rider'],
+      nearbyParticipantIds: ['newly-nearby-rider'],
+      manualParticipantChoices: new Map(),
+      activeParticipantIds: new Set(['organizer', 'original-rider', 'newly-nearby-rider']),
+      freezeSuggestions: true,
+    })).toEqual(['organizer', 'original-rider'])
+
+    expect(participantSelectionAfterPresenceRefresh({
+      identityId: 'organizer',
+      selectedParticipantIds: ['organizer', 'original-rider'],
+      nearbyParticipantIds: ['original-rider'],
+      manualParticipantChoices: new Map(),
+      activeParticipantIds: new Set(['organizer', 'newly-nearby-rider']),
+      freezeSuggestions: true,
+    })).toEqual(['organizer'])
+  })
+
+  it('keeps applying live suggestions before a manual fallback exists', () => {
+    expect(participantSelectionAfterPresenceRefresh({
+      identityId: 'organizer',
+      selectedParticipantIds: ['organizer', 'previously-nearby'],
+      nearbyParticipantIds: ['currently-nearby', 'manually-excluded'],
+      manualParticipantChoices: new Map([
+        ['manual-rider', true],
+        ['manually-excluded', false],
+      ]),
+      activeParticipantIds: new Set([
+        'organizer',
+        'previously-nearby',
+        'currently-nearby',
+        'manual-rider',
+        'manually-excluded',
+      ]),
+      freezeSuggestions: false,
+    })).toEqual(['organizer', 'manual-rider', 'currently-nearby'])
   })
 })
 

--- a/apps/pwa/src/features/checkins/state.test.ts
+++ b/apps/pwa/src/features/checkins/state.test.ts
@@ -4,6 +4,7 @@ import {
   checkInAttentionState,
   participantSelectionAfterPresenceRefresh,
   participantSelectionKey,
+  participantSelectionScopeKey,
   selectCheckInPrimary,
 } from './state'
 
@@ -39,6 +40,15 @@ describe('organizer participant attestation', () => {
   it('uses a stable key for the exact selected participant set', () => {
     expect(participantSelectionKey(['user-b', 'user-a', 'user-b'])).toBe('user-a:user-b')
     expect(participantSelectionKey(['user-a'])).not.toBe(participantSelectionKey(['user-a', 'user-b']))
+  })
+
+  it('keeps one manual selection scope when the nearby point changes or disappears', () => {
+    expect(participantSelectionScopeKey('organizer', 'point-a', 'operation-a')).toBe(
+      participantSelectionScopeKey('organizer', '', 'operation-a'),
+    )
+    expect(participantSelectionScopeKey('organizer', 'point-a', null)).not.toBe(
+      participantSelectionScopeKey('organizer', 'point-b', null),
+    )
   })
 
   it('drops departed participants before a check-in payload is built', () => {

--- a/apps/pwa/src/features/checkins/state.test.ts
+++ b/apps/pwa/src/features/checkins/state.test.ts
@@ -7,7 +7,7 @@ const base = {
   hasManualAttempt: false,
   hasAcceptedFallbackMedia: false,
   hasOtherVerifier: false,
-  viewerIsNavigator: true,
+  viewerCanCoordinate: true,
   hasSelectedPoint: false,
 }
 
@@ -22,9 +22,9 @@ describe('mobile check-in primary action', () => {
     expect(selectCheckInPrimary({ ...base, hasManualAttempt: true, hasAcceptedFallbackMedia: true, hasOtherVerifier: true })).toBe('submit_fallback')
   })
 
-  it('keeps navigator flow to exactly locate or check-in', () => {
+  it('keeps organizer flow to exactly locate or check-in', () => {
     expect(selectCheckInPrimary(base)).toBe('locate')
     expect(selectCheckInPrimary({ ...base, hasSelectedPoint: true })).toBe('check_in')
-    expect(selectCheckInPrimary({ ...base, viewerIsNavigator: false })).toBeNull()
+    expect(selectCheckInPrimary({ ...base, viewerCanCoordinate: false })).toBeNull()
   })
 })

--- a/apps/pwa/src/features/checkins/state.test.ts
+++ b/apps/pwa/src/features/checkins/state.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { selectCheckInPrimary } from './state'
+import {
+  activeParticipantSelection,
+  checkInAttentionState,
+  participantSelectionKey,
+  selectCheckInPrimary,
+} from './state'
 
 const base = {
   hasPendingClaim: false,
@@ -26,5 +31,34 @@ describe('mobile check-in primary action', () => {
     expect(selectCheckInPrimary(base)).toBe('locate')
     expect(selectCheckInPrimary({ ...base, hasSelectedPoint: true })).toBe('check_in')
     expect(selectCheckInPrimary({ ...base, viewerCanCoordinate: false })).toBeNull()
+  })
+})
+
+describe('organizer participant attestation', () => {
+  it('uses a stable key for the exact selected participant set', () => {
+    expect(participantSelectionKey(['user-b', 'user-a', 'user-b'])).toBe('user-a:user-b')
+    expect(participantSelectionKey(['user-a'])).not.toBe(participantSelectionKey(['user-a', 'user-b']))
+  })
+
+  it('drops departed participants before a check-in payload is built', () => {
+    expect(activeParticipantSelection(
+      'organizer',
+      ['organizer', 'still-here', 'departed'],
+      new Set(['organizer', 'still-here']),
+    )).toEqual(['organizer', 'still-here'])
+  })
+})
+
+describe('check-in attention outside point proximity', () => {
+  it('keeps server claims, fallback verification, and local needs-action discoverable', () => {
+    expect(checkInAttentionState({
+      claimIds: ['claim-a'],
+      fallbackIds: ['fallback-b'],
+      manualOperationId: 'operation-c',
+      unsynced: 0,
+    })).toEqual({
+      count: 3,
+      key: 'claim:claim-a|fallback:fallback-b|manual:operation-c',
+    })
   })
 })

--- a/apps/pwa/src/features/checkins/state.ts
+++ b/apps/pwa/src/features/checkins/state.ts
@@ -19,17 +19,18 @@ export function checkInAttentionState(input: {
   fallbackIds: readonly string[]
   manualOperationId: string | null
   unsynced: number
-}): { count: number; key: string } {
-  const keys = [
+}): { count: number; key: string; actionKey: string } {
+  const actionKeys = [
     ...input.claimIds.map((id) => `claim:${id}`),
     ...input.fallbackIds.map((id) => `fallback:${id}`),
     ...(input.manualOperationId ? [`manual:${input.manualOperationId}`] : []),
-    ...(input.unsynced > 0 ? [`unsynced:${input.unsynced}`] : []),
   ]
+  const keys = [...actionKeys, ...(input.unsynced > 0 ? [`unsynced:${input.unsynced}`] : [])]
   return {
     count: input.claimIds.length + input.fallbackIds.length +
       (input.manualOperationId ? 1 : 0) + input.unsynced,
     key: keys.join('|'),
+    actionKey: actionKeys.join('|'),
   }
 }
 

--- a/apps/pwa/src/features/checkins/state.ts
+++ b/apps/pwa/src/features/checkins/state.ts
@@ -6,7 +6,7 @@ export function selectCheckInPrimary(input: {
   hasManualAttempt: boolean
   hasAcceptedFallbackMedia: boolean
   hasOtherVerifier: boolean
-  viewerIsNavigator: boolean
+  viewerCanCoordinate: boolean
   hasSelectedPoint: boolean
 }): CheckInPrimaryKind {
   if (input.hasPendingClaim) return 'claim'
@@ -14,6 +14,6 @@ export function selectCheckInPrimary(input: {
   if (input.hasManualAttempt) {
     return input.hasAcceptedFallbackMedia && input.hasOtherVerifier ? 'submit_fallback' : null
   }
-  if (!input.viewerIsNavigator) return null
+  if (!input.viewerCanCoordinate) return null
   return input.hasSelectedPoint ? 'check_in' : 'locate'
 }

--- a/apps/pwa/src/features/checkins/state.ts
+++ b/apps/pwa/src/features/checkins/state.ts
@@ -1,5 +1,38 @@
 export type CheckInPrimaryKind = 'claim' | 'verify_fallback' | 'submit_fallback' | 'locate' | 'check_in' | null
 
+export function participantSelectionKey(participantIds: readonly string[]): string {
+  return Array.from(new Set(participantIds)).sort().join(':')
+}
+
+export function activeParticipantSelection(
+  identityId: string,
+  selectedParticipantIds: readonly string[],
+  activeParticipantIds: ReadonlySet<string>,
+): string[] {
+  const selected = selectedParticipantIds.filter((id) => activeParticipantIds.has(id))
+  if (activeParticipantIds.has(identityId)) selected.push(identityId)
+  return Array.from(new Set(selected))
+}
+
+export function checkInAttentionState(input: {
+  claimIds: readonly string[]
+  fallbackIds: readonly string[]
+  manualOperationId: string | null
+  unsynced: number
+}): { count: number; key: string } {
+  const keys = [
+    ...input.claimIds.map((id) => `claim:${id}`),
+    ...input.fallbackIds.map((id) => `fallback:${id}`),
+    ...(input.manualOperationId ? [`manual:${input.manualOperationId}`] : []),
+    ...(input.unsynced > 0 ? [`unsynced:${input.unsynced}`] : []),
+  ]
+  return {
+    count: input.claimIds.length + input.fallbackIds.length +
+      (input.manualOperationId ? 1 : 0) + input.unsynced,
+    key: keys.join('|'),
+  }
+}
+
 export function selectCheckInPrimary(input: {
   hasPendingClaim: boolean
   hasPendingFallback: boolean

--- a/apps/pwa/src/features/checkins/state.ts
+++ b/apps/pwa/src/features/checkins/state.ts
@@ -4,6 +4,16 @@ export function participantSelectionKey(participantIds: readonly string[]): stri
   return Array.from(new Set(participantIds)).sort().join(':')
 }
 
+export function participantSelectionScopeKey(
+  identityId: string,
+  selectedPointId: string,
+  manualOperationId: string | null,
+): string {
+  return manualOperationId
+    ? `manual:${identityId}:${manualOperationId}`
+    : `point:${identityId}:${selectedPointId}`
+}
+
 export function activeParticipantSelection(
   identityId: string,
   selectedParticipantIds: readonly string[],

--- a/apps/pwa/src/features/checkins/state.ts
+++ b/apps/pwa/src/features/checkins/state.ts
@@ -14,6 +14,36 @@ export function activeParticipantSelection(
   return Array.from(new Set(selected))
 }
 
+export function participantSelectionAfterPresenceRefresh(input: {
+  identityId: string
+  selectedParticipantIds: readonly string[]
+  nearbyParticipantIds: readonly string[]
+  manualParticipantChoices: ReadonlyMap<string, boolean>
+  activeParticipantIds: ReadonlySet<string>
+  freezeSuggestions: boolean
+}): string[] {
+  const current = activeParticipantSelection(
+    input.identityId,
+    input.selectedParticipantIds,
+    input.activeParticipantIds,
+  )
+  if (input.freezeSuggestions) return current
+
+  const manuallySelected = Array.from(input.manualParticipantChoices)
+    .filter(([id, selected]) => selected && input.activeParticipantIds.has(id))
+    .map(([id]) => id)
+  const suggested = input.nearbyParticipantIds.filter(
+    (id) => id !== input.identityId &&
+      input.activeParticipantIds.has(id) &&
+      !input.manualParticipantChoices.has(id),
+  )
+  return activeParticipantSelection(
+    input.identityId,
+    [input.identityId, ...manuallySelected, ...suggested],
+    input.activeParticipantIds,
+  )
+}
+
 export function checkInAttentionState(input: {
   claimIds: readonly string[]
   fallbackIds: readonly string[]

--- a/apps/pwa/src/features/checkins/types.ts
+++ b/apps/pwa/src/features/checkins/types.ts
@@ -1,6 +1,6 @@
 export interface CheckInPolicy {
   version: 'v1'
-  radiusMeters: 75
+  radiusMeters: 50
   maxAgeSeconds: 60
   maxAccuracyMeters: 50
 }

--- a/apps/pwa/src/features/raids/RaidApp.tsx
+++ b/apps/pwa/src/features/raids/RaidApp.tsx
@@ -500,6 +500,8 @@ function RaidDetailPage({
         onServerPrimary={() => void handlePrimary()}
         onCanonicalRefresh={resource.refresh}
         onApplyRaid={resource.applyRaid}
+        pageMessage={message}
+        resourceError={resource.error}
       />
     </RaidShell>
   }

--- a/apps/pwa/src/features/raids/RaidApp.tsx
+++ b/apps/pwa/src/features/raids/RaidApp.tsx
@@ -56,6 +56,7 @@ import type {
   ReadinessStatus,
 } from './types'
 import { ActiveRaidPanel } from './recording/ActiveRaidPanel'
+import { RaidPresenceGate } from './RaidPresenceGate'
 import { FinalizationPanel } from '../results/FinalizationPanel'
 import { ResultPanel } from '../results/ResultPanel'
 import { leaveRaid } from '../results/api'
@@ -316,6 +317,7 @@ function RaidDetailPage({
   } | null>(null)
   const [navigatorId, setNavigatorId] = useState('')
   const [handoffNavigatorId, setHandoffNavigatorId] = useState('')
+  const [presenceReady, setPresenceReady] = useState(false)
   const operationKeys = useRef(new Map<string, string>())
   const pendingReadiness = useRef<{
     key: string
@@ -457,7 +459,7 @@ function RaidDetailPage({
     if (primary.kind === 'refresh') return resource.refresh()
     if (primary.kind === 'readiness') return runReadiness()
     if (primary.kind === 'navigate') return
-    if (primary.command === 'start' && !window.confirm('Начать один канонический рейд сейчас?')) return
+    if (primary.command === 'start' && !window.confirm('Все здесь — начинаем рейд?')) return
     await applyCommand(primary.command)
   }
 
@@ -485,6 +487,22 @@ function RaidDetailPage({
         ? 'warn'
         : 'pass'
       : 'unknown'
+
+  if (raid.state === 'active' || raid.state === 'paused') {
+    return <RaidShell active>
+      <ActiveRaidPanel
+        backHref={`${appPath('app')}?kabanda=${encodeURIComponent(raid.kabandaId)}&tab=raids`}
+        identityId={user.id}
+        raid={raid}
+        staleProjection={resource.stale}
+        serverPrimary={primary}
+        operationPending={Boolean(operation)}
+        onServerPrimary={() => void handlePrimary()}
+        onCanonicalRefresh={resource.refresh}
+        onApplyRaid={resource.applyRaid}
+      />
+    </RaidShell>
+  }
 
   return (
     <RaidShell>
@@ -518,28 +536,18 @@ function RaidDetailPage({
         </section>
       )}
 
-      {(raid.state === 'draft' || raid.state === 'planned' || raid.state === 'lobby') && (viewerIsNavigator || raid.navigatorUserId) && (
+      {raid.state === 'lobby' && (raid.organizerUserId === user.id || viewerParticipant?.state === 'accepted' || viewerParticipant?.state === 'ready') && (
+        <RaidPresenceGate identityId={user.id} onReadyChange={setPresenceReady} raid={raid} stale={resource.stale} />
+      )}
+
+      {(raid.state === 'draft' || raid.state === 'planned' || raid.state === 'lobby') && viewerIsNavigator && (
         <section className="kb-card raid-readiness">
           <div className="kb-section-head"><div><p className="kb-kicker">Перед стартом</p><h2>Готов ли телефон?</h2></div><span className={`readiness-pill readiness-pill--${readinessStatus}`}>{readinessStatus}</span></div>
           <p className="kb-muted">Проверяем только измеримое. КАБАНДА не обещает запись при выключенном экране.</p>
           {readinessRows.length > 0 && <ul>{readinessRows.map((row) => <li key={row.id} data-status={row.status}><span aria-hidden="true">{statusIcon(row.status)}</span><div><strong>{row.label}</strong><small>{row.detail}</small></div></li>)}</ul>}
           {raid.navigatorBlockers.length ? <div className="kb-error"><strong>Сервер блокирует старт:</strong><ul>{raid.navigatorBlockers.map((blocker) => <li key={blocker}>{readinessCodeLabel(blocker)}</li>)}</ul></div> : null}
           {raid.navigatorWarnings.length ? <div className="kb-notice"><strong>Предупреждения:</strong><ul>{raid.navigatorWarnings.map((warning) => <li key={warning}>{readinessCodeLabel(warning)}</li>)}</ul></div> : null}
-          {!viewerIsNavigator && <p className="kb-notice">Проверку должен отправить {navigatorParticipant?.displayName ?? 'выбранный навигатор'} со своего устройства.</p>}
         </section>
-      )}
-
-      {(raid.state === 'active' || raid.state === 'paused') && (
-        <ActiveRaidPanel
-          identityId={user.id}
-          raid={raid}
-          staleProjection={resource.stale}
-          serverPrimary={primary}
-          operationPending={Boolean(operation)}
-          onServerPrimary={() => void handlePrimary()}
-          onCanonicalRefresh={resource.refresh}
-          onApplyRaid={resource.applyRaid}
-        />
       )}
 
       {raid.state === 'finalizing' && (
@@ -585,8 +593,8 @@ function RaidDetailPage({
         </section>
       )}
 
-      {primary && raid.state !== 'active' && raid.state !== 'paused' && raid.state !== 'finalizing' && (
-        <button className="kb-primary raid-primary raid-sticky" type="button" disabled={Boolean(operation) || (primary.kind === 'command' && primary.command === 'start' && !navigator.onLine)} onClick={handlePrimary}>{operation ? 'Подтверждаем…' : primary.label}</button>
+      {primary && raid.state !== 'finalizing' && (
+        <button className="kb-primary raid-primary raid-sticky" type="button" disabled={Boolean(operation) || (primary.kind === 'command' && primary.command === 'start' && (!navigator.onLine || !presenceReady))} onClick={handlePrimary}>{operation ? 'Подтверждаем…' : primary.kind === 'command' && primary.command === 'start' ? presenceReady ? 'Все здесь — начать рейд' : 'Ждём всю стаю' : primary.label}</button>
       )}
       {allowed.has('cancel') && !resource.stale && <button className="raid-cancel" type="button" disabled={operation === 'cancel'} onClick={() => window.confirm('Отменить рейд для всей команды?') && applyCommand('cancel')}>Отменить рейд</button>}
       {allowed.has('leave') && !resource.stale && <button className="raid-cancel" type="button" disabled={operation === 'leave' || !navigator.onLine} onClick={leaveCurrentRaid}>{operation === 'leave' ? 'Выходим…' : 'Выйти из рейда'}</button>}
@@ -598,8 +606,8 @@ function ParticipantList({ participants, navigatorId }: { participants: RaidPart
   return <ul className="raid-participants">{participants.map((participant) => <li key={participant.id}><span className="raid-avatar">{participant.displayName.slice(0, 1).toUpperCase()}</span><div><strong>{participant.displayName}</strong><small>{participant.id === navigatorId ? 'Навигатор · ' : ''}{participantStateLabel(participant.state)}</small></div><span className={`participant-state participant-state--${participant.state}`}>{participantStateLabel(participant.state)}</span></li>)}</ul>
 }
 
-function RaidShell({ children }: { children: ReactNode }) {
-  return <main className="kb-shell raid-shell"><a className="kb-brand" href={appPath('app')} aria-label="КАБАНДА — на главную"><img src={appPath('brand/kabanda-logo-reference.png')} alt="" /><strong>КАБАНДА</strong></a>{children}</main>
+function RaidShell({ children, active = false }: { children: ReactNode; active?: boolean }) {
+  return <main className={`kb-shell raid-shell${active ? ' raid-shell--active' : ''}`}><a className="kb-brand" href={appPath('app')} aria-label="КАБАНДА — на главную"><img src={appPath('brand/kabanda-logo-reference.png')} alt="" /><strong>КАБАНДА</strong></a>{children}</main>
 }
 
 function EmptyState({ title, detail }: { title: string; detail: string }) {

--- a/apps/pwa/src/features/raids/RaidPresenceGate.tsx
+++ b/apps/pwa/src/features/raids/RaidPresenceGate.tsx
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useState } from 'react'
+import { getOneShotCoordinate } from '../checkins/platform'
+import { getRaidPresence, reportRaidPresence, setManualRaidPresence } from './api'
+import type { RaidPresenceRoster, RaidProjection } from './types'
+
+export function RaidPresenceGate({
+  identityId,
+  raid,
+  stale,
+  onReadyChange,
+}: {
+  identityId: string
+  raid: RaidProjection
+  stale: boolean
+  onReadyChange: (ready: boolean) => void
+}) {
+  const [roster, setRoster] = useState<RaidPresenceRoster | null>(null)
+  const [status, setStatus] = useState<'locating' | 'ready' | 'blocked' | 'offline'>(() => navigator.onLine ? 'locating' : 'offline')
+  const [manualBusy, setManualBusy] = useState<string | null>(null)
+  const viewerIsOrganizer = raid.organizerUserId === identityId
+
+  const refreshRoster = useCallback(async () => {
+    if (!navigator.onLine || document.visibilityState !== 'visible') return
+    try {
+      const next = await getRaidPresence(raid.id)
+      setRoster(next)
+    } catch {
+      // The fresh location submission below remains the primary recovery path.
+    }
+  }, [raid.id])
+
+  const report = useCallback(async () => {
+    if (!navigator.onLine || stale || document.visibilityState !== 'visible') {
+      if (!navigator.onLine) setStatus('offline')
+      return
+    }
+    try {
+      const coordinate = await getOneShotCoordinate(10_000)
+      const next = await reportRaidPresence(raid.id, coordinate)
+      setRoster(next)
+      setStatus('ready')
+    } catch {
+      setStatus('blocked')
+      await refreshRoster()
+    }
+  }, [raid.id, refreshRoster, stale])
+
+  useEffect(() => {
+    void report()
+    const reportTimer = window.setInterval(() => void report(), 12_000)
+    const rosterTimer = window.setInterval(() => void refreshRoster(), 5_000)
+    const resume = () => {
+      void report()
+      void refreshRoster()
+    }
+    window.addEventListener('online', resume)
+    window.addEventListener('focus', resume)
+    document.addEventListener('visibilitychange', resume)
+    return () => {
+      window.clearInterval(reportTimer)
+      window.clearInterval(rosterTimer)
+      window.removeEventListener('online', resume)
+      window.removeEventListener('focus', resume)
+      document.removeEventListener('visibilitychange', resume)
+    }
+  }, [refreshRoster, report])
+
+  useEffect(() => {
+    onReadyChange(Boolean(roster?.allReady))
+  }, [onReadyChange, roster?.allReady])
+
+  const toggleManual = async (participantId: string, present: boolean) => {
+    if (manualBusy || stale || !navigator.onLine) return
+    setManualBusy(participantId)
+    try {
+      setRoster(await setManualRaidPresence(raid.id, participantId, present))
+    } finally {
+      setManualBusy(null)
+    }
+  }
+
+  return <section className="kb-card raid-presence-gate" aria-label="Сбор стаи перед стартом">
+    <div className="kb-section-head">
+      <div><p className="kb-kicker">Перед стартом</p><h2>Все на месте?</h2></div>
+      <span className={`raid-presence-gate__summary${roster?.allReady ? ' is-ready' : ''}`}>{roster?.allReady ? 'Все готовы' : `${roster?.participants.filter(({ status: value }) => value !== 'waiting').length ?? 0}/${roster?.participants.length ?? raid.participants.filter(({ state }) => state === 'accepted' || state === 'ready').length}`}</span>
+    </div>
+    <p className="kb-muted">Статус обновляется автоматически, пока приложение открыто. Радиус встречи — 50 метров от организатора.</p>
+    {status === 'blocked' && <p className="kb-notice" role="status">Не получили свежую геолокацию. Разрешите доступ или попросите организатора отметить вас вручную.</p>}
+    {status === 'offline' && <p className="kb-notice" role="status">Нет сети. Подтверждение присутствия возобновится автоматически.</p>}
+    {!roster && status === 'locating' && <p aria-busy="true">Определяем, кто уже приехал…</p>}
+    {roster && <ul className="raid-presence-list">{roster.participants.map((participant) => <li key={participant.id} data-status={participant.status}>
+      <span className="raid-avatar">{participant.displayName.slice(0, 1).toUpperCase()}</span>
+      <span><strong>{participant.displayName}{participant.id === identityId ? ' · вы' : ''}</strong><small>{participant.status === 'nearby' ? 'Рядом · готов' : participant.status === 'manual' ? 'Добавлен организатором' : 'Ждём геолокацию'}</small></span>
+      <i aria-label={participant.status === 'waiting' ? 'Не готов' : 'Готов'}>{participant.status === 'waiting' ? '○' : '✓'}</i>
+      {viewerIsOrganizer && participant.id !== identityId && participant.status !== 'nearby' && <button disabled={manualBusy === participant.id || stale || !navigator.onLine} onClick={() => void toggleManual(participant.id, participant.status !== 'manual')} type="button">{participant.status === 'manual' ? 'Отменить' : 'Добавить вручную'}</button>}
+    </li>)}</ul>}
+    {!viewerIsOrganizer && <p className="raid-presence-gate__hint">Когда вся стая соберётся, организатор запустит рейд.</p>}
+  </section>
+}

--- a/apps/pwa/src/features/raids/api.ts
+++ b/apps/pwa/src/features/raids/api.ts
@@ -5,6 +5,7 @@ import type {
   RaidProjection,
   RouteBatchInput,
   RouteBatchResponse,
+  RouteTrackProjection,
   RouteLeaseResponse,
   ReadinessReportInput,
   ReadinessReportResponse,
@@ -56,6 +57,13 @@ export function sendRouteBatch(
       body: JSON.stringify(input),
     },
   )
+}
+
+export async function getRouteTrack(raidId: string): Promise<RouteTrackProjection> {
+  const response = await requestJson<{ track: RouteTrackProjection }>(
+    `/api/raids/${encodeURIComponent(raidId)}/route/track`,
+  )
+  return response.track
 }
 
 export async function listActionableRaids(kabandaId: string): Promise<RaidProjection[]> {

--- a/apps/pwa/src/features/raids/api.ts
+++ b/apps/pwa/src/features/raids/api.ts
@@ -2,6 +2,9 @@ import { requestJson } from '../../lib/http'
 import type {
   CreateRaidInput,
   RaidAllowedAction,
+  RaidMapPoint,
+  RaidPointPresenceRoster,
+  RaidPresenceRoster,
   RaidProjection,
   RouteBatchInput,
   RouteBatchResponse,
@@ -64,6 +67,48 @@ export async function getRouteTrack(raidId: string): Promise<RouteTrackProjectio
     `/api/raids/${encodeURIComponent(raidId)}/route/track`,
   )
   return response.track
+}
+
+export async function getRaidMapPoints(raidId: string): Promise<RaidMapPoint[]> {
+  const response = await requestJson<{ points: RaidMapPoint[] }>(
+    `/api/raids/${encodeURIComponent(raidId)}/map-points`,
+  )
+  return response.points
+}
+
+export function getRaidPresence(raidId: string): Promise<RaidPresenceRoster> {
+  return requestJson<RaidPresenceRoster>(`/api/raids/${encodeURIComponent(raidId)}/presence`)
+}
+
+export function reportRaidPresence(
+  raidId: string,
+  evidence: { latitude: number; longitude: number; capturedAt: string; accuracyMeters: number },
+): Promise<RaidPresenceRoster> {
+  return requestJson<RaidPresenceRoster>(`/api/raids/${encodeURIComponent(raidId)}/presence/me`, {
+    method: 'PUT',
+    body: JSON.stringify(evidence),
+  })
+}
+
+export function setManualRaidPresence(
+  raidId: string,
+  participantId: string,
+  present: boolean,
+): Promise<RaidPresenceRoster> {
+  return requestJson<RaidPresenceRoster>(`/api/raids/${encodeURIComponent(raidId)}/presence/${encodeURIComponent(participantId)}/manual`, {
+    method: 'PUT',
+    body: JSON.stringify({ present }),
+  })
+}
+
+export function getRaidPointPresence(
+  raidId: string,
+  pointSnapshotId: string,
+): Promise<RaidPointPresenceRoster> {
+  const query = new URLSearchParams({ pointSnapshotId })
+  return requestJson<RaidPointPresenceRoster>(
+    `/api/raids/${encodeURIComponent(raidId)}/check-ins/presence?${query}`,
+  )
 }
 
 export async function listActionableRaids(kabandaId: string): Promise<RaidProjection[]> {

--- a/apps/pwa/src/features/raids/raids.css
+++ b/apps/pwa/src/features/raids/raids.css
@@ -763,6 +763,27 @@
 .raid-active-map__header small { display: block; color: #69716d; font-size: .72rem; font-weight: 680; }
 .raid-active-map__header strong { display: block; overflow: hidden; font-size: .98rem; text-overflow: ellipsis; white-space: nowrap; }
 
+.raid-active-map__notice {
+  position: absolute;
+  z-index: 23;
+  top: calc(max(12px, env(safe-area-inset-top)) + 76px);
+  right: 72px;
+  left: 12px;
+  display: grid;
+  gap: 8px;
+  width: min(488px, calc(100% - 84px));
+  margin: 0 auto;
+  border: 1px solid rgb(28 32 34 / 10%);
+  border-radius: 16px;
+  padding: 10px;
+  background: rgb(255 253 248 / 97%);
+  box-shadow: 0 8px 24px rgb(26 31 34 / 18%);
+  backdrop-filter: blur(14px);
+}
+
+.raid-active-map__notice p { margin: 0; }
+.raid-active-map__notice .route-recorder__secondary { min-height: 42px; }
+
 .raid-map-controls {
   position: absolute;
   z-index: 18;

--- a/apps/pwa/src/features/raids/raids.css
+++ b/apps/pwa/src/features/raids/raids.css
@@ -443,6 +443,57 @@
 .checkin-gallery figcaption { padding: .5rem; font-size: .75rem; color: var(--kb-muted); }
 .route-recorder__secondary { width: 100%; text-align: center; }
 
+.route-live-card {
+  position: relative;
+  min-height: 320px;
+  margin-top: 12px;
+  overflow: hidden;
+  border: 1px solid var(--kb-line);
+  border-radius: 18px;
+  background: #e6e8df;
+  box-shadow: 0 8px 26px rgb(35 42 53 / 10%);
+}
+.route-live-map { position: absolute; inset: 0; min-height: 320px; }
+.route-live-map__state {
+  position: absolute;
+  z-index: 6;
+  right: 12px;
+  bottom: 12px;
+  left: 12px;
+  width: fit-content;
+  max-width: calc(100% - 24px);
+  margin: 0 auto;
+  border: 1px solid rgb(35 42 53 / 10%);
+  border-radius: 999px;
+  padding: 8px 12px;
+  color: var(--kb-muted);
+  background: rgb(255 255 255 / 94%);
+  box-shadow: 0 4px 16px rgb(35 42 53 / 12%);
+  font-size: .78rem;
+  font-weight: 680;
+  text-align: center;
+  backdrop-filter: blur(12px);
+}
+.route-live-map__state--error { color: #9d3026; }
+.route-live-map__state--notice { color: #665321; }
+.route-live-map__rider {
+  display: block;
+  box-sizing: border-box;
+  width: 46px;
+  height: 46px;
+  transform: translate(-50%, -50%);
+  border: 2px solid rgb(255 255 255 / 96%);
+  border-radius: 50%;
+  background: #fff url('/brand/kabanda-logo-reference.png') center / 40px 40px no-repeat;
+  box-shadow: 0 5px 16px rgb(35 42 53 / 32%), 0 0 0 1px rgb(35 42 53 / 10%);
+  pointer-events: none;
+}
+
+@media (min-width: 700px) {
+  .route-live-card,
+  .route-live-map { min-height: 420px; }
+}
+
 .raid-auth,
 .raid-empty {
   width: min(100%, 540px);

--- a/apps/pwa/src/features/raids/raids.css
+++ b/apps/pwa/src/features/raids/raids.css
@@ -697,3 +697,264 @@
   .raid-shell > .kb-brand { margin-bottom: 18px; }
   .raid-hero { gap: 8px; }
 }
+
+/* Active raid is an immersive map task, separate from the planning shell. */
+.raid-shell--active {
+  width: 100%;
+  max-width: none;
+  padding: 0;
+}
+
+.raid-shell--active > .kb-brand { display: none; }
+
+.raid-active-map {
+  position: fixed;
+  z-index: 80;
+  inset: 0;
+  overflow: hidden;
+  color: #202426;
+  background: #e4e7df;
+}
+
+.route-live-map-shell,
+.raid-active-map .route-live-map {
+  position: absolute;
+  min-height: 0;
+  inset: 0;
+}
+
+.raid-active-map__header {
+  position: absolute;
+  z-index: 20;
+  top: max(12px, env(safe-area-inset-top));
+  right: 12px;
+  left: 12px;
+  display: grid;
+  grid-template-columns: 46px minmax(0, 1fr) 46px;
+  align-items: center;
+  gap: 9px;
+  width: min(560px, calc(100% - 24px));
+  margin: 0 auto;
+  border: 1px solid rgb(28 32 34 / 10%);
+  border-radius: 19px;
+  padding: 7px;
+  background: rgb(255 255 255 / 94%);
+  box-shadow: 0 8px 26px rgb(26 31 34 / 18%);
+  backdrop-filter: blur(14px);
+}
+
+.raid-active-map__header > a,
+.raid-active-map__header > button {
+  display: grid;
+  width: 46px;
+  height: 46px;
+  place-items: center;
+  border: 0;
+  border-radius: 14px;
+  color: #202426;
+  background: #f0f1ed;
+  font: inherit;
+  font-size: 1.2rem;
+  font-weight: 760;
+  text-decoration: none;
+}
+
+.raid-active-map__header > div { min-width: 0; }
+.raid-active-map__header small { display: block; color: #69716d; font-size: .72rem; font-weight: 680; }
+.raid-active-map__header strong { display: block; overflow: hidden; font-size: .98rem; text-overflow: ellipsis; white-space: nowrap; }
+
+.raid-map-controls {
+  position: absolute;
+  z-index: 18;
+  top: calc(max(12px, env(safe-area-inset-top)) + 84px);
+  right: 14px;
+  display: grid;
+  overflow: hidden;
+  border: 1px solid rgb(28 32 34 / 10%);
+  border-radius: 15px;
+  background: rgb(255 255 255 / 95%);
+  box-shadow: 0 7px 20px rgb(26 31 34 / 16%);
+}
+
+.raid-map-controls button {
+  display: grid;
+  width: 46px;
+  height: 46px;
+  place-items: center;
+  border: 0;
+  border-bottom: 1px solid rgb(28 32 34 / 9%);
+  color: #202426;
+  background: transparent;
+  font: inherit;
+  font-size: 1.35rem;
+}
+
+.raid-map-controls button:last-child { border-bottom: 0; font-size: 1.15rem; }
+.raid-map-controls button:disabled { color: #a5aaa6; }
+
+.raid-live-point {
+  position: relative;
+  display: block;
+  box-sizing: border-box;
+  width: 27px;
+  height: 27px;
+  transform: translate(-50%, -50%);
+  border: 7px solid #ea3e35;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 3px 10px rgb(23 27 29 / 28%);
+}
+
+.raid-live-point--visited {
+  border-color: #8c928f;
+  background: #d8dbd8;
+  box-shadow: 0 2px 6px rgb(23 27 29 / 18%);
+  opacity: .75;
+}
+
+.raid-live-point--nearby {
+  width: 35px;
+  height: 35px;
+  border-width: 9px;
+  animation: raid-point-attention 900ms ease-in-out infinite alternate;
+}
+
+.raid-arrival-pill,
+.raid-proximity-status {
+  position: absolute;
+  z-index: 22;
+  right: 12px;
+  bottom: max(14px, env(safe-area-inset-bottom));
+  left: 12px;
+  width: min(560px, calc(100% - 24px));
+  margin: 0 auto;
+  border: 1px solid rgb(28 32 34 / 10%);
+  border-radius: 20px;
+  color: #202426;
+  background: rgb(255 255 255 / 96%);
+  box-shadow: 0 10px 30px rgb(26 31 34 / 22%);
+  backdrop-filter: blur(14px);
+}
+
+.raid-arrival-pill {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  min-height: 72px;
+  padding: 11px 13px;
+  text-align: left;
+}
+
+.raid-arrival-pill > span:first-child,
+.raid-arrival-sheet__pulse {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #ef4338;
+  box-shadow: 0 0 0 7px rgb(239 67 56 / 18%);
+  animation: raid-arrival-pulse 760ms ease-in-out infinite alternate;
+}
+
+.raid-arrival-pill > span:nth-child(2) { display: grid; min-width: 0; gap: 2px; }
+.raid-arrival-pill strong { font-size: .9rem; }
+.raid-arrival-pill small { overflow: hidden; color: #68706c; font-size: .75rem; text-overflow: ellipsis; white-space: nowrap; }
+.raid-arrival-pill b { color: #c62f27; font-size: .78rem; }
+
+.raid-proximity-status {
+  width: fit-content;
+  max-width: calc(100% - 24px);
+  padding: 10px 14px;
+  color: #5f6863;
+  font-size: .78rem;
+  font-weight: 680;
+  text-align: center;
+}
+
+.raid-proximity-status--blocked { color: #9c342d; }
+
+.raid-arrival-sheet {
+  position: absolute;
+  z-index: 25;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: min(620px, 100%);
+  max-height: min(76vh, 680px);
+  margin: 0 auto;
+  overflow: auto;
+  border-radius: 26px 26px 0 0;
+  padding: 8px 18px calc(18px + env(safe-area-inset-bottom));
+  background: #fffdf8;
+  box-shadow: 0 -14px 36px rgb(26 31 34 / 24%);
+  overscroll-behavior: contain;
+}
+
+.raid-arrival-sheet[hidden] { display: none; }
+
+.raid-arrival-sheet__collapse {
+  display: grid;
+  width: 100%;
+  min-height: 32px;
+  place-items: center;
+  border: 0;
+  background: transparent;
+}
+
+.raid-arrival-sheet__collapse span { width: 44px; height: 5px; border-radius: 999px; background: #d1d4d0; }
+.raid-arrival-sheet__heading { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 2px 2px 12px; }
+.raid-arrival-sheet__heading div { min-width: 0; }
+.raid-arrival-sheet__heading small { color: #c6342d; font-size: .75rem; font-weight: 760; }
+.raid-arrival-sheet__heading h2 { margin: 3px 0 0; overflow: hidden; font-size: 1.22rem; text-overflow: ellipsis; white-space: nowrap; }
+.raid-arrival-sheet__waiting { margin: 0 0 8px; border-radius: 14px; padding: 14px; background: #f1f2ee; color: #5f6863; }
+
+.checkin-panel--map { gap: .65rem; }
+.checkin-panel--map > .kb-section-head { display: none; }
+.checkin-panel--map .checkin-points { display: none; }
+.checkin-panel--map .raid-primary { position: sticky; bottom: 0; min-height: 50px; }
+
+.raid-active-map__actions {
+  position: absolute;
+  z-index: 30;
+  top: calc(max(12px, env(safe-area-inset-top)) + 76px);
+  right: 12px;
+  width: min(420px, calc(100% - 24px));
+  max-height: calc(100% - 104px - env(safe-area-inset-bottom));
+  overflow: auto;
+  border-radius: 19px;
+  padding: 14px;
+  background: #fffdf8;
+  box-shadow: 0 12px 36px rgb(26 31 34 / 24%);
+}
+
+.raid-active-map__actions-close { width: 100%; min-height: 44px; border: 0; color: #5f6863; background: transparent; text-align: right; }
+
+.raid-presence-gate { display: grid; gap: 12px; margin-top: 12px; }
+.raid-presence-gate__summary { align-self: start; border-radius: 999px; padding: 6px 9px; color: #6f6251; background: #f2eee5; font-size: .72rem; font-style: normal; font-weight: 760; white-space: nowrap; }
+.raid-presence-gate__summary.is-ready { color: #176047; background: #e2f4eb; }
+.raid-presence-list { display: grid; gap: 0; margin: 0; padding: 0; list-style: none; }
+.raid-presence-list li { display: grid; grid-template-columns: 36px minmax(0, 1fr) 28px; align-items: center; gap: 9px; min-height: 58px; border-top: 1px solid var(--kb-line); padding: 8px 0; }
+.raid-presence-list li > span:nth-child(2) { display: grid; min-width: 0; gap: 2px; }
+.raid-presence-list li strong { overflow: hidden; font-size: .86rem; text-overflow: ellipsis; white-space: nowrap; }
+.raid-presence-list li small { color: var(--kb-muted); font-size: .72rem; }
+.raid-presence-list li > i { display: grid; width: 26px; height: 26px; place-items: center; border-radius: 50%; color: #8d9691; background: #eceeeb; font-style: normal; font-weight: 800; }
+.raid-presence-list li[data-status='nearby'] > i,
+.raid-presence-list li[data-status='manual'] > i { color: #fff; background: #26815f; }
+.raid-presence-list li > button { grid-column: 2 / -1; justify-self: start; min-height: 38px; border: 0; border-radius: 10px; padding: 0 11px; color: #8d3028; background: #fff0ed; font: inherit; font-size: .74rem; font-weight: 720; }
+.raid-presence-gate__hint { margin: 0; color: var(--kb-muted); font-size: .78rem; }
+
+@keyframes raid-point-attention {
+  from { box-shadow: 0 0 0 4px rgb(239 67 56 / 20%), 0 3px 10px rgb(23 27 29 / 28%); transform: translate(-50%, -50%) scale(.96); }
+  to { box-shadow: 0 0 0 18px rgb(239 67 56 / 4%), 0 5px 14px rgb(23 27 29 / 32%); transform: translate(-50%, -50%) scale(1.08); }
+}
+
+@keyframes raid-arrival-pulse {
+  from { box-shadow: 0 0 0 5px rgb(239 67 56 / 15%); transform: scale(.92); }
+  to { box-shadow: 0 0 0 10px rgb(239 67 56 / 3%); transform: scale(1.08); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .raid-live-point--nearby,
+  .raid-arrival-pill > span:first-child,
+  .raid-arrival-sheet__pulse { animation: none; }
+}

--- a/apps/pwa/src/features/raids/recording/ActiveRaidPanel.tsx
+++ b/apps/pwa/src/features/raids/recording/ActiveRaidPanel.tsx
@@ -1,9 +1,10 @@
 import type { RaidPrimaryAction } from '../state'
 import type { RaidProjection } from '../types'
-import { routeStatusLabel, selectActivePrimaryAction, wakeLockLabel } from './state'
+import { selectActivePrimaryAction } from './state'
 import { useRouteRecorder } from './useRouteRecorder'
 import { CheckInPanel } from '../../checkins/CheckInPanel'
 import { FinishRaidPanel } from '../../results/FinishRaidPanel'
+import { RaidRouteMap } from './RaidRouteMap'
 
 export function ActiveRaidPanel({
   identityId,
@@ -27,35 +28,11 @@ export function ActiveRaidPanel({
   const recorder = useRouteRecorder({ identityId, raid, staleProjection, onCanonicalRefresh, onApplyRaid })
   const serverActionAvailable = serverPrimary?.kind === 'command' || serverPrimary?.kind === 'refresh'
   const primary = selectActivePrimaryAction(recorder.phase, serverActionAvailable)
-  const lastSample = recorder.lastPersistedSampleAt
-    ? new Date(recorder.lastPersistedSampleAt).toLocaleTimeString('ru-RU')
-    : 'ещё нет'
-  const distance = recorder.preliminaryDistanceM >= 1_000
-    ? `${(recorder.preliminaryDistanceM / 1_000).toFixed(2)} км`
-    : `${Math.round(recorder.preliminaryDistanceM)} м`
-
   return (
     <>
+    <RaidRouteMap raidId={raid.id} live={raid.state === 'active'} />
     {raid.state === 'active' && <CheckInPanel identityId={identityId} raid={raid} staleProjection={staleProjection} onCanonicalRefresh={onCanonicalRefresh} />}
-    <section className="kb-card route-recorder" data-phase={recorder.phase}>
-      <div className="kb-section-head">
-        <div><p className="kb-kicker">Маршрут навигатора</p><h2>{routeStatusLabel(recorder.phase)}</h2></div>
-        <span className={`route-recorder__signal route-recorder__signal--${recorder.phase}`}>
-          {recorder.phase === 'fresh' ? 'fresh' : recorder.phase}
-        </span>
-      </div>
-      <p className="kb-muted">
-        GPS пишет только эта видимая страница. Выключенный экран и фон не считаются поддержанными без полевого evidence.
-      </p>
-      <div className="route-recorder__metrics">
-        <div><span>Последний sample</span><strong>{lastSample}</strong></div>
-        <div><span>Локально ждут receipt</span><strong>{recorder.pendingCount}</strong></div>
-        <div><span>Предварительно на устройстве</span><strong>≈ {distance}</strong></div>
-        <div><span>Принято сервером</span><strong>{recorder.routeStatus.acceptedSampleCount}</strong></div>
-      </div>
-      <p className={`route-recorder__wake route-recorder__wake--${recorder.wakeLock}`}>
-        {wakeLockLabel(recorder.wakeLock)}. Это не обещание фонового GPS.
-      </p>
+    {(recorder.message || primary === 'recover' || (primary === 'server' && serverPrimary)) && <section aria-label="Управление записью маршрута" className="kb-card route-recorder" data-phase={recorder.phase}>
       {recorder.message && <p className="kb-error" role="alert">{recorder.message}</p>}
       {primary === 'recover' && (
         <button className={raid.state === 'active' ? 'kb-link-button route-recorder__secondary' : 'kb-primary raid-primary'} type="button" onClick={recorder.recover}>
@@ -67,7 +44,7 @@ export function ActiveRaidPanel({
           {operationPending ? 'Подтверждаем…' : serverPrimary.label}
         </button>
       )}
-    </section>
+    </section>}
     {(raid.state === 'active' || raid.state === 'paused') && (
       <FinishRaidPanel
         identityId={identityId}

--- a/apps/pwa/src/features/raids/recording/ActiveRaidPanel.tsx
+++ b/apps/pwa/src/features/raids/recording/ActiveRaidPanel.tsx
@@ -38,7 +38,7 @@ export function ActiveRaidPanel({
   const [sheetOpen, setSheetOpen] = useState(false)
   const [actionsOpen, setActionsOpen] = useState(false)
   const [pendingCheckIns, setPendingCheckIns] = useState(0)
-  const [checkInAttention, setCheckInAttention] = useState({ count: 0, key: '' })
+  const [checkInAttention, setCheckInAttention] = useState({ count: 0, key: '', actionKey: '' })
   const lastPresentedPoint = useRef<string | null>(null)
   const lastPresentedAttention = useRef('')
   const activePoint = proximity.nearby.find(({ creditedByTeam }) => !creditedByTeam) ?? null
@@ -71,12 +71,12 @@ export function ActiveRaidPanel({
   }, [activePoint])
 
   useEffect(() => {
-    if (!checkInAttention.key) {
+    if (!checkInAttention.actionKey) {
       lastPresentedAttention.current = ''
       return
     }
-    if (checkInAttention.key === lastPresentedAttention.current) return
-    lastPresentedAttention.current = checkInAttention.key
+    if (checkInAttention.actionKey === lastPresentedAttention.current) return
+    lastPresentedAttention.current = checkInAttention.actionKey
     setSheetOpen(true)
   }, [checkInAttention])
 
@@ -117,7 +117,7 @@ export function ActiveRaidPanel({
 
     {arrivalAvailable && !sheetOpen && <button className="raid-arrival-pill" onClick={() => setSheetOpen(true)} type="button">
       <span aria-hidden="true" />
-      <span><strong>{activePoint ? 'Вы рядом с точкой' : 'Нужно закончить отметку'}</strong><small>{activePoint ? `${activePoint.name} · ${Math.round(activePoint.distanceMeters)} м` : pendingCheckIns > 0 ? `${pendingCheckIns} действий ждут синхронизации` : 'Есть подтверждение или ручная проверка'}</small></span>
+      <span><strong>{activePoint ? 'Вы рядом с точкой' : pendingCheckIns > 0 ? 'Сохранено без сети' : 'Нужно закончить отметку'}</strong><small>{activePoint ? `${activePoint.name} · ${Math.round(activePoint.distanceMeters)} м` : pendingCheckIns > 0 ? `${pendingCheckIns} действий ждут синхронизации` : 'Есть подтверждение или ручная проверка'}</small></span>
       <b>{activePoint ? 'Отметиться' : 'Открыть'}</b>
     </button>}
 

--- a/apps/pwa/src/features/raids/recording/ActiveRaidPanel.tsx
+++ b/apps/pwa/src/features/raids/recording/ActiveRaidPanel.tsx
@@ -18,6 +18,8 @@ export function ActiveRaidPanel({
   onCanonicalRefresh,
   onApplyRaid,
   backHref,
+  pageMessage,
+  resourceError,
 }: {
   identityId: string
   raid: RaidProjection
@@ -28,23 +30,55 @@ export function ActiveRaidPanel({
   onCanonicalRefresh: () => Promise<unknown>
   onApplyRaid: (raid: RaidProjection) => Promise<unknown>
   backHref: string
+  pageMessage: string | null
+  resourceError: string | null
 }) {
   const recorder = useRouteRecorder({ identityId, raid, staleProjection, onCanonicalRefresh, onApplyRaid })
   const proximity = useRaidProximity(raid.id, raid.state === 'active')
   const [sheetOpen, setSheetOpen] = useState(false)
   const [actionsOpen, setActionsOpen] = useState(false)
   const [pendingCheckIns, setPendingCheckIns] = useState(0)
+  const [checkInAttention, setCheckInAttention] = useState({ count: 0, key: '' })
   const lastPresentedPoint = useRef<string | null>(null)
+  const lastPresentedAttention = useRef('')
   const activePoint = proximity.nearby.find(({ creditedByTeam }) => !creditedByTeam) ?? null
   const viewerIsOrganizer = raid.organizerUserId === identityId
   const serverActionAvailable = serverPrimary?.kind === 'command' || serverPrimary?.kind === 'refresh'
   const primary = selectActivePrimaryAction(recorder.phase, serverActionAvailable)
+  const viewerIsNavigator = raid.navigatorUserId === identityId
+  const hasCheckInAttention = checkInAttention.count > 0
+  const arrivalAvailable = Boolean(activePoint || hasCheckInAttention)
+  const recorderLabel = viewerIsNavigator ? ({
+    fresh: 'Маршрут записывается',
+    waiting: 'Ждём первую GPS-точку',
+    recovering: 'Запускаем запись маршрута',
+    stale: 'GPS давно не обновлялся',
+    standby: 'Запись на другом устройстве',
+    blocked: 'Нет доступа к геолокации',
+    error: 'Запись маршрута остановлена',
+    paused: 'Запись на паузе',
+    ineligible: 'Запись недоступна',
+  } as const)[recorder.phase] : null
 
   useEffect(() => {
-    if (!activePoint || activePoint.pointSnapshotId === lastPresentedPoint.current) return
+    if (!activePoint) {
+      lastPresentedPoint.current = null
+      return
+    }
+    if (activePoint.pointSnapshotId === lastPresentedPoint.current) return
     lastPresentedPoint.current = activePoint.pointSnapshotId
     setSheetOpen(true)
   }, [activePoint])
+
+  useEffect(() => {
+    if (!checkInAttention.key) {
+      lastPresentedAttention.current = ''
+      return
+    }
+    if (checkInAttention.key === lastPresentedAttention.current) return
+    lastPresentedAttention.current = checkInAttention.key
+    setSheetOpen(true)
+  }, [checkInAttention])
 
   const proximityLabel = proximity.status === 'offline'
     ? 'Нет сети · маршрут сохраняется'
@@ -64,36 +98,39 @@ export function ActiveRaidPanel({
 
     <header className="raid-active-map__header">
       <a aria-label="Выйти из карты рейда" href={backHref}>←</a>
-      <div><small>{raid.state === 'paused' ? 'Рейд на паузе' : 'Активный рейд'}</small><strong>{raid.title}</strong></div>
+      <div><small>{raid.state === 'paused' ? 'Рейд на паузе' : recorderLabel ?? 'Активный рейд'}</small><strong>{raid.title}</strong></div>
       <button aria-expanded={actionsOpen} aria-label="Действия рейда" onClick={() => setActionsOpen((value) => !value)} type="button">•••</button>
     </header>
 
     {actionsOpen && <aside className="raid-active-map__actions" aria-label="Действия рейда">
       <button className="raid-active-map__actions-close" onClick={() => setActionsOpen(false)} type="button">Закрыть</button>
-      {(recorder.message || primary === 'recover' || (primary === 'server' && serverPrimary)) && <section aria-label="Управление записью маршрута" className="route-recorder" data-phase={recorder.phase}>
-        {recorder.message && <p className="kb-error" role="alert">{recorder.message}</p>}
-        {primary === 'recover' && <button className="kb-link-button route-recorder__secondary" type="button" onClick={recorder.recover}>{recorder.phase === 'standby' ? 'Продолжить здесь' : 'Возобновить запись'}</button>}
-        {primary === 'server' && serverPrimary && <button className="kb-primary raid-primary" type="button" disabled={operationPending} onClick={onServerPrimary}>{operationPending ? 'Подтверждаем…' : serverPrimary.label}</button>}
-      </section>}
+      {primary === 'server' && serverPrimary && <button className="kb-primary raid-primary" type="button" disabled={operationPending} onClick={onServerPrimary}>{operationPending ? 'Подтверждаем…' : serverPrimary.label}</button>}
       {(raid.state === 'active' || raid.state === 'paused') && <FinishRaidPanel identityId={identityId} raid={raid} flushRoute={recorder.flush} onApplyRaid={onApplyRaid} onCanonicalRefresh={onCanonicalRefresh} />}
     </aside>}
 
-    {(activePoint || pendingCheckIns > 0) && !sheetOpen && <button className="raid-arrival-pill" onClick={() => setSheetOpen(true)} type="button">
+    {(pageMessage || resourceError || recorder.message || primary === 'recover') && <section className="raid-active-map__notice" aria-label="Состояние активного рейда" data-phase={recorder.phase}>
+      {resourceError && <p className="kb-error" role="alert">{resourceError}</p>}
+      {pageMessage && <p className="kb-notice" role="status">{pageMessage}</p>}
+      {recorder.message && <p className="kb-error" role="alert">{recorder.message}</p>}
+      {primary === 'recover' && <button className="kb-link-button route-recorder__secondary" type="button" onClick={recorder.recover}>{recorder.phase === 'standby' ? 'Продолжить запись здесь' : 'Возобновить запись маршрута'}</button>}
+    </section>}
+
+    {arrivalAvailable && !sheetOpen && <button className="raid-arrival-pill" onClick={() => setSheetOpen(true)} type="button">
       <span aria-hidden="true" />
-      <span><strong>{activePoint ? 'Вы рядом с точкой' : 'Сохранено без сети'}</strong><small>{activePoint ? `${activePoint.name} · ${Math.round(activePoint.distanceMeters)} м` : `${pendingCheckIns} действий ждут синхронизации`}</small></span>
+      <span><strong>{activePoint ? 'Вы рядом с точкой' : 'Нужно закончить отметку'}</strong><small>{activePoint ? `${activePoint.name} · ${Math.round(activePoint.distanceMeters)} м` : pendingCheckIns > 0 ? `${pendingCheckIns} действий ждут синхронизации` : 'Есть подтверждение или ручная проверка'}</small></span>
       <b>{activePoint ? 'Отметиться' : 'Открыть'}</b>
     </button>}
 
-    <aside className="raid-arrival-sheet" aria-label={activePoint ? 'Подтверждение точки' : 'Сохранённые действия'} hidden={!sheetOpen || (!activePoint && pendingCheckIns === 0)}>
+    <aside className="raid-arrival-sheet" aria-label={activePoint ? 'Подтверждение точки' : 'Сохранённые действия'} hidden={!sheetOpen || !arrivalAvailable}>
       <button className="raid-arrival-sheet__collapse" aria-label="Свернуть подтверждение точки" onClick={() => setSheetOpen(false)} type="button"><span /></button>
       <div className="raid-arrival-sheet__heading">
-        <div><small>{activePoint ? `Вы на точке · ${Math.round(activePoint.distanceMeters)} м` : 'Офлайн-очередь'}</small><h2>{activePoint?.name ?? 'Сохранённые действия'}</h2></div>
+        <div><small>{activePoint ? `Вы на точке · ${Math.round(activePoint.distanceMeters)} м` : 'Требуется действие'}</small><h2>{activePoint?.name ?? 'Завершите отметку'}</h2></div>
         <span className="raid-arrival-sheet__pulse" aria-hidden="true" />
       </div>
       {!viewerIsOrganizer && activePoint && <p className="raid-arrival-sheet__waiting">Вы на месте. Организатор подтвердит состав группы.</p>}
-      <CheckInPanel identityId={identityId} nearbyPoints={activePoint ? [activePoint] : []} onCanonicalRefresh={onCanonicalRefresh} onPendingChange={setPendingCheckIns} presentation="map-sheet" raid={raid} staleProjection={staleProjection} />
+      <CheckInPanel identityId={identityId} nearbyPoints={activePoint ? [activePoint] : []} onAttentionChange={setCheckInAttention} onCanonicalRefresh={onCanonicalRefresh} onPendingChange={setPendingCheckIns} presentation="map-sheet" raid={raid} staleProjection={staleProjection} />
     </aside>
 
-    {!activePoint && pendingCheckIns === 0 && <p className={`raid-proximity-status raid-proximity-status--${proximity.status}`} role="status">{proximityLabel}</p>}
+    {!arrivalAvailable && <p className={`raid-proximity-status raid-proximity-status--${proximity.status}`} role="status">{proximityLabel}</p>}
   </section>
 }

--- a/apps/pwa/src/features/raids/recording/ActiveRaidPanel.tsx
+++ b/apps/pwa/src/features/raids/recording/ActiveRaidPanel.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react'
 import type { RaidPrimaryAction } from '../state'
 import type { RaidProjection } from '../types'
 import { selectActivePrimaryAction } from './state'
@@ -5,6 +6,7 @@ import { useRouteRecorder } from './useRouteRecorder'
 import { CheckInPanel } from '../../checkins/CheckInPanel'
 import { FinishRaidPanel } from '../../results/FinishRaidPanel'
 import { RaidRouteMap } from './RaidRouteMap'
+import { useRaidProximity } from './useRaidProximity'
 
 export function ActiveRaidPanel({
   identityId,
@@ -15,6 +17,7 @@ export function ActiveRaidPanel({
   onServerPrimary,
   onCanonicalRefresh,
   onApplyRaid,
+  backHref,
 }: {
   identityId: string
   raid: RaidProjection
@@ -24,36 +27,73 @@ export function ActiveRaidPanel({
   onServerPrimary: () => void
   onCanonicalRefresh: () => Promise<unknown>
   onApplyRaid: (raid: RaidProjection) => Promise<unknown>
+  backHref: string
 }) {
   const recorder = useRouteRecorder({ identityId, raid, staleProjection, onCanonicalRefresh, onApplyRaid })
+  const proximity = useRaidProximity(raid.id, raid.state === 'active')
+  const [sheetOpen, setSheetOpen] = useState(false)
+  const [actionsOpen, setActionsOpen] = useState(false)
+  const [pendingCheckIns, setPendingCheckIns] = useState(0)
+  const lastPresentedPoint = useRef<string | null>(null)
+  const activePoint = proximity.nearby.find(({ creditedByTeam }) => !creditedByTeam) ?? null
+  const viewerIsOrganizer = raid.organizerUserId === identityId
   const serverActionAvailable = serverPrimary?.kind === 'command' || serverPrimary?.kind === 'refresh'
   const primary = selectActivePrimaryAction(recorder.phase, serverActionAvailable)
-  return (
-    <>
-    <RaidRouteMap raidId={raid.id} live={raid.state === 'active'} />
-    {raid.state === 'active' && <CheckInPanel identityId={identityId} raid={raid} staleProjection={staleProjection} onCanonicalRefresh={onCanonicalRefresh} />}
-    {(recorder.message || primary === 'recover' || (primary === 'server' && serverPrimary)) && <section aria-label="Управление записью маршрута" className="kb-card route-recorder" data-phase={recorder.phase}>
-      {recorder.message && <p className="kb-error" role="alert">{recorder.message}</p>}
-      {primary === 'recover' && (
-        <button className={raid.state === 'active' ? 'kb-link-button route-recorder__secondary' : 'kb-primary raid-primary'} type="button" onClick={recorder.recover}>
-          {recorder.phase === 'standby' ? 'Продолжить здесь' : 'Возобновить запись'}
-        </button>
-      )}
-      {primary === 'server' && serverPrimary && (
-        <button className={raid.state === 'active' ? 'kb-link-button route-recorder__secondary' : 'kb-primary raid-primary'} type="button" disabled={operationPending} onClick={onServerPrimary}>
-          {operationPending ? 'Подтверждаем…' : serverPrimary.label}
-        </button>
-      )}
-    </section>}
-    {(raid.state === 'active' || raid.state === 'paused') && (
-      <FinishRaidPanel
-        identityId={identityId}
-        raid={raid}
-        flushRoute={recorder.flush}
-        onApplyRaid={onApplyRaid}
-        onCanonicalRefresh={onCanonicalRefresh}
-      />
-    )}
-    </>
-  )
+
+  useEffect(() => {
+    if (!activePoint || activePoint.pointSnapshotId === lastPresentedPoint.current) return
+    lastPresentedPoint.current = activePoint.pointSnapshotId
+    setSheetOpen(true)
+  }, [activePoint])
+
+  const proximityLabel = proximity.status === 'offline'
+    ? 'Нет сети · маршрут сохраняется'
+    : proximity.status === 'blocked'
+      ? 'Разрешите геолокацию для поиска точек'
+      : proximity.status === 'locating'
+        ? 'Определяем ближайшую точку…'
+        : 'Едем дальше · ищем точку в радиусе 50 м'
+
+  return <section className="raid-active-map" aria-label={`Активный рейд ${raid.title}`}>
+    <RaidRouteMap
+      highlightedPointId={activePoint?.pointSnapshotId ?? null}
+      live={raid.state === 'active'}
+      location={proximity.coordinate}
+      raidId={raid.id}
+    />
+
+    <header className="raid-active-map__header">
+      <a aria-label="Выйти из карты рейда" href={backHref}>←</a>
+      <div><small>{raid.state === 'paused' ? 'Рейд на паузе' : 'Активный рейд'}</small><strong>{raid.title}</strong></div>
+      <button aria-expanded={actionsOpen} aria-label="Действия рейда" onClick={() => setActionsOpen((value) => !value)} type="button">•••</button>
+    </header>
+
+    {actionsOpen && <aside className="raid-active-map__actions" aria-label="Действия рейда">
+      <button className="raid-active-map__actions-close" onClick={() => setActionsOpen(false)} type="button">Закрыть</button>
+      {(recorder.message || primary === 'recover' || (primary === 'server' && serverPrimary)) && <section aria-label="Управление записью маршрута" className="route-recorder" data-phase={recorder.phase}>
+        {recorder.message && <p className="kb-error" role="alert">{recorder.message}</p>}
+        {primary === 'recover' && <button className="kb-link-button route-recorder__secondary" type="button" onClick={recorder.recover}>{recorder.phase === 'standby' ? 'Продолжить здесь' : 'Возобновить запись'}</button>}
+        {primary === 'server' && serverPrimary && <button className="kb-primary raid-primary" type="button" disabled={operationPending} onClick={onServerPrimary}>{operationPending ? 'Подтверждаем…' : serverPrimary.label}</button>}
+      </section>}
+      {(raid.state === 'active' || raid.state === 'paused') && <FinishRaidPanel identityId={identityId} raid={raid} flushRoute={recorder.flush} onApplyRaid={onApplyRaid} onCanonicalRefresh={onCanonicalRefresh} />}
+    </aside>}
+
+    {(activePoint || pendingCheckIns > 0) && !sheetOpen && <button className="raid-arrival-pill" onClick={() => setSheetOpen(true)} type="button">
+      <span aria-hidden="true" />
+      <span><strong>{activePoint ? 'Вы рядом с точкой' : 'Сохранено без сети'}</strong><small>{activePoint ? `${activePoint.name} · ${Math.round(activePoint.distanceMeters)} м` : `${pendingCheckIns} действий ждут синхронизации`}</small></span>
+      <b>{activePoint ? 'Отметиться' : 'Открыть'}</b>
+    </button>}
+
+    <aside className="raid-arrival-sheet" aria-label={activePoint ? 'Подтверждение точки' : 'Сохранённые действия'} hidden={!sheetOpen || (!activePoint && pendingCheckIns === 0)}>
+      <button className="raid-arrival-sheet__collapse" aria-label="Свернуть подтверждение точки" onClick={() => setSheetOpen(false)} type="button"><span /></button>
+      <div className="raid-arrival-sheet__heading">
+        <div><small>{activePoint ? `Вы на точке · ${Math.round(activePoint.distanceMeters)} м` : 'Офлайн-очередь'}</small><h2>{activePoint?.name ?? 'Сохранённые действия'}</h2></div>
+        <span className="raid-arrival-sheet__pulse" aria-hidden="true" />
+      </div>
+      {!viewerIsOrganizer && activePoint && <p className="raid-arrival-sheet__waiting">Вы на месте. Организатор подтвердит состав группы.</p>}
+      <CheckInPanel identityId={identityId} nearbyPoints={activePoint ? [activePoint] : []} onCanonicalRefresh={onCanonicalRefresh} onPendingChange={setPendingCheckIns} presentation="map-sheet" raid={raid} staleProjection={staleProjection} />
+    </aside>
+
+    {!activePoint && pendingCheckIns === 0 && <p className={`raid-proximity-status raid-proximity-status--${proximity.status}`} role="status">{proximityLabel}</p>}
+  </section>
 }

--- a/apps/pwa/src/features/raids/recording/RaidRouteMap.test.ts
+++ b/apps/pwa/src/features/raids/recording/RaidRouteMap.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { routeTrackView } from './RaidRouteMap'
+import { routeTrackView, userMarkerCoordinate } from './RaidRouteMap'
 
 describe('live raid route map', () => {
   it('centres a short track tightly around the traveled points', () => {
@@ -20,5 +20,15 @@ describe('live raid route map', () => {
     expect(view.center[0]).toBeCloseTo(56.85)
     expect(view.center[1]).toBeCloseTo(53.195)
     expect(view.zoom).toBe(13)
+  })
+
+  it('never labels the team track endpoint as the viewer location', () => {
+    expect(userMarkerCoordinate(null)).toBeNull()
+    expect(userMarkerCoordinate({
+      latitude: 56.85,
+      longitude: 53.2,
+      accuracyMeters: 8,
+      capturedAt: '2026-08-28T12:00:00.000Z',
+    })).toEqual([56.85, 53.2])
   })
 })

--- a/apps/pwa/src/features/raids/recording/RaidRouteMap.test.ts
+++ b/apps/pwa/src/features/raids/recording/RaidRouteMap.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { routeTrackView } from './RaidRouteMap'
+
+describe('live raid route map', () => {
+  it('centres a short track tightly around the traveled points', () => {
+    const view = routeTrackView([
+      { latitude: 56.85, longitude: 53.2, capturedAt: '2026-08-28T12:00:00.000Z' },
+      { latitude: 56.854, longitude: 53.204, capturedAt: '2026-08-28T12:00:05.000Z' },
+    ])
+    expect(view.center[0]).toBeCloseTo(56.852)
+    expect(view.center[1]).toBeCloseTo(53.202)
+    expect(view.zoom).toBe(17)
+  })
+
+  it('zooms out to keep a district-sized track visible', () => {
+    const view = routeTrackView([
+      { latitude: 56.82, longitude: 53.16, capturedAt: '2026-08-28T12:00:00.000Z' },
+      { latitude: 56.88, longitude: 53.23, capturedAt: '2026-08-28T13:00:00.000Z' },
+    ])
+    expect(view.center[0]).toBeCloseTo(56.85)
+    expect(view.center[1]).toBeCloseTo(53.195)
+    expect(view.zoom).toBe(13)
+  })
+})

--- a/apps/pwa/src/features/raids/recording/RaidRouteMap.tsx
+++ b/apps/pwa/src/features/raids/recording/RaidRouteMap.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useRef, useState } from 'react'
+import { loadYandexMaps, type YandexMap, type YandexMapObject } from '../../kabandas/yandex-maps'
+import { getRouteTrack } from '../api'
+import type { RouteTrackPoint, RouteTrackProjection } from '../types'
+
+const IZHEVSK_CENTER = [56.8528, 53.2045] as const
+
+export function routeTrackView(points: readonly RouteTrackPoint[]) {
+  if (!points.length) return { center: IZHEVSK_CENTER, zoom: 12 }
+  let minLatitude = points[0]!.latitude
+  let maxLatitude = minLatitude
+  let minLongitude = points[0]!.longitude
+  let maxLongitude = minLongitude
+  for (const point of points.slice(1)) {
+    minLatitude = Math.min(minLatitude, point.latitude)
+    maxLatitude = Math.max(maxLatitude, point.latitude)
+    minLongitude = Math.min(minLongitude, point.longitude)
+    maxLongitude = Math.max(maxLongitude, point.longitude)
+  }
+  const span = Math.max(maxLatitude - minLatitude, maxLongitude - minLongitude)
+  const zoom = span > .08 ? 12 : span > .04 ? 13 : span > .02 ? 14 : span > .01 ? 15 : span > .005 ? 16 : 17
+  return {
+    center: [(minLatitude + maxLatitude) / 2, (minLongitude + maxLongitude) / 2] as const,
+    zoom,
+  }
+}
+
+export function RaidRouteMap({ raidId, live }: { raidId: string; live: boolean }) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const mapRef = useRef<YandexMap | null>(null)
+  const routeObjectsRef = useRef<YandexMapObject[]>([])
+  const [providerState, setProviderState] = useState<'loading' | 'ready' | 'failed'>('loading')
+  const [track, setTrack] = useState<RouteTrackProjection | null>(null)
+  const [trackState, setTrackState] = useState<'loading' | 'ready' | 'failed'>('loading')
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    let active = true
+    const apiKey = import.meta.env.VITE_YANDEX_MAPS_API_KEY?.trim() ?? ''
+    void loadYandexMaps(apiKey).then((runtime) => {
+      if (!active) return
+      mapRef.current = new runtime.Map(container, {
+        center: IZHEVSK_CENTER,
+        zoom: 12,
+        controls: [],
+        behaviors: ['default', 'scrollZoom'],
+        type: 'yandex#map',
+      }, { suppressMapOpenBlock: true })
+      setProviderState('ready')
+    }).catch(() => {
+      if (active) setProviderState('failed')
+    })
+    return () => {
+      active = false
+      mapRef.current?.destroy()
+      mapRef.current = null
+      routeObjectsRef.current = []
+    }
+  }, [])
+
+  useEffect(() => {
+    let active = true
+    let inFlight = false
+    const refresh = async () => {
+      if (inFlight || !navigator.onLine) return
+      inFlight = true
+      try {
+        const next = await getRouteTrack(raidId)
+        if (!active) return
+        setTrack((current) => current?.updatedAt === next.updatedAt && current.pointCount === next.pointCount ? current : next)
+        setTrackState('ready')
+      } catch {
+        if (active) setTrackState('failed')
+      } finally {
+        inFlight = false
+      }
+    }
+    void refresh()
+    const timer = live ? window.setInterval(() => void refresh(), 5_000) : null
+    const onOnline = () => void refresh()
+    window.addEventListener('online', onOnline)
+    return () => {
+      active = false
+      if (timer !== null) window.clearInterval(timer)
+      window.removeEventListener('online', onOnline)
+    }
+  }, [live, raidId])
+
+  useEffect(() => {
+    const map = mapRef.current
+    if (providerState !== 'ready' || !map || !track) return
+    let disposed = false
+    const apiKey = import.meta.env.VITE_YANDEX_MAPS_API_KEY?.trim() ?? ''
+    void loadYandexMaps(apiKey).then((runtime) => {
+      if (disposed || mapRef.current !== map) return
+      for (const object of routeObjectsRef.current) map.geoObjects.remove(object)
+      routeObjectsRef.current = []
+      const points = track.segments.flat()
+      for (const segment of track.segments) {
+        if (segment.length < 2) continue
+        const coordinates = segment.map(({ latitude, longitude }) => [latitude, longitude] as const)
+        const casing = new runtime.Polyline(coordinates, {}, {
+          strokeColor: '#ffffff',
+          strokeOpacity: .96,
+          strokeWidth: 9,
+          zIndex: 2,
+        })
+        const line = new runtime.Polyline(coordinates, {}, {
+          strokeColor: '#17191b',
+          strokeOpacity: 1,
+          strokeWidth: 5,
+          zIndex: 3,
+        })
+        routeObjectsRef.current.push(casing, line)
+        map.geoObjects.add(casing)
+        map.geoObjects.add(line)
+      }
+      const last = points.at(-1)
+      if (last) {
+        const riderLayout = runtime.templateLayoutFactory.createClass(
+          '<span class="route-live-map__rider" aria-label="Положение навигатора рейда"></span>',
+        )
+        const rider = new runtime.Placemark([last.latitude, last.longitude], {}, {
+          iconLayout: riderLayout,
+          iconShape: { type: 'Circle', coordinates: [0, 0], radius: 23 },
+          hasBalloon: false,
+          hasHint: false,
+          zIndex: 5,
+        })
+        routeObjectsRef.current.push(rider)
+        map.geoObjects.add(rider)
+      }
+      const view = routeTrackView(points)
+      map.setCenter(view.center, view.zoom, { duration: 320, timingFunction: 'ease-in-out' })
+    })
+    return () => {
+      disposed = true
+    }
+  }, [providerState, track])
+
+  const pointCount = track?.pointCount ?? 0
+  return <section className="route-live-card" aria-label="Пройденный маршрут рейда">
+    <div className="route-live-map" ref={containerRef} />
+    {providerState === 'loading' && <p className="route-live-map__state" role="status">Загружаем карту…</p>}
+    {providerState === 'failed' && <p className="route-live-map__state route-live-map__state--error" role="alert">Карта не загрузилась. Трек продолжает записываться.</p>}
+    {providerState === 'ready' && trackState === 'loading' && <p className="route-live-map__state" role="status">Загружаем пройденный маршрут…</p>}
+    {providerState === 'ready' && trackState === 'failed' && !track && <p className="route-live-map__state route-live-map__state--error" role="alert">Не удалось загрузить трек. Повторим автоматически.</p>}
+    {providerState === 'ready' && trackState === 'ready' && pointCount < 2 && <p className="route-live-map__state">Трек появится, когда навигатор начнёт движение.</p>}
+    {track?.truncated && <p className="route-live-map__state route-live-map__state--notice">Показана первая часть длинного трека.</p>}
+  </section>
+}

--- a/apps/pwa/src/features/raids/recording/RaidRouteMap.tsx
+++ b/apps/pwa/src/features/raids/recording/RaidRouteMap.tsx
@@ -1,11 +1,27 @@
 import { useEffect, useRef, useState } from 'react'
-import { loadYandexMaps, type YandexMap, type YandexMapObject } from '../../kabandas/yandex-maps'
-import { getRouteTrack } from '../api'
-import type { RouteTrackPoint, RouteTrackProjection } from '../types'
+import {
+  loadYandexMaps,
+  type YandexMap,
+  type YandexMapObject,
+  type YandexMapsRuntime,
+} from '../../kabandas/yandex-maps'
+import type { OneShotCoordinate } from '../../checkins/types'
+import { getRaidMapPoints, getRouteTrack } from '../api'
+import type { RaidMapPoint, RouteTrackPoint, RouteTrackProjection } from '../types'
 
 const IZHEVSK_CENTER = [56.8528, 53.2045] as const
 
-export function routeTrackView(points: readonly RouteTrackPoint[]) {
+function sameMapPoints(current: readonly RaidMapPoint[], next: readonly RaidMapPoint[]): boolean {
+  return current.length === next.length && current.every((point, index) => {
+    const candidate = next[index]
+    return candidate !== undefined &&
+      point.id === candidate.id &&
+      point.visitedByMe === candidate.visitedByMe &&
+      point.visitedByTeam === candidate.visitedByTeam
+  })
+}
+
+export function routeTrackView(points: readonly (Pick<RouteTrackPoint, 'latitude' | 'longitude'> & Partial<Pick<RouteTrackPoint, 'capturedAt'>>)[]) {
   if (!points.length) return { center: IZHEVSK_CENTER, zoom: 12 }
   let minLatitude = points[0]!.latitude
   let maxLatitude = minLatitude
@@ -25,13 +41,29 @@ export function routeTrackView(points: readonly RouteTrackPoint[]) {
   }
 }
 
-export function RaidRouteMap({ raidId, live }: { raidId: string; live: boolean }) {
+export function RaidRouteMap({
+  raidId,
+  live,
+  location,
+  highlightedPointId,
+}: {
+  raidId: string
+  live: boolean
+  location: OneShotCoordinate | null
+  highlightedPointId: string | null
+}) {
   const containerRef = useRef<HTMLDivElement>(null)
   const mapRef = useRef<YandexMap | null>(null)
+  const runtimeRef = useRef<YandexMapsRuntime | null>(null)
   const routeObjectsRef = useRef<YandexMapObject[]>([])
+  const pointObjectsRef = useRef<YandexMapObject[]>([])
+  const riderRef = useRef<YandexMapObject | null>(null)
+  const firstViewApplied = useRef(false)
+  const firstLocationApplied = useRef(false)
   const [providerState, setProviderState] = useState<'loading' | 'ready' | 'failed'>('loading')
   const [track, setTrack] = useState<RouteTrackProjection | null>(null)
-  const [trackState, setTrackState] = useState<'loading' | 'ready' | 'failed'>('loading')
+  const [points, setPoints] = useState<RaidMapPoint[]>([])
+  const [dataState, setDataState] = useState<'loading' | 'ready' | 'failed'>('loading')
 
   useEffect(() => {
     const container = containerRef.current
@@ -40,6 +72,7 @@ export function RaidRouteMap({ raidId, live }: { raidId: string; live: boolean }
     const apiKey = import.meta.env.VITE_YANDEX_MAPS_API_KEY?.trim() ?? ''
     void loadYandexMaps(apiKey).then((runtime) => {
       if (!active) return
+      runtimeRef.current = runtime
       mapRef.current = new runtime.Map(container, {
         center: IZHEVSK_CENTER,
         zoom: 12,
@@ -55,7 +88,10 @@ export function RaidRouteMap({ raidId, live }: { raidId: string; live: boolean }
       active = false
       mapRef.current?.destroy()
       mapRef.current = null
+      runtimeRef.current = null
       routeObjectsRef.current = []
+      pointObjectsRef.current = []
+      riderRef.current = null
     }
   }, [])
 
@@ -66,12 +102,16 @@ export function RaidRouteMap({ raidId, live }: { raidId: string; live: boolean }
       if (inFlight || !navigator.onLine) return
       inFlight = true
       try {
-        const next = await getRouteTrack(raidId)
+        const [nextTrack, nextPoints] = await Promise.all([
+          getRouteTrack(raidId),
+          getRaidMapPoints(raidId),
+        ])
         if (!active) return
-        setTrack((current) => current?.updatedAt === next.updatedAt && current.pointCount === next.pointCount ? current : next)
-        setTrackState('ready')
+        setTrack((current) => current?.updatedAt === nextTrack.updatedAt && current.pointCount === nextTrack.pointCount ? current : nextTrack)
+        setPoints((current) => sameMapPoints(current, nextPoints) ? current : nextPoints)
+        setDataState('ready')
       } catch {
-        if (active) setTrackState('failed')
+        if (active) setDataState('failed')
       } finally {
         inFlight = false
       }
@@ -89,64 +129,126 @@ export function RaidRouteMap({ raidId, live }: { raidId: string; live: boolean }
 
   useEffect(() => {
     const map = mapRef.current
-    if (providerState !== 'ready' || !map || !track) return
-    let disposed = false
-    const apiKey = import.meta.env.VITE_YANDEX_MAPS_API_KEY?.trim() ?? ''
-    void loadYandexMaps(apiKey).then((runtime) => {
-      if (disposed || mapRef.current !== map) return
-      for (const object of routeObjectsRef.current) map.geoObjects.remove(object)
-      routeObjectsRef.current = []
-      const points = track.segments.flat()
-      for (const segment of track.segments) {
-        if (segment.length < 2) continue
-        const coordinates = segment.map(({ latitude, longitude }) => [latitude, longitude] as const)
-        const casing = new runtime.Polyline(coordinates, {}, {
-          strokeColor: '#ffffff',
-          strokeOpacity: .96,
-          strokeWidth: 9,
-          zIndex: 2,
-        })
-        const line = new runtime.Polyline(coordinates, {}, {
-          strokeColor: '#17191b',
-          strokeOpacity: 1,
-          strokeWidth: 5,
-          zIndex: 3,
-        })
-        routeObjectsRef.current.push(casing, line)
-        map.geoObjects.add(casing)
-        map.geoObjects.add(line)
-      }
-      const last = points.at(-1)
-      if (last) {
-        const riderLayout = runtime.templateLayoutFactory.createClass(
-          '<span class="route-live-map__rider" aria-label="Положение навигатора рейда"></span>',
-        )
-        const rider = new runtime.Placemark([last.latitude, last.longitude], {}, {
-          iconLayout: riderLayout,
-          iconShape: { type: 'Circle', coordinates: [0, 0], radius: 23 },
-          hasBalloon: false,
-          hasHint: false,
-          zIndex: 5,
-        })
-        routeObjectsRef.current.push(rider)
-        map.geoObjects.add(rider)
-      }
-      const view = routeTrackView(points)
-      map.setCenter(view.center, view.zoom, { duration: 320, timingFunction: 'ease-in-out' })
-    })
-    return () => {
-      disposed = true
+    const runtime = runtimeRef.current
+    if (providerState !== 'ready' || !map || !runtime || !track) return
+    for (const object of routeObjectsRef.current) map.geoObjects.remove(object)
+    routeObjectsRef.current = []
+
+    const trackPoints = track.segments.flat()
+    for (const segment of track.segments) {
+      if (segment.length < 2) continue
+      const coordinates = segment.map(({ latitude, longitude }) => [latitude, longitude] as const)
+      const casing = new runtime.Polyline(coordinates, {}, {
+        strokeColor: '#ffffff',
+        strokeOpacity: .96,
+        strokeWidth: 9,
+        zIndex: 2,
+      })
+      const line = new runtime.Polyline(coordinates, {}, {
+        strokeColor: '#17191b',
+        strokeOpacity: 1,
+        strokeWidth: 5,
+        zIndex: 3,
+      })
+      routeObjectsRef.current.push(casing, line)
+      map.geoObjects.add(casing)
+      map.geoObjects.add(line)
+    }
+
+    if (!firstViewApplied.current && trackPoints.length > 0) {
+      const view = routeTrackView(trackPoints)
+      map.setCenter(view.center, view.zoom, { duration: 0 })
+      firstViewApplied.current = true
     }
   }, [providerState, track])
 
-  const pointCount = track?.pointCount ?? 0
-  return <section className="route-live-card" aria-label="Пройденный маршрут рейда">
+  useEffect(() => {
+    const map = mapRef.current
+    const runtime = runtimeRef.current
+    if (providerState !== 'ready' || !map || !runtime) return
+    for (const object of pointObjectsRef.current) map.geoObjects.remove(object)
+    pointObjectsRef.current = []
+
+    const pointLayout = runtime.templateLayoutFactory.createClass(
+      '<span class="{{ properties.markerClass }}" aria-label="{{ properties.ariaLabel }}"></span>',
+    )
+    for (const point of points) {
+      const highlighted = point.id === highlightedPointId
+      const markerClass = `raid-live-point${point.visitedByTeam ? ' raid-live-point--visited' : ''}${highlighted ? ' raid-live-point--nearby' : ''}`
+      const marker = new runtime.Placemark([point.latitude, point.longitude], {
+        markerClass,
+        ariaLabel: `${point.name}. ${point.visitedByTeam ? 'Точка закрыта' : highlighted ? 'Вы рядом, подтвердите посещение' : 'Точка рейда'}`,
+      }, {
+        iconLayout: pointLayout,
+        iconShape: { type: 'Circle', coordinates: [0, 0], radius: highlighted ? 22 : 14 },
+        hasBalloon: false,
+        hasHint: false,
+        zIndex: highlighted ? 8 : point.visitedByTeam ? 1 : 4,
+      })
+      pointObjectsRef.current.push(marker)
+      map.geoObjects.add(marker)
+    }
+
+    if (!firstViewApplied.current && points.length > 0) {
+      const view = routeTrackView(points)
+      map.setCenter(view.center, view.zoom, { duration: 0 })
+      firstViewApplied.current = true
+    }
+  }, [highlightedPointId, points, providerState])
+
+  useEffect(() => {
+    const map = mapRef.current
+    const runtime = runtimeRef.current
+    if (providerState !== 'ready' || !map || !runtime) return
+    if (riderRef.current) map.geoObjects.remove(riderRef.current)
+    riderRef.current = null
+
+    const current = location ?? track?.segments.flat().at(-1) ?? null
+    if (!current) return
+    const riderLayout = runtime.templateLayoutFactory.createClass(
+      '<span class="route-live-map__rider" aria-label="Моё положение"></span>',
+    )
+    const rider = new runtime.Placemark([current.latitude, current.longitude], {}, {
+      iconLayout: riderLayout,
+      iconShape: { type: 'Circle', coordinates: [0, 0], radius: 23 },
+      hasBalloon: false,
+      hasHint: false,
+      zIndex: 10,
+    })
+    riderRef.current = rider
+    map.geoObjects.add(rider)
+
+    if (location && !firstLocationApplied.current) {
+      map.setCenter([location.latitude, location.longitude], 15, {
+        duration: firstViewApplied.current ? 260 : 0,
+        timingFunction: 'ease-in-out',
+      })
+      firstLocationApplied.current = true
+      firstViewApplied.current = true
+    }
+  }, [location, providerState, track])
+
+  const changeZoom = (delta: number) => {
+    const map = mapRef.current
+    if (map) map.setZoom(Math.max(3, Math.min(19, map.getZoom() + delta)), { duration: 180 })
+  }
+
+  const centerLocation = () => {
+    const map = mapRef.current
+    if (map && location) map.setCenter([location.latitude, location.longitude], 15, { duration: 260, timingFunction: 'ease-in-out' })
+  }
+
+  return <div className="route-live-map-shell">
     <div className="route-live-map" ref={containerRef} />
+    <nav className="raid-map-controls" aria-label="Управление картой">
+      <button aria-label="Увеличить карту" onClick={() => changeZoom(1)} type="button">＋</button>
+      <button aria-label="Уменьшить карту" onClick={() => changeZoom(-1)} type="button">−</button>
+      <button aria-label="Показать моё местоположение" disabled={!location} onClick={centerLocation} type="button">⌖</button>
+    </nav>
     {providerState === 'loading' && <p className="route-live-map__state" role="status">Загружаем карту…</p>}
     {providerState === 'failed' && <p className="route-live-map__state route-live-map__state--error" role="alert">Карта не загрузилась. Трек продолжает записываться.</p>}
-    {providerState === 'ready' && trackState === 'loading' && <p className="route-live-map__state" role="status">Загружаем пройденный маршрут…</p>}
-    {providerState === 'ready' && trackState === 'failed' && !track && <p className="route-live-map__state route-live-map__state--error" role="alert">Не удалось загрузить трек. Повторим автоматически.</p>}
-    {providerState === 'ready' && trackState === 'ready' && pointCount < 2 && <p className="route-live-map__state">Трек появится, когда навигатор начнёт движение.</p>}
+    {providerState === 'ready' && dataState === 'loading' && <p className="route-live-map__state" role="status">Открываем точки рейда…</p>}
+    {providerState === 'ready' && dataState === 'failed' && !track && <p className="route-live-map__state route-live-map__state--error" role="alert">Не удалось загрузить карту рейда. Повторим автоматически.</p>}
     {track?.truncated && <p className="route-live-map__state route-live-map__state--notice">Показана первая часть длинного трека.</p>}
-  </section>
+  </div>
 }

--- a/apps/pwa/src/features/raids/recording/RaidRouteMap.tsx
+++ b/apps/pwa/src/features/raids/recording/RaidRouteMap.tsx
@@ -41,6 +41,10 @@ export function routeTrackView(points: readonly (Pick<RouteTrackPoint, 'latitude
   }
 }
 
+export function userMarkerCoordinate(location: OneShotCoordinate | null): readonly [number, number] | null {
+  return location ? [location.latitude, location.longitude] : null
+}
+
 export function RaidRouteMap({
   raidId,
   live,
@@ -203,12 +207,12 @@ export function RaidRouteMap({
     if (riderRef.current) map.geoObjects.remove(riderRef.current)
     riderRef.current = null
 
-    const current = location ?? track?.segments.flat().at(-1) ?? null
-    if (!current) return
+    const markerCoordinate = userMarkerCoordinate(location)
+    if (!markerCoordinate) return
     const riderLayout = runtime.templateLayoutFactory.createClass(
       '<span class="route-live-map__rider" aria-label="Моё положение"></span>',
     )
-    const rider = new runtime.Placemark([current.latitude, current.longitude], {}, {
+    const rider = new runtime.Placemark(markerCoordinate, {}, {
       iconLayout: riderLayout,
       iconShape: { type: 'Circle', coordinates: [0, 0], radius: 23 },
       hasBalloon: false,
@@ -226,7 +230,7 @@ export function RaidRouteMap({
       firstLocationApplied.current = true
       firstViewApplied.current = true
     }
-  }, [location, providerState, track])
+  }, [location, providerState])
 
   const changeZoom = (delta: number) => {
     const map = mapRef.current

--- a/apps/pwa/src/features/raids/recording/useRaidProximity.ts
+++ b/apps/pwa/src/features/raids/recording/useRaidProximity.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { getNearbyPoints } from '../../checkins/api'
+import { getOneShotCoordinate } from '../../checkins/platform'
+import type { NearbyPoint, OneShotCoordinate } from '../../checkins/types'
+import { reportRaidPresence } from '../api'
+
+export type RaidProximityState = {
+  status: 'locating' | 'ready' | 'offline' | 'blocked'
+  coordinate: OneShotCoordinate | null
+  nearby: NearbyPoint[]
+  refresh: () => Promise<void>
+}
+
+export function useRaidProximity(raidId: string, enabled: boolean): RaidProximityState {
+  const [status, setStatus] = useState<RaidProximityState['status']>(() => navigator.onLine ? 'locating' : 'offline')
+  const [coordinate, setCoordinate] = useState<OneShotCoordinate | null>(null)
+  const [nearby, setNearby] = useState<NearbyPoint[]>([])
+  const inFlight = useRef(false)
+
+  const refresh = useCallback(async () => {
+    if (!enabled || inFlight.current || document.visibilityState !== 'visible') return
+    if (!navigator.onLine) {
+      setStatus('offline')
+      return
+    }
+    inFlight.current = true
+    try {
+      const nextCoordinate = await getOneShotCoordinate(10_000)
+      const response = await getNearbyPoints(
+        raidId,
+        nextCoordinate.latitude,
+        nextCoordinate.longitude,
+      )
+      setCoordinate(nextCoordinate)
+      setNearby(response.points)
+      setStatus('ready')
+      if (nextCoordinate.accuracyMeters <= 50) {
+        void reportRaidPresence(raidId, nextCoordinate).catch(() => undefined)
+      }
+    } catch {
+      setStatus('blocked')
+    } finally {
+      inFlight.current = false
+    }
+  }, [enabled, raidId])
+
+  useEffect(() => {
+    if (!enabled) return
+    void refresh()
+    const timer = window.setInterval(() => void refresh(), 8_000)
+    const resume = () => void refresh()
+    window.addEventListener('online', resume)
+    window.addEventListener('focus', resume)
+    document.addEventListener('visibilitychange', resume)
+    return () => {
+      window.clearInterval(timer)
+      window.removeEventListener('online', resume)
+      window.removeEventListener('focus', resume)
+      document.removeEventListener('visibilitychange', resume)
+    }
+  }, [enabled, refresh])
+
+  return { status, coordinate, nearby, refresh }
+}

--- a/apps/pwa/src/features/raids/state.test.ts
+++ b/apps/pwa/src/features/raids/state.test.ts
@@ -81,7 +81,7 @@ describe('raid primary CTA', () => {
     ).toBeNull()
   })
 
-  it('makes every accepted participant ready before navigator device readiness', () => {
+  it('keeps the explicit phone-readiness step only for the selected navigator', () => {
     const acceptedNavigator = selectPrimaryAction(
       { ...raid, allowedActions: ['ready'] },
       {
@@ -104,7 +104,7 @@ describe('raid primary CTA', () => {
       },
     )
     expect(acceptedNavigator).toEqual({ kind: 'command', command: 'ready', label: 'Я готов' })
-    expect(acceptedMember).toEqual({ kind: 'command', command: 'ready', label: 'Я готов' })
+    expect(acceptedMember).toBeNull()
   })
 
   it('checks the selected navigator device only after participant ready', () => {

--- a/apps/pwa/src/features/raids/state.ts
+++ b/apps/pwa/src/features/raids/state.ts
@@ -46,7 +46,7 @@ export function selectPrimaryAction(
 
   const allowed = new Set(raid.allowedActions)
   if (allowed.has('accept')) return { kind: 'command', command: 'accept', label: 'Принять приглашение' }
-  if (context.viewerParticipantState === 'accepted' && allowed.has('ready')) {
+  if (context.viewerIsNavigator && context.viewerParticipantState === 'accepted' && allowed.has('ready')) {
     return { kind: 'command', command: 'ready', label: 'Я готов' }
   }
   if (

--- a/apps/pwa/src/features/raids/types.ts
+++ b/apps/pwa/src/features/raids/types.ts
@@ -133,6 +133,42 @@ export interface RouteTrackProjection {
   serverAt: string
 }
 
+export interface RaidMapPoint {
+  id: string
+  sourcePointId: string
+  name: string
+  latitude: number
+  longitude: number
+  position: number
+  visitedByMe: boolean
+  visitedByTeam: boolean
+}
+
+export interface RaidPresenceRoster {
+  radiusMeters: 50
+  maxAgeSeconds: 30
+  allReady: boolean
+  participants: Array<{
+    id: string
+    displayName: string
+    avatarUrl: string | null
+    status: 'nearby' | 'manual' | 'waiting'
+    observedAt: string | null
+  }>
+  serverAt: string
+}
+
+export interface RaidPointPresenceRoster {
+  pointSnapshotId: string
+  radiusMeters: 50
+  participants: Array<{
+    id: string
+    status: 'nearby' | 'waiting'
+    observedAt: string | null
+  }>
+  serverAt: string
+}
+
 export interface RouteLeaseResponse {
   receipt: {
     operationId: string

--- a/apps/pwa/src/features/raids/types.ts
+++ b/apps/pwa/src/features/raids/types.ts
@@ -119,6 +119,20 @@ export interface RouteBatchResponse {
   serverAt: string
 }
 
+export interface RouteTrackPoint {
+  latitude: number
+  longitude: number
+  capturedAt: string
+}
+
+export interface RouteTrackProjection {
+  segments: RouteTrackPoint[][]
+  pointCount: number
+  truncated: boolean
+  updatedAt: string | null
+  serverAt: string
+}
+
 export interface RouteLeaseResponse {
   receipt: {
     operationId: string

--- a/e2e/golden-raid.spec.ts
+++ b/e2e/golden-raid.spec.ts
@@ -108,9 +108,10 @@ test('owner completes one canonical raid and opens the next raid form', async ({
   await page.getByRole('button', { name: 'Назначить', exact: true }).click()
   await page.getByRole('button', { name: 'Я готов' }).click()
   await page.getByRole('button', { name: 'Проверить телефон' }).click()
-  await page.getByRole('button', { name: 'Начать рейд' }).click()
+  await expect(page.getByText('Все готовы', { exact: true })).toBeVisible({ timeout: 15_000 })
+  await page.getByRole('button', { name: 'Все здесь — начать рейд' }).click()
 
-  await expect(page.getByLabel('Пройденный маршрут рейда')).toBeVisible()
+  await expect(page.getByLabel(/Активный рейд Синтетический золотой рейд/)).toBeVisible()
   await expect.poll(async () => {
     const response = await api<{ raid: { routeStatus: { status: string } } }>(
       page,
@@ -139,10 +140,12 @@ test('owner completes one canonical raid and opens the next raid form', async ({
     return response.track.pointCount
   }, { timeout: 30_000 }).toBeGreaterThan(1)
   await expect(page.locator('[data-yandex-polyline][data-stroke-color="#17191b"]')).toBeVisible({ timeout: 10_000 })
-  await expect(page.getByLabel('Положение навигатора рейда')).toBeVisible()
-  await page.getByRole('button', { name: 'Найти точку рядом' }).click()
-  await expect(page.getByText('Синтетическая точка E2E')).toBeVisible()
+  await expect(page.getByLabel('Моё положение')).toBeVisible()
+  await expect(page.getByLabel('Подтверждение точки')).toBeVisible({ timeout: 15_000 })
+  await expect(page.getByRole('heading', { name: 'Синтетическая точка E2E' })).toBeVisible()
   await context.setGeolocation({ latitude: 56.8601, longitude: 53.2101, accuracy: 8 })
+  await page.locator('input[type="file"]').setInputFiles('apps/pwa/public/pwa-192x192.png')
+  await expect(page.getByText(/Фото сохранено локально/)).toBeVisible()
   await page.getByRole('button', { name: 'Отметиться у точки' }).click()
   await expect(page.getByText(/Попытка сохранена на телефоне/)).toBeVisible()
 
@@ -154,14 +157,12 @@ test('owner completes one canonical raid and opens the next raid form', async ({
     )
     return nearby.points[0]?.creditedByTeam ?? false
   }, { timeout: 30_000 }).toBe(true)
-  await page.locator('input[type="file"]').setInputFiles('apps/pwa/public/pwa-192x192.png')
-  await expect(page.getByText(/Фото сохранено локально/)).toBeVisible()
-
   await expect.poll(async () => {
     const gallery = await api<{ media: unknown[] }>(page, 'GET', `/api/raids/${raid.id}/media`)
     return gallery.media.length
   }, { timeout: 30_000 }).toBe(1)
 
+  await page.getByRole('button', { name: 'Действия рейда' }).click()
   await page.getByRole('button', { name: 'Завершить рейд' }).click()
   await page.getByRole('button', { name: 'Зафиксировать итог' }).click()
   await expect(page.getByText('Канонический итог')).toBeVisible()

--- a/e2e/golden-raid.spec.ts
+++ b/e2e/golden-raid.spec.ts
@@ -139,7 +139,7 @@ test('owner completes one canonical raid and opens the next raid form', async ({
     )
     return response.track.pointCount
   }, { timeout: 30_000 }).toBeGreaterThan(1)
-  await expect(page.locator('[data-yandex-polyline][data-stroke-color="#17191b"]')).toBeVisible({ timeout: 10_000 })
+  await expect(page.locator('[data-yandex-polyline][data-stroke-color="#17191b"]')).toHaveCount(1, { timeout: 10_000 })
   await expect(page.getByLabel('Моё положение')).toBeVisible()
   await expect(page.getByRole('complementary', { name: 'Подтверждение точки' })).toBeVisible({ timeout: 15_000 })
   await expect(page.getByRole('heading', { name: 'Синтетическая точка E2E' })).toBeVisible()

--- a/e2e/golden-raid.spec.ts
+++ b/e2e/golden-raid.spec.ts
@@ -112,6 +112,7 @@ test('owner completes one canonical raid and opens the next raid form', async ({
   await page.getByRole('button', { name: 'Все здесь — начать рейд' }).click()
 
   await expect(page.getByLabel(/Активный рейд Синтетический золотой рейд/)).toBeVisible()
+  await context.setGeolocation({ latitude: 56.86001, longitude: 53.21001, accuracy: 8 })
   await expect.poll(async () => {
     const response = await api<{ raid: { routeStatus: { status: string } } }>(
       page,
@@ -120,7 +121,6 @@ test('owner completes one canonical raid and opens the next raid form', async ({
     )
     return response.raid.routeStatus.status
   }, { timeout: 30_000 }).toBe('fresh')
-  await context.setGeolocation({ latitude: 56.86001, longitude: 53.21001, accuracy: 8 })
   await expect.poll(async () => {
     const response = await api<{ raid: { routeStatus: { acceptedSampleCount: number } } }>(
       page,
@@ -141,7 +141,7 @@ test('owner completes one canonical raid and opens the next raid form', async ({
   }, { timeout: 30_000 }).toBeGreaterThan(1)
   await expect(page.locator('[data-yandex-polyline][data-stroke-color="#17191b"]')).toBeVisible({ timeout: 10_000 })
   await expect(page.getByLabel('Моё положение')).toBeVisible()
-  await expect(page.getByLabel('Подтверждение точки')).toBeVisible({ timeout: 15_000 })
+  await expect(page.getByRole('complementary', { name: 'Подтверждение точки' })).toBeVisible({ timeout: 15_000 })
   await expect(page.getByRole('heading', { name: 'Синтетическая точка E2E' })).toBeVisible()
   await context.setGeolocation({ latitude: 56.8601, longitude: 53.2101, accuracy: 8 })
   await page.locator('input[type="file"]').setInputFiles('apps/pwa/public/pwa-192x192.png')

--- a/e2e/golden-raid.spec.ts
+++ b/e2e/golden-raid.spec.ts
@@ -110,7 +110,15 @@ test('owner completes one canonical raid and opens the next raid form', async ({
   await page.getByRole('button', { name: 'Проверить телефон' }).click()
   await page.getByRole('button', { name: 'Начать рейд' }).click()
 
-  await expect(page.getByText('fresh', { exact: true })).toBeVisible({ timeout: 30_000 })
+  await expect(page.getByLabel('Пройденный маршрут рейда')).toBeVisible()
+  await expect.poll(async () => {
+    const response = await api<{ raid: { routeStatus: { status: string } } }>(
+      page,
+      'GET',
+      `/api/raids/${raid.id}`,
+    )
+    return response.raid.routeStatus.status
+  }, { timeout: 30_000 }).toBe('fresh')
   await context.setGeolocation({ latitude: 56.86001, longitude: 53.21001, accuracy: 8 })
   await expect.poll(async () => {
     const response = await api<{ raid: { routeStatus: { acceptedSampleCount: number } } }>(
@@ -122,6 +130,16 @@ test('owner completes one canonical raid and opens the next raid form', async ({
   }, { timeout: 30_000 }).toBeGreaterThan(0)
 
   await context.setGeolocation({ latitude: 56.86005, longitude: 53.21005, accuracy: 8 })
+  await expect.poll(async () => {
+    const response = await api<{ track: { pointCount: number } }>(
+      page,
+      'GET',
+      `/api/raids/${raid.id}/route/track`,
+    )
+    return response.track.pointCount
+  }, { timeout: 30_000 }).toBeGreaterThan(1)
+  await expect(page.locator('[data-yandex-polyline][data-stroke-color="#17191b"]')).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByLabel('Положение навигатора рейда')).toBeVisible()
   await page.getByRole('button', { name: 'Найти точку рядом' }).click()
   await expect(page.getByText('Синтетическая точка E2E')).toBeVisible()
   await context.setGeolocation({ latitude: 56.8601, longitude: 53.2101, accuracy: 8 })

--- a/e2e/offline-recovery.spec.ts
+++ b/e2e/offline-recovery.spec.ts
@@ -3,6 +3,7 @@ import {
   api,
   fixture,
   installSyntheticSession,
+  installYandexMapsMock,
   operationId,
   type FixtureIdentity,
   waitForServiceWorkerControl,
@@ -62,6 +63,7 @@ async function localCounts(page: Page, raidId: string): Promise<LocalCounts> {
 
 test('offline route, check-in and photo survive reload and replay once', async ({ context, page }) => {
   const identity = fixture<FixtureIdentity>('prepare')
+  await installYandexMapsMock(context)
   await installSyntheticSession(context, identity)
 
   const kabanda = await api<{ kabanda: { id: string } }>(page, 'POST', '/api/kabandas', {
@@ -114,6 +116,12 @@ test('offline route, check-in and photo survive reload and replay once', async (
     },
     operationId('readiness'),
   )).raid
+  await api(page, 'PUT', `/api/raids/${raid.id}/presence/me`, {
+    latitude: identity.point.latitude,
+    longitude: identity.point.longitude,
+    capturedAt: new Date().toISOString(),
+    accuracyMeters: 8,
+  })
   raid = (await api<{ raid: typeof raid }>(
     page,
     'POST',
@@ -124,10 +132,10 @@ test('offline route, check-in and photo survive reload and replay once', async (
 
   await page.goto(`/app?raid=${raid.id}`)
   await waitForServiceWorkerControl(page)
-  await expect(page.getByText('fresh', { exact: true })).toBeVisible({ timeout: 30_000 })
+  await expect(page.getByLabel(/Активный рейд Offline recovery raid/)).toBeVisible({ timeout: 30_000 })
   await context.setGeolocation({ latitude: 56.86005, longitude: 53.21005, accuracy: 8 })
-  await page.getByRole('button', { name: 'Найти точку рядом' }).click()
-  await expect(page.getByText('Синтетическая точка E2E')).toBeVisible()
+  await expect(page.getByLabel('Подтверждение точки')).toBeVisible({ timeout: 15_000 })
+  await expect(page.getByRole('heading', { name: 'Синтетическая точка E2E' })).toBeVisible()
 
   const serverBaseline = fixture<RaidCounts>('inspect-raid', raid.id)
   const localBaseline = await localCounts(page, raid.id)
@@ -157,10 +165,10 @@ test('offline route, check-in and photo survive reload and replay once', async (
       })),
     })
   }, { latitude: 56.86015, longitude: 53.21015, accuracy: 8 })
-  await page.getByRole('button', { name: 'Отметиться у точки' }).click()
-  await expect(page.getByText(/Попытка сохранена на телефоне/)).toBeVisible()
   await page.locator('input[type="file"]').setInputFiles('apps/pwa/public/pwa-192x192.png')
   await expect(page.getByText(/Фото сохранено локально/)).toBeVisible()
+  await page.getByRole('button', { name: 'Отметиться у точки' }).click()
+  await expect(page.getByText(/Попытка сохранена на телефоне/)).toBeVisible()
   await expect(page.getByText('Локально: 2', { exact: true })).toBeVisible()
   await expect.poll(async () => {
     const counts = await localCounts(page, raid.id)
@@ -168,6 +176,7 @@ test('offline route, check-in and photo survive reload and replay once', async (
   }).toEqual([1, 1])
 
   await page.reload({ waitUntil: 'domcontentloaded' })
+  await page.getByRole('button', { name: /Сохранено без сети/ }).click()
   await expect(page.getByText('Локально: 2', { exact: true })).toBeVisible()
   await expect.poll(async () => {
     const counts = await localCounts(page, raid.id)
@@ -199,8 +208,9 @@ test('offline route, check-in and photo survive reload and replay once', async (
     const gallery = await api<{ media: unknown[] }>(page, 'GET', `/api/raids/${raid.id}/media`)
     return gallery.media.length
   }, { timeout: 45_000 }).toBe(1)
+  await page.getByRole('button', { name: 'Действия рейда' }).click()
   await page.getByRole('button', { name: 'Поставить на паузу' }).click()
-  await expect(page.getByText('Пауза', { exact: true })).toBeVisible()
+  await expect(page.getByText('Рейд на паузе', { exact: true })).toBeVisible()
 
   const acceptedBeforeReload = fixture<RaidCounts>('inspect-raid', raid.id, String(offlineRouteSequence))
   expect(acceptedBeforeReload.routeSamples).toBeGreaterThan(serverBaseline.routeSamples)

--- a/e2e/offline-recovery.spec.ts
+++ b/e2e/offline-recovery.spec.ts
@@ -169,7 +169,7 @@ test('offline route, check-in and photo survive reload and replay once', async (
   await expect(page.getByText(/Фото сохранено локально/)).toBeVisible()
   await page.getByRole('button', { name: 'Отметиться у точки' }).click()
   await expect(page.getByText(/Попытка сохранена на телефоне/)).toBeVisible()
-  await expect(page.getByText('Локально: 2', { exact: true }).first()).toBeVisible()
+  await expect(page.locator('.checkin-panel--map > .checkin-pending')).toHaveText('Локально: 2')
   await expect.poll(async () => {
     const counts = await localCounts(page, raid.id)
     return [counts.checkInPending, counts.mediaPending]
@@ -177,7 +177,7 @@ test('offline route, check-in and photo survive reload and replay once', async (
 
   await page.reload({ waitUntil: 'domcontentloaded' })
   await page.getByRole('button', { name: /Сохранено без сети/ }).click()
-  await expect(page.getByText('Локально: 2', { exact: true }).first()).toBeVisible()
+  await expect(page.locator('.checkin-panel--map > .checkin-pending')).toHaveText('Локально: 2')
   await expect.poll(async () => {
     const counts = await localCounts(page, raid.id)
     return [counts.checkInPending, counts.mediaPending]

--- a/e2e/offline-recovery.spec.ts
+++ b/e2e/offline-recovery.spec.ts
@@ -134,7 +134,7 @@ test('offline route, check-in and photo survive reload and replay once', async (
   await waitForServiceWorkerControl(page)
   await expect(page.getByLabel(/Активный рейд Offline recovery raid/)).toBeVisible({ timeout: 30_000 })
   await context.setGeolocation({ latitude: 56.86005, longitude: 53.21005, accuracy: 8 })
-  await expect(page.getByLabel('Подтверждение точки')).toBeVisible({ timeout: 15_000 })
+  await expect(page.getByRole('complementary', { name: 'Подтверждение точки' })).toBeVisible({ timeout: 15_000 })
   await expect(page.getByRole('heading', { name: 'Синтетическая точка E2E' })).toBeVisible()
 
   const serverBaseline = fixture<RaidCounts>('inspect-raid', raid.id)

--- a/e2e/offline-recovery.spec.ts
+++ b/e2e/offline-recovery.spec.ts
@@ -169,7 +169,7 @@ test('offline route, check-in and photo survive reload and replay once', async (
   await expect(page.getByText(/Фото сохранено локально/)).toBeVisible()
   await page.getByRole('button', { name: 'Отметиться у точки' }).click()
   await expect(page.getByText(/Попытка сохранена на телефоне/)).toBeVisible()
-  await expect(page.getByText('Локально: 2', { exact: true })).toBeVisible()
+  await expect(page.getByText('Локально: 2', { exact: true }).first()).toBeVisible()
   await expect.poll(async () => {
     const counts = await localCounts(page, raid.id)
     return [counts.checkInPending, counts.mediaPending]
@@ -177,7 +177,7 @@ test('offline route, check-in and photo survive reload and replay once', async (
 
   await page.reload({ waitUntil: 'domcontentloaded' })
   await page.getByRole('button', { name: /Сохранено без сети/ }).click()
-  await expect(page.getByText('Локально: 2', { exact: true })).toBeVisible()
+  await expect(page.getByText('Локально: 2', { exact: true }).first()).toBeVisible()
   await expect.poll(async () => {
     const counts = await localCounts(page, raid.id)
     return [counts.checkInPending, counts.mediaPending]

--- a/e2e/support.ts
+++ b/e2e/support.ts
@@ -146,7 +146,7 @@ export async function installYandexMapsMock(context: BrowserContext): Promise<vo
           if (element instanceof HTMLButtonElement) element.type = 'button'
           if (typeof markerClass !== 'string') {
             element.className = rider ? 'route-live-map__rider' : 'kb-yandex-user-location'
-            element.setAttribute('aria-label', rider ? 'Положение навигатора рейда' : 'Моё местоположение')
+            element.setAttribute('aria-label', rider ? 'Моё положение' : 'Моё местоположение')
           }
           placemark.element = element
           placemark.syncElement()

--- a/e2e/support.ts
+++ b/e2e/support.ts
@@ -51,6 +51,7 @@ export async function installYandexMapsMock(context: BrowserContext): Promise<vo
     type MapEvent = { get: (name: string) => unknown }
     type MapHandler = (event: MapEvent) => void
     type PlacemarkHandler = (event: { stopPropagation: () => void }) => void
+    type MockMapObject = MockPlacemark | MockPolyline
 
     class MockPlacemark {
       element: HTMLElement | null = null
@@ -94,25 +95,58 @@ export async function installYandexMapsMock(context: BrowserContext): Promise<vo
       }
     }
 
+    class MockPolyline {
+      element: HTMLElement | null = null
+      private coordinates: readonly (readonly [number, number])[]
+      readonly settings: Record<string, unknown>
+      readonly geometry = {
+        getCoordinates: () => this.coordinates,
+        setCoordinates: (coordinates: readonly (readonly [number, number])[]) => {
+          this.coordinates = coordinates
+        },
+      }
+
+      constructor(
+        coordinates: readonly (readonly [number, number])[],
+        _properties: Record<string, unknown> = {},
+        options: Record<string, unknown> = {},
+      ) {
+        this.coordinates = coordinates
+        this.settings = { ...options }
+      }
+    }
+
     class MockYandexMap {
       private center: readonly [number, number]
       private zoom: number
       private readonly handlers: Record<string, MapHandler[]> = {}
-      private readonly objects = new Set<MockPlacemark>()
+      private readonly objects = new Set<MockMapObject>()
       readonly events = {
         add: (name: string, handler: MapHandler) => {
           this.handlers[name] = [...(this.handlers[name] ?? []), handler]
         },
       }
       readonly geoObjects = {
-        add: (placemark: MockPlacemark) => {
-          this.objects.add(placemark)
+        add: (object: MockMapObject) => {
+          this.objects.add(object)
+          if (object instanceof MockPolyline) {
+            const element = document.createElement('span')
+            element.dataset.yandexPolyline = 'true'
+            const strokeColor = object.settings.strokeColor
+            if (typeof strokeColor === 'string') element.dataset.strokeColor = strokeColor
+            object.element = element
+            this.container.append(element)
+            return
+          }
+          const placemark = object
           const markerClass = placemark.values.markerClass
+          const iconLayout = placemark.settings.iconLayout
+          const rider = typeof iconLayout === 'string' && iconLayout.includes('route-live-map__rider')
           const element = document.createElement(typeof markerClass === 'string' ? 'button' : 'span')
           if (element instanceof HTMLButtonElement) element.type = 'button'
           if (typeof markerClass !== 'string') {
-            element.className = 'kb-yandex-user-location'
-            element.setAttribute('aria-label', 'Моё местоположение')
+            element.className = rider ? 'route-live-map__rider' : 'kb-yandex-user-location'
+            element.setAttribute('aria-label', rider ? 'Положение навигатора рейда' : 'Моё местоположение')
           }
           placemark.element = element
           placemark.syncElement()
@@ -123,10 +157,10 @@ export async function installYandexMapsMock(context: BrowserContext): Promise<vo
           })
           this.container.append(element)
         },
-        remove: (placemark: MockPlacemark) => {
-          this.objects.delete(placemark)
-          placemark.element?.remove()
-          placemark.element = null
+        remove: (object: MockMapObject) => {
+          this.objects.delete(object)
+          object.element?.remove()
+          object.element = null
         },
       }
 
@@ -157,7 +191,7 @@ export async function installYandexMapsMock(context: BrowserContext): Promise<vo
         this.emitBoundsChange()
       }
       destroy() {
-        for (const placemark of this.objects) placemark.element?.remove()
+        for (const object of this.objects) object.element?.remove()
         this.objects.clear()
       }
     }
@@ -166,6 +200,7 @@ export async function installYandexMapsMock(context: BrowserContext): Promise<vo
       ready: (success: () => void) => success(),
       Map: MockYandexMap,
       Placemark: MockPlacemark,
+      Polyline: MockPolyline,
       templateLayoutFactory: { createClass: (template: string) => template },
     }
     ;(window as unknown as { ymaps: typeof ymaps }).ymaps = ymaps

--- a/infra/postgres/migrations/0013_raid_presence.sql
+++ b/infra/postgres/migrations/0013_raid_presence.sql
@@ -1,0 +1,18 @@
+ALTER TABLE raid_participants
+  ADD COLUMN presence_override_at timestamptz,
+  ADD COLUMN presence_override_by uuid REFERENCES users(id) ON DELETE RESTRICT;
+
+CREATE TABLE raid_presence_reports (
+  raid_id uuid NOT NULL REFERENCES raids(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  location geography(Point, 4326) NOT NULL,
+  captured_at timestamptz NOT NULL,
+  accuracy_meters double precision NOT NULL CHECK (accuracy_meters BETWEEN 0 AND 50),
+  expires_at timestamptz NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (raid_id, user_id),
+  CHECK (expires_at > captured_at)
+);
+
+CREATE INDEX raid_presence_reports_expiry_idx
+  ON raid_presence_reports (raid_id, expires_at);

--- a/infra/stand/kabanda.env.example
+++ b/infra/stand/kabanda.env.example
@@ -8,7 +8,7 @@ NOMINATIM_BASE_URL=https://nominatim.openstreetmap.org
 VITE_YANDEX_MAPS_API_KEY=replace-with-referer-restricted-browser-key
 PWA_DIST_DIR=/opt/kabanda/current/apps/pwa/dist
 TRUST_PROXY_ADDRESS=127.0.0.1
-EXPECTED_MIGRATION=0012_raid_template_visibility.sql
+EXPECTED_MIGRATION=0013_raid_presence.sql
 ALPHA_ACCESS_MODE=enforced
 ALPHA_ACCESS_SECRET=replace-with-a-distinct-random-secret-at-least-32-characters
 # Required only when importing a manifest with field_verified points.


### PR DESCRIPTION
## Что изменено
- автоматический сбор участников в радиусе 50 м перед стартом и server-side блокировка старта
- organizer-only ручное подтверждение присутствия
- полноэкранная карта активного рейда, пройденный трек и собственные маркеры
- auto-arrival sheet, пульсация точки и компактное напоминание
- автоматическое предложение участников рядом с точкой и ручной fallback
- offline check-in/media recovery
- additive migration 0013_raid_presence.sql

## Проверки
- локальные typecheck, unit tests и production build зелёные
- полный PostgreSQL/PostGIS и Playwright E2E запускаются этим draft PR

## Ограничения
Draft only. Не merge и не deploy автоматически.